### PR TITLE
feat: add Portfolio Breakdown page (#206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Run thousands of probabilistic simulations accounting for market volatility and 
 Track your portfolio allocation across stocks, bonds, real estate, commodities, and cash. Get intelligent rebalancing recommendations to maintain your target allocation with customizable allocation targets and visual feedback.
 
 **🍩 Portfolio Breakdown**  
-Slice your current portfolio across multiple dimensions — currency, holding, sector, continent, region, market (exchange), and ETF provider — to spot concentration risk and diversification gaps. ETF sector exposure is automatically expanded using Yahoo Finance sector weightings, and metadata is cached locally for 7 days to minimise API calls.
+Slice your current portfolio across multiple dimensions — currency, holding, sector, continent, region, market (exchange), and ETF provider — to spot concentration risk and diversification gaps. Stock sector and exchange come from Yahoo Finance's anonymous search endpoint; stock country is derived from the ISIN prefix. For ETFs (where Yahoo's holdings endpoint requires authentication), the provider, region theme, and asset focus are inferred from the fund's name. Metadata is cached locally for 7 days to minimise API calls.
 
 **💵 DCA Helper**  
 Plan your dollar-cost averaging strategy with built-in calculations that help you invest systematically and reduce market timing risk.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Run thousands of probabilistic simulations accounting for market volatility and 
 **📊 Asset Allocation Manager**  
 Track your portfolio allocation across stocks, bonds, real estate, commodities, and cash. Get intelligent rebalancing recommendations to maintain your target allocation with customizable allocation targets and visual feedback.
 
+**🍩 Portfolio Breakdown**  
+Slice your current portfolio across multiple dimensions — currency, holding, sector, continent, region, market (exchange), and ETF provider — to spot concentration risk and diversification gaps. ETF sector exposure is automatically expanded using Yahoo Finance sector weightings, and metadata is cached locally for 7 days to minimise API calls.
+
 **💵 DCA Helper**  
 Plan your dollar-cost averaging strategy with built-in calculations that help you invest systematically and reduce market timing risk.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Run thousands of probabilistic simulations accounting for market volatility and 
 **📊 Asset Allocation Manager**  
 Track your portfolio allocation across stocks, bonds, real estate, commodities, and cash. Get intelligent rebalancing recommendations to maintain your target allocation with customizable allocation targets and visual feedback.
 
-**🍩 Portfolio Breakdown**  
-Slice your current portfolio across multiple dimensions — currency, holding, sector, continent, region, market (exchange), and ETF provider — to spot concentration risk and diversification gaps. Stock sector and exchange come from Yahoo Finance's anonymous search endpoint; stock country is derived from the ISIN prefix. For ETFs (where Yahoo's holdings endpoint requires authentication), the provider, region theme, and asset focus are inferred from the fund's name. Metadata is cached locally for 7 days to minimise API calls.
+**🍩 Portfolio Breakdown** *(experimental — disabled by default)*  
+Slice your current portfolio across multiple dimensions — currency, holding, sector, continent, region, market (exchange), and ETF provider — to spot concentration risk and diversification gaps. Stock sector and exchange come from Yahoo Finance's anonymous search endpoint; stock country is derived from the ISIN prefix. For ETFs (where Yahoo's holdings endpoint requires authentication), the provider, region theme, and asset focus are inferred from the fund's name. Metadata is cached locally for 7 days to minimise API calls. Enable it under **Settings → Experimental Features**.
 
 **💵 DCA Helper**  
 Plan your dollar-cost averaging strategy with built-in calculations that help you invest systematically and reduce market timing risk.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { NetWorthChart } from './components/NetWorthChart';
 import { FIREMetrics } from './components/FIREMetrics';
 import { MonteCarloPage } from './components/MonteCarloPage';
 import { AssetAllocationPage } from './components/AssetAllocationPage';
+import { PortfolioBreakdownPage } from './components/PortfolioBreakdownPage';
 import { ExpenseTrackerPage } from './components/ExpenseTrackerPage';
 import { NetWorthTrackerPage } from './components/NetWorthTrackerPage';
 import { HomePage } from './components/HomePage';
@@ -82,6 +83,14 @@ function Navigation({ accountName }: { accountName: string }) {
           aria-current={location.pathname === '/asset-allocation' ? 'page' : undefined}
         >
           <MaterialIcon name="pie_chart" className="nav-icon" /> Asset Allocation
+        </Link>
+        <Link 
+          to="/portfolio-breakdown" 
+          className={`nav-link ${location.pathname === '/portfolio-breakdown' ? 'active' : ''}`}
+          onClick={closeMenu}
+          aria-current={location.pathname === '/portfolio-breakdown' ? 'page' : undefined}
+        >
+          <MaterialIcon name="donut_large" className="nav-icon" /> Portfolio Breakdown
         </Link>
         <Link 
           to="/expense-tracker" 
@@ -468,6 +477,7 @@ function App() {
             <Route path="/fire-calculator" element={<FIRECalculatorPage />} />
             <Route path="/monte-carlo" element={<MonteCarloPage />} />
             <Route path="/asset-allocation" element={<AssetAllocationPage />} />
+            <Route path="/portfolio-breakdown" element={<PortfolioBreakdownPage />} />
             <Route path="/expense-tracker" element={<ExpenseTrackerPage />} />
             <Route path="/net-worth-tracker" element={<NetWorthTrackerPage />} />
             <Route path="/questionnaire" element={<QuestionnairePage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,7 @@ export const PolicyModalContext = createContext<PolicyModalContextType>({
 
 export const usePolicyModal = () => useContext(PolicyModalContext);
 
-function Navigation({ accountName }: { accountName: string }) {
+function Navigation({ accountName, showPortfolioBreakdown }: { accountName: string; showPortfolioBreakdown: boolean }) {
   const location = useLocation();
   const [isOpen, setIsOpen] = useState(false);
   
@@ -84,14 +84,16 @@ function Navigation({ accountName }: { accountName: string }) {
         >
           <MaterialIcon name="pie_chart" className="nav-icon" /> Asset Allocation
         </Link>
-        <Link 
-          to="/portfolio-breakdown" 
-          className={`nav-link ${location.pathname === '/portfolio-breakdown' ? 'active' : ''}`}
-          onClick={closeMenu}
-          aria-current={location.pathname === '/portfolio-breakdown' ? 'page' : undefined}
-        >
-          <MaterialIcon name="donut_large" className="nav-icon" /> Portfolio Breakdown
-        </Link>
+        {showPortfolioBreakdown && (
+          <Link 
+            to="/portfolio-breakdown" 
+            className={`nav-link ${location.pathname === '/portfolio-breakdown' ? 'active' : ''}`}
+            onClick={closeMenu}
+            aria-current={location.pathname === '/portfolio-breakdown' ? 'page' : undefined}
+          >
+            <MaterialIcon name="donut_large" className="nav-icon" /> Portfolio Breakdown
+          </Link>
+        )}
         <Link 
           to="/expense-tracker" 
           className={`nav-link ${location.pathname === '/expense-tracker' ? 'active' : ''}`}
@@ -470,14 +472,14 @@ function App() {
             <p>Rocket fuel for your financial planning</p>
           </header>
 
-          <Navigation accountName={settings.accountName} />
+          <Navigation accountName={settings.accountName} showPortfolioBreakdown={settings.experimentalFeatures?.portfolioBreakdown ?? false} />
 
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/fire-calculator" element={<FIRECalculatorPage />} />
             <Route path="/monte-carlo" element={<MonteCarloPage />} />
             <Route path="/asset-allocation" element={<AssetAllocationPage />} />
-            <Route path="/portfolio-breakdown" element={<PortfolioBreakdownPage />} />
+            <Route path="/portfolio-breakdown" element={settings.experimentalFeatures?.portfolioBreakdown ? <PortfolioBreakdownPage /> : <NotFoundPage />} />
             <Route path="/expense-tracker" element={<ExpenseTrackerPage />} />
             <Route path="/net-worth-tracker" element={<NetWorthTrackerPage />} />
             <Route path="/questionnaire" element={<QuestionnairePage />} />

--- a/src/components/AssetAllocationManager.css
+++ b/src/components/AssetAllocationManager.css
@@ -2704,3 +2704,17 @@ select:disabled {
   font-weight: 600;
 }
 
+
+/* Link to the Portfolio Breakdown page from the Graphs section */
+.breakdown-link-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.75rem;
+}
+
+.breakdown-page-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-decoration: none;
+}

--- a/src/components/AssetAllocationPage.tsx
+++ b/src/components/AssetAllocationPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import { Asset, PortfolioAllocation, AssetClass, AllocationMode } from '../types/assetAllocation';
 import { calculatePortfolioAllocation, prepareAssetClassChartData, prepareAssetChartData, formatAssetName, formatCurrency } from '../utils/allocationCalculator';
 import { DEFAULT_ASSETS, DEFAULT_PORTFOLIO_VALUE } from '../utils/defaultAssets';
@@ -790,6 +791,11 @@ export const AssetAllocationPage: React.FC = () => {
               )}
             </div>
           )}
+          <div className="breakdown-link-row">
+            <Link to="/portfolio-breakdown" className="action-btn breakdown-page-link">
+              <MaterialIcon name="donut_large" /> View Detailed Portfolio Breakdown
+            </Link>
+          </div>
         </section>
 
         <section className="allocation-section" aria-labelledby="portfolio-details-heading" data-tour="asset-list">

--- a/src/components/AssetAllocationPage.tsx
+++ b/src/components/AssetAllocationPage.tsx
@@ -111,6 +111,10 @@ export const AssetAllocationPage: React.FC = () => {
     const settings = loadSettings();
     return settings.privacyMode;
   });
+  // Feature flags from user settings (e.g., experimental Portfolio Breakdown page)
+  const [showPortfolioBreakdown] = useState<boolean>(
+    () => loadSettings().experimentalFeatures?.portfolioBreakdown ?? false,
+  );
   
   // Track if we're currently syncing to prevent infinite loops
   const isSyncingRef = useRef(false);
@@ -791,11 +795,13 @@ export const AssetAllocationPage: React.FC = () => {
               )}
             </div>
           )}
-          <div className="breakdown-link-row">
-            <Link to="/portfolio-breakdown" className="action-btn breakdown-page-link">
-              <MaterialIcon name="donut_large" /> View Detailed Portfolio Breakdown
-            </Link>
-          </div>
+          {showPortfolioBreakdown && (
+            <div className="breakdown-link-row">
+              <Link to="/portfolio-breakdown" className="action-btn breakdown-page-link">
+                <MaterialIcon name="donut_large" /> View Detailed Portfolio Breakdown
+              </Link>
+            </div>
+          )}
         </section>
 
         <section className="allocation-section" aria-labelledby="portfolio-details-heading" data-tour="asset-list">

--- a/src/components/BreakdownChart.tsx
+++ b/src/components/BreakdownChart.tsx
@@ -1,0 +1,170 @@
+/**
+ * BreakdownChart
+ *
+ * Donut chart + accessible table for a single breakdown dimension.
+ * Reuses the look-and-feel of `AllocationChart` while accepting the richer
+ * `BreakdownResult` shape from the Portfolio Breakdown page.
+ */
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
+import { BreakdownResult } from '../types/portfolioBreakdown';
+import { formatCurrency, formatPercent } from '../utils/allocationCalculator';
+import { PrivacyBlur } from './PrivacyBlur';
+
+interface BreakdownChartProps {
+  title: string;
+  description?: string;
+  result: BreakdownResult;
+  currency: string;
+  isPrivacyMode: boolean;
+  /** Maximum number of slices to show in chart/table; remainder bucketed as "Other". */
+  maxEntries?: number;
+}
+
+interface TooltipPayloadEntry {
+  payload: {
+    label: string;
+    value: number;
+    percentage: number;
+  };
+}
+
+const DEFAULT_MAX_ENTRIES = 12;
+
+function truncate(label: string, max = 18): string {
+  return label.length > max ? label.substring(0, max - 1) + '…' : label;
+}
+
+function condense(
+  entries: BreakdownResult['entries'],
+  maxEntries: number,
+): BreakdownResult['entries'] {
+  if (entries.length <= maxEntries) return entries;
+  const head = entries.slice(0, maxEntries - 1);
+  const tail = entries.slice(maxEntries - 1);
+  const otherValue = tail.reduce((s, e) => s + e.value, 0);
+  const otherPercent = tail.reduce((s, e) => s + e.percentage, 0);
+  return [
+    ...head,
+    {
+      label: `Other (${tail.length})`,
+      value: otherValue,
+      percentage: otherPercent,
+      color: '#9ca3af',
+    },
+  ];
+}
+
+export const BreakdownChart: React.FC<BreakdownChartProps> = ({
+  title,
+  description,
+  result,
+  currency,
+  isPrivacyMode,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+}) => {
+  if (!result.entries || result.entries.length === 0) {
+    return (
+      <div className="chart-container breakdown-chart">
+        <h3>{title}</h3>
+        {description && <p className="breakdown-chart-description">{description}</p>}
+        <div className="empty-chart">No data to display</div>
+      </div>
+    );
+  }
+
+  const entries = condense(result.entries, maxEntries);
+
+  const CustomTooltip = ({
+    active,
+    payload,
+  }: {
+    active?: boolean;
+    payload?: TooltipPayloadEntry[];
+  }) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="custom-tooltip">
+          <p className="label">
+            <strong>{data.label}</strong>
+          </p>
+          <p className="value">
+            <PrivacyBlur isPrivacyMode={isPrivacyMode}>
+              {formatCurrency(data.value, currency)}
+            </PrivacyBlur>
+          </p>
+          <p className="percentage">{formatPercent(data.percentage)}</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const renderLegend = (value: string) => truncate(value, 22);
+
+  return (
+    <div className="chart-container breakdown-chart">
+      <h3>{title}</h3>
+      {description && <p className="breakdown-chart-description">{description}</p>}
+
+      <ResponsiveContainer width="100%" height={340}>
+        <PieChart>
+          <Pie
+            data={entries}
+            dataKey="value"
+            nameKey="label"
+            cx="50%"
+            cy="50%"
+            outerRadius={110}
+            innerRadius={55}
+            paddingAngle={1}
+          >
+            {entries.map((entry, i) => (
+              <Cell key={`cell-${i}`} fill={entry.color || '#5568d4'} />
+            ))}
+          </Pie>
+          <Tooltip content={<CustomTooltip />} />
+          <Legend
+            formatter={renderLegend}
+            wrapperStyle={{ paddingTop: '8px', color: '#F8FAFC', fontSize: '12px' }}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+
+      <table className="breakdown-table" aria-label={`${title} breakdown table`}>
+        <thead>
+          <tr>
+            <th scope="col">Bucket</th>
+            <th scope="col" className="numeric">
+              Value
+            </th>
+            <th scope="col" className="numeric">
+              %
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(e => (
+            <tr key={e.label}>
+              <td>
+                <span
+                  className="breakdown-color-dot"
+                  aria-hidden="true"
+                  style={{ background: e.color || '#5568d4' }}
+                />
+                {e.label}
+              </td>
+              <td className="numeric">
+                <PrivacyBlur isPrivacyMode={isPrivacyMode}>
+                  {formatCurrency(e.value, currency)}
+                </PrivacyBlur>
+              </td>
+              <td className="numeric">{formatPercent(e.percentage)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/PortfolioBreakdownPage.css
+++ b/src/components/PortfolioBreakdownPage.css
@@ -1,0 +1,124 @@
+.portfolio-breakdown-page {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1rem 1.25rem 4rem;
+}
+
+.portfolio-breakdown-page .page-header {
+  margin-bottom: 1.5rem;
+}
+
+.portfolio-breakdown-page .page-header-link {
+  margin-top: 0.25rem;
+}
+
+.portfolio-breakdown-page .inline-link {
+  color: var(--accent-color, #5568d4);
+  text-decoration: none;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.portfolio-breakdown-page .inline-link:hover {
+  text-decoration: underline;
+}
+
+.portfolio-breakdown-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.portfolio-breakdown-page .breakdown-refresh-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.empty-portfolio-banner,
+.breakdown-info-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(85, 104, 212, 0.12);
+  border: 1px solid rgba(85, 104, 212, 0.35);
+  color: #F8FAFC;
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+}
+
+.empty-portfolio-banner .inline-link,
+.breakdown-info-banner .inline-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.breakdowns-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  gap: 1.25rem;
+}
+
+.breakdown-chart {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 1rem 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.breakdown-chart h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+  color: #F8FAFC;
+}
+
+.breakdown-chart-description {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.7);
+  line-height: 1.35;
+}
+
+.breakdown-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #F8FAFC;
+}
+
+.breakdown-table th,
+.breakdown-table td {
+  text-align: left;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.breakdown-table th.numeric,
+.breakdown-table td.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.breakdown-color-dot {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}
+
+@media (max-width: 640px) {
+  .breakdowns-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/PortfolioBreakdownPage.tsx
+++ b/src/components/PortfolioBreakdownPage.tsx
@@ -1,0 +1,227 @@
+/**
+ * Portfolio Breakdown Page
+ *
+ * Renders multiple breakdowns of the *current* portfolio:
+ * currency, holding, sector, continent, region, market (exchange), ETF provider.
+ *
+ * Data flow:
+ *   - Loads the saved asset allocation (current portfolio only)
+ *   - Fetches per-ticker metadata from Yahoo Finance via `useAssetMetadata`
+ *   - Computes breakdowns with `computeAllBreakdowns`
+ *   - Renders a donut + table per dimension via `BreakdownChart`
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Asset } from '../types/assetAllocation';
+import { BreakdownDimension } from '../types/portfolioBreakdown';
+import { loadAssetAllocation } from '../utils/cookieStorage';
+import { loadSettings, saveSettings } from '../utils/cookieSettings';
+import { computeAllBreakdowns, selectActiveAssets } from '../utils/portfolioBreakdownCalculator';
+import { formatCurrency } from '../utils/allocationCalculator';
+import { useAssetMetadata } from '../hooks/useAssetMetadata';
+import { MaterialIcon } from './MaterialIcon';
+import { BreakdownChart } from './BreakdownChart';
+import { PrivacyBlur } from './PrivacyBlur';
+import { ScrollToTopButton } from './ScrollToTopButton';
+import './PortfolioBreakdownPage.css';
+
+interface DimensionConfig {
+  dimension: BreakdownDimension;
+  title: string;
+  description: string;
+  /** Whether this dimension needs Yahoo metadata to be meaningful. */
+  needsMetadata: boolean;
+}
+
+const DIMENSIONS: DimensionConfig[] = [
+  {
+    dimension: 'currency',
+    title: 'By Currency',
+    description: 'Distribution of holdings by the currency they were originally entered in.',
+    needsMetadata: false,
+  },
+  {
+    dimension: 'holding',
+    title: 'By Holding',
+    description: 'Each individual asset as a share of the portfolio.',
+    needsMetadata: false,
+  },
+  {
+    dimension: 'sector',
+    title: 'By Sector',
+    description:
+      'For ETFs and funds, sector exposure is expanded using Yahoo Finance sector weightings. Individual stocks use their listed sector.',
+    needsMetadata: true,
+  },
+  {
+    dimension: 'continent',
+    title: 'By Continent',
+    description: 'Derived from each stock’s country of incorporation. ETFs fall back to their asset class.',
+    needsMetadata: true,
+  },
+  {
+    dimension: 'region',
+    title: 'By Region',
+    description: 'Finer-grained region (e.g., Western Europe, East Asia) derived from country of incorporation.',
+    needsMetadata: true,
+  },
+  {
+    dimension: 'market',
+    title: 'By Market',
+    description: 'The listing exchange for each holding (e.g., NASDAQ, LSE, Xetra).',
+    needsMetadata: true,
+  },
+  {
+    dimension: 'etfProvider',
+    title: 'By ETF Provider',
+    description:
+      'The fund family / issuer (e.g., Vanguard, iShares). Direct stock holdings are grouped under “Direct holding”.',
+    needsMetadata: true,
+  },
+];
+
+export const PortfolioBreakdownPage: React.FC = () => {
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [currency] = useState<string>(() => loadSettings().currencySettings.defaultCurrency);
+  const [isPrivacyMode, setIsPrivacyMode] = useState<boolean>(() => loadSettings().privacyMode);
+
+  useEffect(() => {
+    const saved = loadAssetAllocation();
+    setAssets(saved.assets || []);
+  }, []);
+
+  const togglePrivacyMode = () => {
+    const newMode = !isPrivacyMode;
+    setIsPrivacyMode(newMode);
+    const settings = loadSettings();
+    saveSettings({ ...settings, privacyMode: newMode });
+  };
+
+  const { metadata, isLoading, lastRefresh, error, refresh } = useAssetMetadata(assets);
+
+  const activeAssets = useMemo(() => selectActiveAssets(assets), [assets]);
+  const totalValue = useMemo(
+    () => activeAssets.reduce((s, a) => s + a.currentValue, 0),
+    [activeAssets],
+  );
+  const tickerAssetCount = useMemo(
+    () => activeAssets.filter(a => a.ticker && a.ticker.trim().length > 0).length,
+    [activeAssets],
+  );
+
+  const breakdowns = useMemo(
+    () => computeAllBreakdowns(assets, metadata),
+    [assets, metadata],
+  );
+
+  const hasNoData = activeAssets.length === 0;
+  const hasNoTickers = tickerAssetCount === 0;
+
+  return (
+    <div className="portfolio-breakdown-page">
+      <header className="page-header">
+        <div className="page-header-top">
+          <h1>
+            <MaterialIcon name="donut_large" className="page-header-icon" /> Portfolio Breakdown
+          </h1>
+        </div>
+        <p>
+          Slice your current portfolio across multiple dimensions to understand concentration risk,
+          diversification, and exposure. Data is read from your saved Asset Allocation; for ETFs and
+          individual stocks, additional metadata is fetched from Yahoo Finance.
+        </p>
+        <p className="page-header-link">
+          <Link to="/asset-allocation" className="inline-link">
+            <MaterialIcon name="pie_chart" size="small" /> Back to Asset Allocation
+          </Link>
+        </p>
+      </header>
+
+      <main className="portfolio-breakdown-content" id="main-content">
+        <section className="portfolio-value-section" aria-labelledby="portfolio-value-heading">
+          <div className="portfolio-value-label">
+            <strong id="portfolio-value-heading">Portfolio Value:</strong>
+            <span className="portfolio-value">
+              <PrivacyBlur isPrivacyMode={isPrivacyMode}>
+                {formatCurrency(totalValue, currency)}
+              </PrivacyBlur>
+            </span>
+            <button
+              className="privacy-eye-btn"
+              onClick={togglePrivacyMode}
+              title={isPrivacyMode ? 'Show values' : 'Hide values'}
+              aria-pressed={isPrivacyMode}
+            >
+              <MaterialIcon name={isPrivacyMode ? 'visibility_off' : 'visibility'} size="small" />
+            </button>
+          </div>
+
+          <div className="breakdown-refresh-row">
+            <button
+              className="action-btn"
+              onClick={() => void refresh()}
+              disabled={isLoading || hasNoTickers}
+              aria-label="Refresh asset metadata from Yahoo Finance"
+              title="Re-fetch sector, country, and fund family from Yahoo Finance"
+            >
+              <MaterialIcon name={isLoading ? 'hourglass_empty' : 'refresh'} />
+              {isLoading ? ' Refreshing…' : ' Refresh Metadata'}
+            </button>
+            {lastRefresh && lastRefresh.fetchedCount > 0 && (
+              <span className="price-refresh-status" role="status">
+                Metadata for {lastRefresh.fetchedCount} ticker
+                {lastRefresh.fetchedCount !== 1 ? 's' : ''}
+                {lastRefresh.failedTickers.length > 0 && (
+                  <> · Failed: {lastRefresh.failedTickers.join(', ')}</>
+                )}
+              </span>
+            )}
+            {error && (
+              <span className="price-refresh-error" role="alert">
+                {error}
+              </span>
+            )}
+          </div>
+        </section>
+
+        {hasNoData && (
+          <div className="empty-portfolio-banner" role="status">
+            <MaterialIcon name="info" /> Your portfolio is empty. Add assets in the{' '}
+            <Link to="/asset-allocation" className="inline-link">
+              Asset Allocation Manager
+            </Link>{' '}
+            to see breakdowns here.
+          </div>
+        )}
+
+        {!hasNoData && hasNoTickers && (
+          <div className="breakdown-info-banner" role="status">
+            <MaterialIcon name="info" /> None of your assets have a ticker symbol, so only the
+            Currency and Holding breakdowns are available. Add tickers in the Asset Allocation
+            Manager to unlock sector, region, market, and provider breakdowns.
+          </div>
+        )}
+
+        <section className="breakdowns-grid" aria-label="Portfolio breakdowns">
+          {DIMENSIONS.map(d => {
+            if (hasNoData) return null;
+            if (d.needsMetadata && hasNoTickers) return null;
+            return (
+              <BreakdownChart
+                key={d.dimension}
+                title={d.title}
+                description={d.description}
+                result={breakdowns[d.dimension]}
+                currency={currency}
+                isPrivacyMode={isPrivacyMode}
+              />
+            );
+          })}
+        </section>
+      </main>
+
+      <ScrollToTopButton />
+    </div>
+  );
+};

--- a/src/components/PortfolioBreakdownPage.tsx
+++ b/src/components/PortfolioBreakdownPage.tsx
@@ -51,19 +51,19 @@ const DIMENSIONS: DimensionConfig[] = [
     dimension: 'sector',
     title: 'By Sector',
     description:
-      'For ETFs and funds, sector exposure is expanded using Yahoo Finance sector weightings. Individual stocks use their listed sector.',
+      'Individual stocks use their listed sector from Yahoo Finance. ETFs use a sector label inferred from their fund name (e.g. "Technology", "Government Bonds"), as Yahoo no longer exposes per-ETF holdings without authentication.',
     needsMetadata: true,
   },
   {
     dimension: 'continent',
     title: 'By Continent',
-    description: 'Derived from each stock’s country of incorporation. ETFs fall back to their asset class.',
+    description: 'For stocks, derived from the ISIN country prefix. For ETFs, derived from the fund name (e.g. an "MSCI World" ETF maps to Global).',
     needsMetadata: true,
   },
   {
     dimension: 'region',
     title: 'By Region',
-    description: 'Finer-grained region (e.g., Western Europe, East Asia) derived from country of incorporation.',
+    description: 'Finer-grained region (e.g., Western Europe, East Asia, Emerging Markets) derived from ISIN country (stocks) or fund name (ETFs).',
     needsMetadata: true,
   },
   {
@@ -76,7 +76,7 @@ const DIMENSIONS: DimensionConfig[] = [
     dimension: 'etfProvider',
     title: 'By ETF Provider',
     description:
-      'The fund family / issuer (e.g., Vanguard, iShares). Direct stock holdings are grouped under “Direct holding”.',
+      'The fund family / issuer inferred from the fund name (e.g., Vanguard, iShares). Direct stock holdings are grouped under "Direct holding".',
     needsMetadata: true,
   },
 ];

--- a/src/components/PortfolioBreakdownPage.tsx
+++ b/src/components/PortfolioBreakdownPage.tsx
@@ -11,7 +11,7 @@
  *   - Renders a donut + table per dimension via `BreakdownChart`
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Asset } from '../types/assetAllocation';
 import { BreakdownDimension } from '../types/portfolioBreakdown';
@@ -82,14 +82,12 @@ const DIMENSIONS: DimensionConfig[] = [
 ];
 
 export const PortfolioBreakdownPage: React.FC = () => {
-  const [assets, setAssets] = useState<Asset[]>([]);
+  // Load assets synchronously so the metadata hook sees them on first mount.
+  // Loading them later (via useEffect) would mean the metadata fetch fires
+  // with an empty array and never retries when the real assets arrive.
+  const [assets] = useState<Asset[]>(() => loadAssetAllocation().assets || []);
   const [currency] = useState<string>(() => loadSettings().currencySettings.defaultCurrency);
   const [isPrivacyMode, setIsPrivacyMode] = useState<boolean>(() => loadSettings().privacyMode);
-
-  useEffect(() => {
-    const saved = loadAssetAllocation();
-    setAssets(saved.assets || []);
-  }, []);
 
   const togglePrivacyMode = () => {
     const newMode = !isPrivacyMode;

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -35,7 +35,7 @@ interface SettingsPageProps {
 }
 
 // Section identifiers for collapsible state
-const SETTINGS_SECTIONS = ['account', 'fire', 'display', 'privacy', 'notifications', 'email', 'disclaimer', 'currency', 'marketData', 'categories', 'data', 'support'] as const;
+const SETTINGS_SECTIONS = ['account', 'fire', 'display', 'privacy', 'experimental', 'notifications', 'email', 'disclaimer', 'currency', 'marketData', 'categories', 'data', 'support'] as const;
 type SettingsSection = typeof SETTINGS_SECTIONS[number];
 
 export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) => {
@@ -963,6 +963,48 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                   }
                   return null;
                 })()}
+              </div>
+            </div>
+          )}
+        </section>
+
+        {/* Experimental Features */}
+        <section className="settings-section collapsible-section">
+          <button 
+            className="collapsible-header" 
+            onClick={() => toggleSection('experimental')}
+            aria-expanded={!collapsedSections.has('experimental')}
+            aria-controls="experimental-content"
+          >
+            <h2><MaterialIcon name="science" /> Experimental Features <span className="collapse-icon-small" aria-hidden="true">{collapsedSections.has('experimental') ? '▶' : '▼'}</span></h2>
+          </button>
+          {!collapsedSections.has('experimental') && (
+            <div id="experimental-content" className="collapsible-content">
+              <p className="setting-help" style={{ marginBottom: '1rem' }}>
+                <MaterialIcon name="warning" size="small" /> These features are still in preview. They may be incomplete, change without notice, or rely on third-party data that may be inaccurate or unavailable.
+              </p>
+              <div className="setting-item">
+                <div className="label-with-tooltip">
+                  <label htmlFor="experimentalPortfolioBreakdown">Portfolio Breakdown page</label>
+                  <Tooltip content="Adds a new Portfolio Breakdown page that slices your current portfolio by currency, holding, sector, continent, region, market, and ETF provider. ETF metadata is inferred from fund names (Yahoo Finance does not expose holdings data without authentication), so results are heuristic.">
+                    <span className="info-icon" aria-label="More information">i</span>
+                  </Tooltip>
+                </div>
+                <div className="toggle-group">
+                  <button
+                    className={`toggle-btn ${!settings.experimentalFeatures?.portfolioBreakdown ? 'active' : ''}`}
+                    onClick={() => handleSettingChange('experimentalFeatures', { ...settings.experimentalFeatures, portfolioBreakdown: false })}
+                  >
+                    Disabled
+                  </button>
+                  <button
+                    className={`toggle-btn ${settings.experimentalFeatures?.portfolioBreakdown ? 'active' : ''}`}
+                    onClick={() => handleSettingChange('experimentalFeatures', { ...settings.experimentalFeatures, portfolioBreakdown: true })}
+                  >
+                    Enabled
+                  </button>
+                </div>
+                <span className="setting-help">Enable the Portfolio Breakdown page in navigation</span>
               </div>
             </div>
           )}

--- a/src/hooks/useAssetMetadata.ts
+++ b/src/hooks/useAssetMetadata.ts
@@ -1,0 +1,94 @@
+/**
+ * useAssetMetadata Hook
+ *
+ * Fetches Yahoo Finance metadata for all unique tickers in a list of assets,
+ * caching results across renders. Returns the metadata map plus loading state.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { Asset } from '../types/assetAllocation';
+import { AssetMetadata } from '../types/portfolioBreakdown';
+import { fetchAssetMetadataBatch } from '../utils/yahooMetadata';
+import { uniqueTickers } from '../utils/portfolioBreakdownCalculator';
+
+export interface MetadataRefreshResult {
+  fetchedCount: number;
+  failedTickers: string[];
+  timestamp: string;
+}
+
+export interface UseAssetMetadataReturn {
+  metadata: Record<string, AssetMetadata>;
+  isLoading: boolean;
+  lastRefresh: MetadataRefreshResult | null;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Loads metadata for all ticker-bearing assets on mount and exposes a
+ * `refresh()` action for manual re-fetch.
+ */
+export function useAssetMetadata(assets: Asset[]): UseAssetMetadataReturn {
+  const [metadata, setMetadata] = useState<Record<string, AssetMetadata>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState<MetadataRefreshResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const assetsRef = useRef(assets);
+  assetsRef.current = assets;
+
+  const fetchFor = useCallback(async (currentAssets: Asset[]) => {
+    const tickers = uniqueTickers(currentAssets);
+    if (tickers.length === 0) {
+      setMetadata({});
+      setLastRefresh({
+        fetchedCount: 0,
+        failedTickers: [],
+        timestamp: new Date().toISOString(),
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await fetchAssetMetadataBatch(tickers);
+      const failed: string[] = [];
+      let fetched = 0;
+      for (const [t, meta] of Object.entries(result)) {
+        if (meta.error) {
+          failed.push(t);
+        } else {
+          fetched++;
+        }
+      }
+      setMetadata(result);
+      setLastRefresh({
+        fetchedCount: fetched,
+        failedTickers: failed,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to fetch metadata';
+      setError(msg);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    await fetchFor(assetsRef.current);
+  }, [fetchFor]);
+
+  // Initial fetch
+  const hasFetchedRef = useRef(false);
+  useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
+    void fetchFor(assets);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { metadata, isLoading, lastRefresh, error, refresh };
+}

--- a/src/hooks/useAssetMetadata.ts
+++ b/src/hooks/useAssetMetadata.ts
@@ -53,7 +53,15 @@ export function useAssetMetadata(assets: Asset[]): UseAssetMetadataReturn {
     setError(null);
 
     try {
-      const result = await fetchAssetMetadataBatch(tickers);
+      // Build ticker → ISIN map so the fetcher can derive country for stocks
+      const isinByTicker: Record<string, string | undefined> = {};
+      for (const a of currentAssets) {
+        if (a.ticker && a.isin) {
+          isinByTicker[a.ticker.trim().toUpperCase()] = a.isin;
+        }
+      }
+
+      const result = await fetchAssetMetadataBatch(tickers, isinByTicker);
       const failed: string[] = [];
       let fetched = 0;
       for (const [t, meta] of Object.entries(result)) {

--- a/src/hooks/useAssetMetadata.ts
+++ b/src/hooks/useAssetMetadata.ts
@@ -89,14 +89,13 @@ export function useAssetMetadata(assets: Asset[]): UseAssetMetadataReturn {
     await fetchFor(assetsRef.current);
   }, [fetchFor]);
 
-  // Initial fetch
-  const hasFetchedRef = useRef(false);
+  // Refetch whenever the set of unique tickers changes. Using a stable string
+  // key avoids spurious refetches when assets are mutated for unrelated reasons.
+  const tickerKey = uniqueTickers(assets).sort().join(',');
   useEffect(() => {
-    if (hasFetchedRef.current) return;
-    hasFetchedRef.current = true;
-    void fetchFor(assets);
+    void fetchFor(assetsRef.current);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [tickerKey]);
 
   return { metadata, isLoading, lastRefresh, error, refresh };
 }

--- a/src/types/portfolioBreakdown.ts
+++ b/src/types/portfolioBreakdown.ts
@@ -1,0 +1,94 @@
+/**
+ * Portfolio Breakdown Types
+ *
+ * Types used by the Portfolio Breakdown page to slice the *current* portfolio
+ * across multiple dimensions (currency, sector, region, market, ETF provider, holding).
+ */
+
+import { SupportedCurrency } from './currency';
+
+export type BreakdownDimension =
+  | 'currency'
+  | 'holding'
+  | 'sector'
+  | 'continent'
+  | 'region'
+  | 'market'
+  | 'etfProvider';
+
+/**
+ * Sector weight as returned/normalized from Yahoo `topHoldings.sectorWeightings`.
+ * Values are fractions in [0, 1].
+ */
+export interface SectorWeight {
+  sector: string;
+  weight: number;
+}
+
+/**
+ * Region weight derived from ETF holdings or country exposure.
+ * Values are fractions in [0, 1].
+ */
+export interface RegionWeight {
+  region: string;
+  weight: number;
+}
+
+/**
+ * Metadata for a single ticker, derived from Yahoo `quoteSummary`.
+ * All fields are optional because Yahoo coverage varies by instrument.
+ */
+export interface AssetMetadata {
+  ticker: string;
+  quoteType?: string; // EQUITY, ETF, MUTUALFUND, CRYPTOCURRENCY, INDEX
+  longName?: string;
+  shortName?: string;
+  currency?: SupportedCurrency | string;
+  exchange?: string; // Full exchange name (e.g., "NASDAQ Global Select")
+
+  // Equity-specific
+  sector?: string;
+  industry?: string;
+  country?: string; // Free-text from Yahoo (e.g., "United States")
+
+  // Fund-specific
+  fundFamily?: string; // ETF provider (e.g., "Vanguard", "iShares")
+  category?: string;
+
+  // Sector weights (for ETFs/mutual funds)
+  sectorWeightings?: SectorWeight[];
+  regionWeightings?: RegionWeight[];
+
+  fetchedAt: string; // ISO timestamp
+  error?: string;
+}
+
+/**
+ * A single bucket in a breakdown (e.g., "Technology" sector with 23.4% of portfolio).
+ */
+export interface BreakdownEntry {
+  /** Display label for the bucket (e.g., "Technology", "United States", "Vanguard"). */
+  label: string;
+  /** Absolute monetary value contributed to this bucket. */
+  value: number;
+  /** Fraction of total portfolio value (0-100). */
+  percentage: number;
+  /** Stable color for charts. */
+  color?: string;
+  /** Optional ticker fallback label, only meaningful for `holding` dimension. */
+  ticker?: string;
+}
+
+/**
+ * Result of a single-dimension breakdown for the whole portfolio.
+ */
+export interface BreakdownResult {
+  dimension: BreakdownDimension;
+  entries: BreakdownEntry[];
+  totalValue: number;
+  /** Value not classified into any specific bucket; bundled under "Unknown" / asset class label. */
+  unknownValue: number;
+}
+
+/** Special label used when a non-ticker asset (real estate, cash, etc.) cannot be classified. */
+export const UNCLASSIFIED_LABEL = 'Unknown';

--- a/src/utils/cookieSettings.ts
+++ b/src/utils/cookieSettings.ts
@@ -13,6 +13,20 @@ import { encryptData, decryptData } from './cookieEncryption';
 
 export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD';
 
+/**
+ * Opt-in experimental / preview features. All default to false so they don't
+ * appear in the UI for users who haven't explicitly enabled them.
+ */
+export interface ExperimentalFeatures {
+  /** Portfolio Breakdown page — slices the current portfolio by currency,
+   *  holding, sector, region, market, and ETF provider. */
+  portfolioBreakdown: boolean;
+}
+
+export const DEFAULT_EXPERIMENTAL_FEATURES: ExperimentalFeatures = {
+  portfolioBreakdown: false,
+};
+
 export interface UserSettings {
   accountName: string;
   decimalSeparator: '.' | ',';
@@ -24,6 +38,7 @@ export interface UserSettings {
   fireAssetClassInclusion: Record<AssetClass, boolean>;
   includePrimaryResidenceInFIRE: boolean;
   searchThreshold: number;
+  experimentalFeatures: ExperimentalFeatures;
 }
 
 export const DEFAULT_FIRE_ASSET_CLASS_INCLUSION: Record<AssetClass, boolean> = {
@@ -49,6 +64,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   fireAssetClassInclusion: DEFAULT_FIRE_ASSET_CLASS_INCLUSION,
   includePrimaryResidenceInFIRE: true, // Default to including primary residence
   searchThreshold: 8,
+  experimentalFeatures: DEFAULT_EXPERIMENTAL_FEATURES,
 };
 
 const SETTINGS_KEY = 'fire-calculator-settings';
@@ -102,6 +118,10 @@ export function loadSettings(): UserSettings {
           fireAssetClassInclusion: {
             ...DEFAULT_FIRE_ASSET_CLASS_INCLUSION,
             ...(parsed.fireAssetClassInclusion || {}),
+          },
+          experimentalFeatures: {
+            ...DEFAULT_EXPERIMENTAL_FEATURES,
+            ...(parsed.experimentalFeatures || {}),
           },
         };
       }

--- a/src/utils/countryToRegion.ts
+++ b/src/utils/countryToRegion.ts
@@ -16,7 +16,9 @@ export type Continent =
   | 'Asia'
   | 'Africa'
   | 'Oceania'
-  | 'Antarctica';
+  | 'Antarctica'
+  | 'Global'
+  | 'Emerging Markets';
 
 export interface CountryRegionInfo {
   countryCode: string; // ISO 3166-1 alpha-2
@@ -150,8 +152,34 @@ const NAME_ALIASES: Record<string, string> = {
 };
 
 /**
- * Look up region info by country code (preferred) or free-text country name.
- * Returns undefined if no mapping found.
+ * Synthetic region themes used for ETFs whose underlying holdings span many
+ * countries. They are not real countries but they ARE meaningful buckets in
+ * the Continent / Region breakdowns.
+ */
+const SYNTHETIC_REGIONS: Record<string, { continent: string; region: string }> = {
+  global: { continent: 'Global', region: 'Global' },
+  'developed markets ex-us': { continent: 'Global', region: 'Developed Markets ex-US' },
+  'emerging markets': { continent: 'Emerging Markets', region: 'Emerging Markets' },
+  'asia pacific': { continent: 'Asia', region: 'Asia Pacific' },
+  'asia ex-japan': { continent: 'Asia', region: 'Asia ex-Japan' },
+  europe: { continent: 'Europe', region: 'Europe' },
+  'eastern europe': { continent: 'Europe', region: 'Eastern Europe' },
+  'western europe': { continent: 'Europe', region: 'Western Europe' },
+  'southern europe': { continent: 'Europe', region: 'Southern Europe' },
+  'northern europe': { continent: 'Europe', region: 'Northern Europe' },
+  'north america': { continent: 'North America', region: 'North America' },
+  'latin america': { continent: 'South America', region: 'Latin America' },
+  'middle east': { continent: 'Asia', region: 'Middle East' },
+  africa: { continent: 'Africa', region: 'Africa' },
+  oceania: { continent: 'Oceania', region: 'Oceania' },
+  'east asia': { continent: 'Asia', region: 'East Asia' },
+  'south asia': { continent: 'Asia', region: 'South Asia' },
+  'southeast asia': { continent: 'Asia', region: 'Southeast Asia' },
+};
+
+/**
+ * Look up region info by country code (preferred), free-text country name, or
+ * synthetic ETF region theme. Returns undefined if no mapping found.
  */
 export function lookupCountry(input: string | undefined | null): CountryRegionInfo | undefined {
   if (!input) return undefined;
@@ -173,6 +201,17 @@ export function lookupCountry(input: string | undefined | null): CountryRegionIn
   const canonical = NAME_ALIASES[lower];
   if (canonical) {
     return BY_NAME.get(canonical.toLowerCase());
+  }
+
+  // Try synthetic region theme (used for ETFs)
+  const synthetic = SYNTHETIC_REGIONS[lower];
+  if (synthetic) {
+    return {
+      countryCode: '',
+      countryName: trimmed,
+      continent: synthetic.continent as Continent,
+      region: synthetic.region,
+    };
   }
 
   return undefined;

--- a/src/utils/countryToRegion.ts
+++ b/src/utils/countryToRegion.ts
@@ -1,0 +1,192 @@
+/**
+ * Country to Region / Continent mapping
+ *
+ * Maps ISO 3166-1 alpha-2 country codes AND the free-text country names that
+ * Yahoo Finance returns from `summaryProfile.country` to a continent and a
+ * finer-grained region label.
+ *
+ * Yahoo returns full country names (e.g. "United States", "United Kingdom"),
+ * not ISO codes, so we accept either format.
+ */
+
+export type Continent =
+  | 'North America'
+  | 'South America'
+  | 'Europe'
+  | 'Asia'
+  | 'Africa'
+  | 'Oceania'
+  | 'Antarctica';
+
+export interface CountryRegionInfo {
+  countryCode: string; // ISO 3166-1 alpha-2
+  countryName: string; // Canonical name as Yahoo returns
+  continent: Continent;
+  /** Finer-grained region (e.g., "Western Europe", "North America", "East Asia"). */
+  region: string;
+}
+
+const COUNTRY_TABLE: CountryRegionInfo[] = [
+  // North America
+  { countryCode: 'US', countryName: 'United States', continent: 'North America', region: 'North America' },
+  { countryCode: 'CA', countryName: 'Canada', continent: 'North America', region: 'North America' },
+  { countryCode: 'MX', countryName: 'Mexico', continent: 'North America', region: 'Latin America' },
+
+  // South / Latin America
+  { countryCode: 'BR', countryName: 'Brazil', continent: 'South America', region: 'Latin America' },
+  { countryCode: 'AR', countryName: 'Argentina', continent: 'South America', region: 'Latin America' },
+  { countryCode: 'CL', countryName: 'Chile', continent: 'South America', region: 'Latin America' },
+  { countryCode: 'CO', countryName: 'Colombia', continent: 'South America', region: 'Latin America' },
+  { countryCode: 'PE', countryName: 'Peru', continent: 'South America', region: 'Latin America' },
+
+  // Western Europe
+  { countryCode: 'GB', countryName: 'United Kingdom', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'IE', countryName: 'Ireland', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'FR', countryName: 'France', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'DE', countryName: 'Germany', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'NL', countryName: 'Netherlands', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'BE', countryName: 'Belgium', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'LU', countryName: 'Luxembourg', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'CH', countryName: 'Switzerland', continent: 'Europe', region: 'Western Europe' },
+  { countryCode: 'AT', countryName: 'Austria', continent: 'Europe', region: 'Western Europe' },
+
+  // Southern Europe
+  { countryCode: 'IT', countryName: 'Italy', continent: 'Europe', region: 'Southern Europe' },
+  { countryCode: 'ES', countryName: 'Spain', continent: 'Europe', region: 'Southern Europe' },
+  { countryCode: 'PT', countryName: 'Portugal', continent: 'Europe', region: 'Southern Europe' },
+  { countryCode: 'GR', countryName: 'Greece', continent: 'Europe', region: 'Southern Europe' },
+  { countryCode: 'MT', countryName: 'Malta', continent: 'Europe', region: 'Southern Europe' },
+  { countryCode: 'CY', countryName: 'Cyprus', continent: 'Europe', region: 'Southern Europe' },
+  { countryCode: 'HR', countryName: 'Croatia', continent: 'Europe', region: 'Southern Europe' },
+  { countryCode: 'SI', countryName: 'Slovenia', continent: 'Europe', region: 'Southern Europe' },
+
+  // Northern Europe
+  { countryCode: 'SE', countryName: 'Sweden', continent: 'Europe', region: 'Northern Europe' },
+  { countryCode: 'NO', countryName: 'Norway', continent: 'Europe', region: 'Northern Europe' },
+  { countryCode: 'DK', countryName: 'Denmark', continent: 'Europe', region: 'Northern Europe' },
+  { countryCode: 'FI', countryName: 'Finland', continent: 'Europe', region: 'Northern Europe' },
+  { countryCode: 'IS', countryName: 'Iceland', continent: 'Europe', region: 'Northern Europe' },
+  { countryCode: 'EE', countryName: 'Estonia', continent: 'Europe', region: 'Northern Europe' },
+  { countryCode: 'LV', countryName: 'Latvia', continent: 'Europe', region: 'Northern Europe' },
+  { countryCode: 'LT', countryName: 'Lithuania', continent: 'Europe', region: 'Northern Europe' },
+
+  // Eastern Europe
+  { countryCode: 'PL', countryName: 'Poland', continent: 'Europe', region: 'Eastern Europe' },
+  { countryCode: 'CZ', countryName: 'Czechia', continent: 'Europe', region: 'Eastern Europe' },
+  { countryCode: 'SK', countryName: 'Slovakia', continent: 'Europe', region: 'Eastern Europe' },
+  { countryCode: 'HU', countryName: 'Hungary', continent: 'Europe', region: 'Eastern Europe' },
+  { countryCode: 'RO', countryName: 'Romania', continent: 'Europe', region: 'Eastern Europe' },
+  { countryCode: 'BG', countryName: 'Bulgaria', continent: 'Europe', region: 'Eastern Europe' },
+  { countryCode: 'RU', countryName: 'Russia', continent: 'Europe', region: 'Eastern Europe' },
+  { countryCode: 'UA', countryName: 'Ukraine', continent: 'Europe', region: 'Eastern Europe' },
+
+  // East Asia
+  { countryCode: 'JP', countryName: 'Japan', continent: 'Asia', region: 'East Asia' },
+  { countryCode: 'CN', countryName: 'China', continent: 'Asia', region: 'East Asia' },
+  { countryCode: 'KR', countryName: 'South Korea', continent: 'Asia', region: 'East Asia' },
+  { countryCode: 'TW', countryName: 'Taiwan', continent: 'Asia', region: 'East Asia' },
+  { countryCode: 'HK', countryName: 'Hong Kong', continent: 'Asia', region: 'East Asia' },
+  { countryCode: 'MO', countryName: 'Macao', continent: 'Asia', region: 'East Asia' },
+
+  // Southeast Asia
+  { countryCode: 'SG', countryName: 'Singapore', continent: 'Asia', region: 'Southeast Asia' },
+  { countryCode: 'MY', countryName: 'Malaysia', continent: 'Asia', region: 'Southeast Asia' },
+  { countryCode: 'TH', countryName: 'Thailand', continent: 'Asia', region: 'Southeast Asia' },
+  { countryCode: 'ID', countryName: 'Indonesia', continent: 'Asia', region: 'Southeast Asia' },
+  { countryCode: 'PH', countryName: 'Philippines', continent: 'Asia', region: 'Southeast Asia' },
+  { countryCode: 'VN', countryName: 'Vietnam', continent: 'Asia', region: 'Southeast Asia' },
+
+  // South Asia
+  { countryCode: 'IN', countryName: 'India', continent: 'Asia', region: 'South Asia' },
+  { countryCode: 'PK', countryName: 'Pakistan', continent: 'Asia', region: 'South Asia' },
+  { countryCode: 'BD', countryName: 'Bangladesh', continent: 'Asia', region: 'South Asia' },
+
+  // Middle East
+  { countryCode: 'IL', countryName: 'Israel', continent: 'Asia', region: 'Middle East' },
+  { countryCode: 'AE', countryName: 'United Arab Emirates', continent: 'Asia', region: 'Middle East' },
+  { countryCode: 'SA', countryName: 'Saudi Arabia', continent: 'Asia', region: 'Middle East' },
+  { countryCode: 'QA', countryName: 'Qatar', continent: 'Asia', region: 'Middle East' },
+  { countryCode: 'KW', countryName: 'Kuwait', continent: 'Asia', region: 'Middle East' },
+  { countryCode: 'TR', countryName: 'Turkey', continent: 'Asia', region: 'Middle East' },
+
+  // Africa
+  { countryCode: 'ZA', countryName: 'South Africa', continent: 'Africa', region: 'Africa' },
+  { countryCode: 'EG', countryName: 'Egypt', continent: 'Africa', region: 'Africa' },
+  { countryCode: 'NG', countryName: 'Nigeria', continent: 'Africa', region: 'Africa' },
+  { countryCode: 'KE', countryName: 'Kenya', continent: 'Africa', region: 'Africa' },
+  { countryCode: 'MA', countryName: 'Morocco', continent: 'Africa', region: 'Africa' },
+
+  // Oceania
+  { countryCode: 'AU', countryName: 'Australia', continent: 'Oceania', region: 'Oceania' },
+  { countryCode: 'NZ', countryName: 'New Zealand', continent: 'Oceania', region: 'Oceania' },
+];
+
+const BY_CODE = new Map<string, CountryRegionInfo>();
+const BY_NAME = new Map<string, CountryRegionInfo>();
+
+for (const info of COUNTRY_TABLE) {
+  BY_CODE.set(info.countryCode.toUpperCase(), info);
+  BY_NAME.set(info.countryName.toLowerCase(), info);
+}
+
+// Common Yahoo variations / aliases mapped to canonical names.
+const NAME_ALIASES: Record<string, string> = {
+  usa: 'United States',
+  'us': 'United States',
+  'u.s.': 'United States',
+  'u.s.a.': 'United States',
+  america: 'United States',
+  'united states of america': 'United States',
+  uk: 'United Kingdom',
+  britain: 'United Kingdom',
+  'great britain': 'United Kingdom',
+  'czech republic': 'Czechia',
+  'korea, south': 'South Korea',
+  'south korea': 'South Korea',
+  republic_of_korea: 'South Korea',
+  'taiwan, province of china': 'Taiwan',
+  'hong kong sar china': 'Hong Kong',
+  'russian federation': 'Russia',
+};
+
+/**
+ * Look up region info by country code (preferred) or free-text country name.
+ * Returns undefined if no mapping found.
+ */
+export function lookupCountry(input: string | undefined | null): CountryRegionInfo | undefined {
+  if (!input) return undefined;
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+
+  // Try ISO code (2 chars, uppercase)
+  if (trimmed.length === 2) {
+    const byCode = BY_CODE.get(trimmed.toUpperCase());
+    if (byCode) return byCode;
+  }
+
+  // Try exact name
+  const lower = trimmed.toLowerCase();
+  const byName = BY_NAME.get(lower);
+  if (byName) return byName;
+
+  // Try alias
+  const canonical = NAME_ALIASES[lower];
+  if (canonical) {
+    return BY_NAME.get(canonical.toLowerCase());
+  }
+
+  return undefined;
+}
+
+/** Get continent for an arbitrary country input, or "Unknown" if not found. */
+export function getContinent(input: string | undefined | null): string {
+  return lookupCountry(input)?.continent ?? 'Unknown';
+}
+
+/** Get fine-grained region for an arbitrary country input, or "Unknown" if not found. */
+export function getRegion(input: string | undefined | null): string {
+  return lookupCountry(input)?.region ?? 'Unknown';
+}
+
+/** Full table — exported for testing. */
+export const COUNTRY_REGION_TABLE: ReadonlyArray<CountryRegionInfo> = COUNTRY_TABLE;

--- a/src/utils/etfHeuristics.ts
+++ b/src/utils/etfHeuristics.ts
@@ -1,0 +1,194 @@
+/**
+ * ETF Name Heuristics
+ *
+ * Yahoo Finance's `/v1/finance/search` endpoint (which works without crumb auth)
+ * returns long names for ETFs but no provider, region, or holdings data. The
+ * `quoteSummary` endpoint that would return that data requires a crumb cookie
+ * which can't be obtained from a static browser app.
+ *
+ * As a fallback, we parse the ETF's long name to extract:
+ *   - Provider (fund family)        e.g. "Vanguard", "iShares"
+ *   - Region theme                  e.g. "Global", "United States", "Emerging Markets"
+ *   - Sector / asset focus          e.g. "Equity - Global", "Government Bonds", "Gold"
+ *
+ * These heuristics are intentionally conservative: if no confident match is
+ * found the field is left undefined and the calling code falls back to the
+ * asset class label.
+ */
+
+export interface ETFHeuristicResult {
+  provider?: string;
+  regionTheme?: string;
+  sectorTheme?: string;
+  assetFocus?: 'Equity' | 'Bond' | 'Commodity' | 'Real Estate' | 'Mixed';
+}
+
+// -- Provider patterns -----------------------------------------------------
+// Ordered: more specific first.
+const PROVIDER_PATTERNS: Array<{ regex: RegExp; provider: string }> = [
+  { regex: /\bvanguard\b/i, provider: 'Vanguard' },
+  { regex: /\bishares\b/i, provider: 'iShares' },
+  { regex: /\bspdr\b/i, provider: 'SPDR' },
+  { regex: /\bxtrackers\b/i, provider: 'Xtrackers' },
+  { regex: /\bdb x-trackers\b/i, provider: 'Xtrackers' },
+  { regex: /\blyxor\b/i, provider: 'Lyxor' },
+  { regex: /\bamundi\b/i, provider: 'Amundi' },
+  { regex: /\binvesco\b/i, provider: 'Invesco' },
+  { regex: /\bwisdomtree\b/i, provider: 'WisdomTree' },
+  { regex: /\bvaneck\b/i, provider: 'VanEck' },
+  { regex: /\barkk?\b/i, provider: 'ARK' },
+  { regex: /\bproshares\b/i, provider: 'ProShares' },
+  { regex: /\bfirst trust\b/i, provider: 'First Trust' },
+  { regex: /\bschwab\b/i, provider: 'Schwab' },
+  { regex: /\bfidelity\b/i, provider: 'Fidelity' },
+  { regex: /\bjpmorgan\b|\bjp morgan\b/i, provider: 'JPMorgan' },
+  { regex: /\bbnp paribas\b/i, provider: 'BNP Paribas' },
+  { regex: /\bhsbc\b/i, provider: 'HSBC' },
+  { regex: /\bubs\b/i, provider: 'UBS' },
+  { regex: /\bblackrock\b/i, provider: 'BlackRock' },
+  { regex: /\bstate street\b/i, provider: 'State Street' },
+  { regex: /\bdimensional\b/i, provider: 'Dimensional' },
+  { regex: /\bglobal x\b/i, provider: 'Global X' },
+  { regex: /\bcsif\b/i, provider: 'Credit Suisse' },
+  { regex: /\bossiam\b/i, provider: 'Ossiam' },
+  { regex: /\bpimco\b/i, provider: 'PIMCO' },
+];
+
+// -- Region patterns -------------------------------------------------------
+// Most specific first. Each maps to a region label that's meaningful in the
+// Continent / Region breakdowns.
+const REGION_PATTERNS: Array<{ regex: RegExp; region: string; continent?: string }> = [
+  // Global
+  { regex: /\b(all[- ]?world|all[- ]?country|acwi|msci world|ftse all[- ]world|global aggregate|world index|world equity)\b/i, region: 'Global', continent: 'Global' },
+  { regex: /\bglobal\b/i, region: 'Global', continent: 'Global' },
+  { regex: /\bworld\b/i, region: 'Global', continent: 'Global' },
+
+  // Emerging Markets
+  { regex: /\b(emerging markets?|em equity|em asia|em\b(?! equity)|emim|emerging|developing)\b/i, region: 'Emerging Markets', continent: 'Emerging Markets' },
+
+  // United States
+  { regex: /\b(s&p ?500|s&p500|sp500|nasdaq[- ]?100|russell ?(1000|2000|3000)|dow jones (industrial|us)|us ?500|u\.s\.\b|usa|united states|america)\b/i, region: 'United States', continent: 'North America' },
+
+  // Japan
+  { regex: /\b(japan|nikkei|topix)\b/i, region: 'Japan', continent: 'Asia' },
+
+  // Europe (broader catches)
+  { regex: /\b(euro ?stoxx ?50?|stoxx ?600|euro ?zone|eurozone|ftse ?100|dax|cac ?40|smi|ibex|ftse mib)\b/i, region: 'Europe', continent: 'Europe' },
+  { regex: /\b(europe|european)\b/i, region: 'Europe', continent: 'Europe' },
+
+  // Asia ex-Japan & Pacific
+  { regex: /\basia[- ]pacific\b/i, region: 'Asia Pacific', continent: 'Asia' },
+  { regex: /\b(asia ex[- ]?japan)\b/i, region: 'Asia ex-Japan', continent: 'Asia' },
+  { regex: /\b(asia|pacific)\b/i, region: 'Asia Pacific', continent: 'Asia' },
+
+  // Country-specific
+  { regex: /\bchina\b/i, region: 'China', continent: 'Asia' },
+  { regex: /\bindia\b/i, region: 'India', continent: 'Asia' },
+  { regex: /\bkorea\b/i, region: 'South Korea', continent: 'Asia' },
+  { regex: /\btaiwan\b/i, region: 'Taiwan', continent: 'Asia' },
+  { regex: /\baustralia\b/i, region: 'Australia', continent: 'Oceania' },
+  { regex: /\bcanada\b/i, region: 'Canada', continent: 'North America' },
+  { regex: /\bbrazil\b/i, region: 'Brazil', continent: 'South America' },
+  { regex: /\b(germany|deutsch)\b/i, region: 'Germany', continent: 'Europe' },
+  { regex: /\b(united kingdom|britain|uk equity)\b/i, region: 'United Kingdom', continent: 'Europe' },
+  { regex: /\bfrance\b/i, region: 'France', continent: 'Europe' },
+  { regex: /\bitaly\b/i, region: 'Italy', continent: 'Europe' },
+  { regex: /\bswitzerland\b/i, region: 'Switzerland', continent: 'Europe' },
+
+  // Developed Markets (last as fallback for "developed")
+  { regex: /\b(developed markets?|dm equity|msci eafe|eafe)\b/i, region: 'Developed Markets ex-US', continent: 'Global' },
+];
+
+// -- Asset focus / sector theme patterns -----------------------------------
+const ASSET_FOCUS_PATTERNS: Array<{
+  regex: RegExp;
+  focus: ETFHeuristicResult['assetFocus'];
+  sectorTheme: string;
+}> = [
+  // Bonds
+  { regex: /\b(treasur(y|ies)|govt bond|government bond|sovereign|gilt|bund)\b/i, focus: 'Bond', sectorTheme: 'Government Bonds' },
+  { regex: /\b(corporate bond|corp bond|investment grade|ig credit|aggregate bond)\b/i, focus: 'Bond', sectorTheme: 'Corporate Bonds' },
+  { regex: /\b(high[- ]?yield|hy bond|junk bond)\b/i, focus: 'Bond', sectorTheme: 'High-Yield Bonds' },
+  { regex: /\b(inflation[- ]?linked|tips|linker|inflation protected)\b/i, focus: 'Bond', sectorTheme: 'Inflation-Linked Bonds' },
+  { regex: /\b(em(?:erging)? debt|emerging bond)\b/i, focus: 'Bond', sectorTheme: 'Emerging Markets Bonds' },
+  { regex: /\b(bond|fixed income|treasuries|aggregate)\b/i, focus: 'Bond', sectorTheme: 'Bonds' },
+
+  // Real Estate
+  { regex: /\b(reit|real estate)\b/i, focus: 'Real Estate', sectorTheme: 'Real Estate' },
+
+  // Commodities
+  { regex: /\bgold\b/i, focus: 'Commodity', sectorTheme: 'Gold' },
+  { regex: /\bsilver\b/i, focus: 'Commodity', sectorTheme: 'Silver' },
+  { regex: /\b(crude|oil|brent|wti)\b/i, focus: 'Commodity', sectorTheme: 'Oil & Gas' },
+  { regex: /\bcommodit(y|ies)\b/i, focus: 'Commodity', sectorTheme: 'Commodities' },
+
+  // Sector-themed equity
+  { regex: /\b(technology|tech sector|information technology)\b/i, focus: 'Equity', sectorTheme: 'Technology' },
+  { regex: /\b(healthcare|health care|biotech|pharmaceutical)\b/i, focus: 'Equity', sectorTheme: 'Healthcare' },
+  { regex: /\b(financial|banks|insurance)\b/i, focus: 'Equity', sectorTheme: 'Financial Services' },
+  { regex: /\b(energy|oil & gas)\b/i, focus: 'Equity', sectorTheme: 'Energy' },
+  { regex: /\b(consumer staples)\b/i, focus: 'Equity', sectorTheme: 'Consumer Defensive' },
+  { regex: /\b(consumer discretionary)\b/i, focus: 'Equity', sectorTheme: 'Consumer Cyclical' },
+  { regex: /\b(utilities)\b/i, focus: 'Equity', sectorTheme: 'Utilities' },
+  { regex: /\b(materials|metals|mining)\b/i, focus: 'Equity', sectorTheme: 'Basic Materials' },
+  { regex: /\b(industrials)\b/i, focus: 'Equity', sectorTheme: 'Industrials' },
+  { regex: /\b(communications?|telecom)\b/i, focus: 'Equity', sectorTheme: 'Communication Services' },
+
+  // Mixed / allocation
+  { regex: /\b(allocation|multi[- ]asset|balanced|lifestrategy)\b/i, focus: 'Mixed', sectorTheme: 'Multi-Asset' },
+];
+
+/** Infer provider, region, and asset focus from an ETF's long name. */
+export function inferEtfInfo(longName: string | undefined, shortName?: string): ETFHeuristicResult {
+  const text = [longName, shortName].filter(Boolean).join(' ');
+  if (!text) return {};
+
+  const result: ETFHeuristicResult = {};
+
+  for (const { regex, provider } of PROVIDER_PATTERNS) {
+    if (regex.test(text)) {
+      result.provider = provider;
+      break;
+    }
+  }
+
+  for (const { regex, region } of REGION_PATTERNS) {
+    if (regex.test(text)) {
+      result.regionTheme = region;
+      break;
+    }
+  }
+
+  for (const { regex, focus, sectorTheme } of ASSET_FOCUS_PATTERNS) {
+    if (regex.test(text)) {
+      result.assetFocus = focus;
+      result.sectorTheme = sectorTheme;
+      break;
+    }
+  }
+
+  // If no sector theme matched but we did identify a region, default focus to Equity.
+  if (!result.sectorTheme && result.regionTheme) {
+    result.assetFocus = 'Equity';
+    result.sectorTheme = `${result.regionTheme} Equity`;
+  }
+
+  return result;
+}
+
+/**
+ * Derive an ISO country code from an ISIN's first two characters.
+ * The ISIN prefix is the country of issuance. For individual stocks it usually
+ * matches the company's primary listing country (and often HQ); for ETFs it
+ * indicates the *domicile* (often IE, LU), not the underlying region.
+ *
+ * Returns undefined if the input doesn't look like a valid ISIN.
+ */
+export function isinToCountryCode(isin: string | undefined | null): string | undefined {
+  if (!isin) return undefined;
+  const clean = isin.trim().toUpperCase();
+  if (clean.length < 2) return undefined;
+  const prefix = clean.substring(0, 2);
+  if (!/^[A-Z]{2}$/.test(prefix)) return undefined;
+  return prefix;
+}

--- a/src/utils/portfolioBreakdownCalculator.ts
+++ b/src/utils/portfolioBreakdownCalculator.ts
@@ -1,0 +1,314 @@
+/**
+ * Portfolio Breakdown Calculator
+ *
+ * Pure functions to slice a portfolio across multiple dimensions:
+ * currency, holding, sector, continent, region, market (exchange), ETF provider.
+ *
+ * For ETFs we expand sector exposure via Yahoo's `sectorWeightings` so a single
+ * S&P 500 ETF contributes proportionally to Technology / Healthcare / etc.
+ * Non-ticker assets (real estate, cash, vehicles, collectibles, art) are bucketed
+ * by their asset-class label in dimensions where they can't be classified.
+ */
+
+import { Asset, AssetClass } from '../types/assetAllocation';
+import {
+  AssetMetadata,
+  BreakdownDimension,
+  BreakdownEntry,
+  BreakdownResult,
+} from '../types/portfolioBreakdown';
+import { getContinent, getRegion } from './countryToRegion';
+import { formatAssetName } from './allocationCalculator';
+
+const GOLDEN_ANGLE_DEGREES = 137.5;
+
+/** Stable color per asset class — mirrors `prepareAssetClassChartData`. */
+const ASSET_CLASS_COLORS: Record<AssetClass, string> = {
+  STOCKS: '#5568d4',
+  BONDS: '#764ba2',
+  CASH: '#4CAF50',
+  CRYPTO: '#FF9800',
+  REAL_ESTATE: '#9C27B0',
+  COMMODITIES: '#FFC107',
+  VEHICLE: '#607D8B',
+  COLLECTIBLE: '#E91E63',
+  ART: '#00BCD4',
+};
+
+function assetClassLabel(cls: AssetClass): string {
+  return formatAssetName(cls);
+}
+
+/**
+ * Filter assets the breakdown page should consider: anything not OFF and with
+ * a positive value (matches what the user sees in the Asset Allocation table).
+ */
+export function selectActiveAssets(assets: Asset[]): Asset[] {
+  return assets.filter(a => a.targetMode !== 'OFF' && a.currentValue > 0);
+}
+
+/** Sum currentValue across active assets. */
+export function activePortfolioValue(assets: Asset[]): number {
+  return selectActiveAssets(assets).reduce((sum, a) => sum + a.currentValue, 0);
+}
+
+// -- Bucket helpers ---------------------------------------------------------
+
+interface BucketAccumulator {
+  value: number;
+  ticker?: string;
+}
+
+function addBucket(
+  buckets: Map<string, BucketAccumulator>,
+  label: string,
+  value: number,
+  ticker?: string,
+): void {
+  if (value <= 0) return;
+  const existing = buckets.get(label);
+  if (existing) {
+    existing.value += value;
+    // Keep first ticker as the representative one
+  } else {
+    buckets.set(label, { value, ticker });
+  }
+}
+
+function bucketsToEntries(
+  buckets: Map<string, BucketAccumulator>,
+  totalValue: number,
+  colorFor?: (label: string, index: number) => string,
+): BreakdownEntry[] {
+  const entries = [...buckets.entries()].map(([label, b], index) => {
+    const percentage = totalValue > 0 ? (b.value / totalValue) * 100 : 0;
+    return {
+      label,
+      value: b.value,
+      percentage,
+      color: colorFor
+        ? colorFor(label, index)
+        : `hsl(${(index * GOLDEN_ANGLE_DEGREES) % 360}, 70%, 60%)`,
+      ticker: b.ticker,
+    };
+  });
+
+  // Sort by value desc for readability
+  entries.sort((a, b) => b.value - a.value);
+  // Re-assign colors based on final order if using golden-angle scheme
+  if (!colorFor) {
+    entries.forEach((e, i) => {
+      e.color = `hsl(${(i * GOLDEN_ANGLE_DEGREES) % 360}, 70%, 60%)`;
+    });
+  }
+
+  return entries;
+}
+
+// -- Dimension breakdowns ---------------------------------------------------
+
+function byCurrency(assets: Asset[]): Map<string, BucketAccumulator> {
+  const buckets = new Map<string, BucketAccumulator>();
+  for (const a of assets) {
+    const currency = a.originalCurrency || 'EUR';
+    addBucket(buckets, currency, a.currentValue);
+  }
+  return buckets;
+}
+
+function byHolding(assets: Asset[]): Map<string, BucketAccumulator> {
+  const buckets = new Map<string, BucketAccumulator>();
+  for (const a of assets) {
+    const label = a.name || a.ticker || assetClassLabel(a.assetClass);
+    addBucket(buckets, label, a.currentValue, a.ticker || undefined);
+  }
+  return buckets;
+}
+
+function bySector(
+  assets: Asset[],
+  metadataByTicker: Record<string, AssetMetadata | undefined>,
+): Map<string, BucketAccumulator> {
+  const buckets = new Map<string, BucketAccumulator>();
+
+  for (const a of assets) {
+    const meta = a.ticker ? metadataByTicker[a.ticker.toUpperCase()] : undefined;
+    const weights = meta?.sectorWeightings;
+
+    if (weights && weights.length > 0) {
+      // ETF / fund: distribute value across sectors using weights
+      const totalWeight = weights.reduce((s, w) => s + w.weight, 0);
+      if (totalWeight > 0) {
+        for (const w of weights) {
+          const portion = (w.weight / totalWeight) * a.currentValue;
+          addBucket(buckets, w.sector, portion);
+        }
+        continue;
+      }
+    }
+
+    if (meta?.sector) {
+      // Individual stock
+      addBucket(buckets, meta.sector, a.currentValue);
+      continue;
+    }
+
+    // Fallback: asset class label
+    addBucket(buckets, assetClassLabel(a.assetClass), a.currentValue);
+  }
+
+  return buckets;
+}
+
+function byCountryDerived(
+  assets: Asset[],
+  metadataByTicker: Record<string, AssetMetadata | undefined>,
+  derive: (country: string | undefined) => string,
+): Map<string, BucketAccumulator> {
+  const buckets = new Map<string, BucketAccumulator>();
+
+  for (const a of assets) {
+    const meta = a.ticker ? metadataByTicker[a.ticker.toUpperCase()] : undefined;
+    if (meta?.country) {
+      const label = derive(meta.country);
+      addBucket(buckets, label, a.currentValue);
+      continue;
+    }
+    // ETFs / non-classifiable: fall back to asset class label
+    addBucket(buckets, assetClassLabel(a.assetClass), a.currentValue);
+  }
+
+  return buckets;
+}
+
+function byMarket(
+  assets: Asset[],
+  metadataByTicker: Record<string, AssetMetadata | undefined>,
+): Map<string, BucketAccumulator> {
+  const buckets = new Map<string, BucketAccumulator>();
+
+  for (const a of assets) {
+    const meta = a.ticker ? metadataByTicker[a.ticker.toUpperCase()] : undefined;
+    const label = meta?.exchange || assetClassLabel(a.assetClass);
+    addBucket(buckets, label, a.currentValue);
+  }
+  return buckets;
+}
+
+function byEtfProvider(
+  assets: Asset[],
+  metadataByTicker: Record<string, AssetMetadata | undefined>,
+): Map<string, BucketAccumulator> {
+  const buckets = new Map<string, BucketAccumulator>();
+
+  for (const a of assets) {
+    const meta = a.ticker ? metadataByTicker[a.ticker.toUpperCase()] : undefined;
+    let label: string;
+    if (meta?.fundFamily) {
+      label = meta.fundFamily;
+    } else if (meta?.quoteType === 'EQUITY') {
+      label = 'Direct holding';
+    } else {
+      label = assetClassLabel(a.assetClass);
+    }
+    addBucket(buckets, label, a.currentValue);
+  }
+  return buckets;
+}
+
+// -- Entry point ------------------------------------------------------------
+
+export interface ComputeBreakdownOptions {
+  assets: Asset[];
+  metadataByTicker: Record<string, AssetMetadata | undefined>;
+  dimension: BreakdownDimension;
+}
+
+/**
+ * Compute a single-dimension breakdown of a portfolio.
+ *
+ * Values are based on `asset.currentValue` (already converted to the user's
+ * default currency upstream).
+ */
+export function computeBreakdown(opts: ComputeBreakdownOptions): BreakdownResult {
+  const active = selectActiveAssets(opts.assets);
+  const totalValue = active.reduce((s, a) => s + a.currentValue, 0);
+
+  let buckets: Map<string, BucketAccumulator>;
+  let colorFor: ((label: string, index: number) => string) | undefined;
+
+  switch (opts.dimension) {
+    case 'currency':
+      buckets = byCurrency(active);
+      break;
+    case 'holding':
+      buckets = byHolding(active);
+      break;
+    case 'sector':
+      buckets = bySector(active, opts.metadataByTicker);
+      break;
+    case 'continent':
+      buckets = byCountryDerived(active, opts.metadataByTicker, getContinent);
+      break;
+    case 'region':
+      buckets = byCountryDerived(active, opts.metadataByTicker, getRegion);
+      break;
+    case 'market':
+      buckets = byMarket(active, opts.metadataByTicker);
+      break;
+    case 'etfProvider':
+      buckets = byEtfProvider(active, opts.metadataByTicker);
+      // If a known asset class label happens to be the bucket key, color it
+      // consistently with the existing asset-class palette.
+      colorFor = (label: string, i: number) => {
+        const knownClassEntry = (Object.keys(ASSET_CLASS_COLORS) as AssetClass[]).find(
+          c => assetClassLabel(c) === label,
+        );
+        if (knownClassEntry) return ASSET_CLASS_COLORS[knownClassEntry];
+        return `hsl(${(i * GOLDEN_ANGLE_DEGREES) % 360}, 70%, 60%)`;
+      };
+      break;
+  }
+
+  const unknownValue = buckets.get('Unknown')?.value ?? 0;
+  const entries = bucketsToEntries(buckets, totalValue, colorFor);
+
+  return {
+    dimension: opts.dimension,
+    entries,
+    totalValue,
+    unknownValue,
+  };
+}
+
+/** Convenience: compute every dimension at once. */
+export function computeAllBreakdowns(
+  assets: Asset[],
+  metadataByTicker: Record<string, AssetMetadata | undefined>,
+): Record<BreakdownDimension, BreakdownResult> {
+  const dims: BreakdownDimension[] = [
+    'currency',
+    'holding',
+    'sector',
+    'continent',
+    'region',
+    'market',
+    'etfProvider',
+  ];
+  const out: Partial<Record<BreakdownDimension, BreakdownResult>> = {};
+  for (const dim of dims) {
+    out[dim] = computeBreakdown({ assets, metadataByTicker, dimension: dim });
+  }
+  return out as Record<BreakdownDimension, BreakdownResult>;
+}
+
+/** Tickers that we should fetch metadata for, given a set of assets. */
+export function uniqueTickers(assets: Asset[]): string[] {
+  const set = new Set<string>();
+  for (const a of selectActiveAssets(assets)) {
+    if (a.ticker && a.ticker.trim().length > 0) {
+      set.add(a.ticker.trim().toUpperCase());
+    }
+  }
+  return [...set];
+}

--- a/src/utils/yahooMetadata.ts
+++ b/src/utils/yahooMetadata.ts
@@ -1,22 +1,33 @@
 /**
  * Yahoo Finance metadata fetcher
  *
- * Fetches per-ticker metadata (sector, country, fund family, sector weightings…)
- * via Yahoo Finance `quoteSummary` endpoint and caches results in localStorage
- * with a 7-day TTL.
+ * Fetches per-ticker metadata (sector, country, fund family, exchange, ...)
+ * for the Portfolio Breakdown page.
  *
- * Used by the Portfolio Breakdown page to slice the portfolio across multiple
- * dimensions. Goes through the shared `yahooFetch` so it respects the global
- * rate limit.
+ * Goes through the shared rate-limited `yahooFetch` proxy and caches results
+ * in localStorage for 7 days.
+ *
+ * Data sources (all anonymous — no crumb cookie required):
+ *   - `/v1/finance/search` — sector / industry / exchange / quoteType / longName
+ *   - For ETFs, the longName is run through `etfHeuristics` to extract a
+ *     provider, region theme, and asset focus, since Yahoo's per-ETF holdings
+ *     endpoint (`quoteSummary` with `topHoldings`) requires crumb auth which
+ *     isn't available in a static browser app.
+ *   - Stock country is derived from the ISIN prefix when stored on the asset.
+ *
+ * Why not `quoteSummary`?
+ *   `https://query1.finance.yahoo.com/v10/finance/quoteSummary/<ticker>` now
+ *   returns `{"finance":{"error":{"code":"Unauthorized","description":"Invalid Crumb"}}}`
+ *   for unauthenticated callers, so we don't even attempt it.
  */
 
-import { AssetMetadata, SectorWeight, RegionWeight } from '../types/portfolioBreakdown';
+import { AssetMetadata, RegionWeight } from '../types/portfolioBreakdown';
 import { yahooFetch, hasRateLimitCapacity, YahooRateLimitError } from './yahooProxy';
+import { inferEtfInfo, isinToCountryCode } from './etfHeuristics';
 
-const MODULES = ['summaryProfile', 'fundProfile', 'topHoldings', 'quoteType'].join(',');
-const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const CACHE_PREFIX = 'fire-tools:asset-metadata:';
-const CACHE_VERSION = 1;
+const CACHE_VERSION = 2; // bumped when fields/strategy change
 
 interface CachedEntry {
   v: number;
@@ -24,7 +35,6 @@ interface CachedEntry {
   expiresAt: number;
 }
 
-// In-memory mirror so we don't hit localStorage repeatedly within a session.
 const memoryCache = new Map<string, AssetMetadata>();
 
 function cacheKey(ticker: string): string {
@@ -72,7 +82,6 @@ function writeToStorage(ticker: string, data: AssetMetadata): void {
     };
     localStorage.setItem(cacheKey(ticker), JSON.stringify(entry));
   } catch (err) {
-    // Storage quota or privacy mode — non-fatal.
     console.error('Failed to write asset metadata cache', err);
   }
 }
@@ -95,119 +104,55 @@ export function clearAssetMetadataCache(): void {
   }
 }
 
-// -- Yahoo response parsing -------------------------------------------------
+// -- Yahoo response shape --------------------------------------------------
 
-interface YahooQuoteSummaryRaw {
-  quoteSummary?: {
-    result?: Array<{
-      summaryProfile?: {
-        sector?: string;
-        industry?: string;
-        country?: string;
-      };
-      fundProfile?: {
-        family?: string;
-        categoryName?: string;
-        legalType?: string;
-      };
-      topHoldings?: {
-        sectorWeightings?: Array<Record<string, { raw?: number } | number>>;
-      };
-      quoteType?: {
-        quoteType?: string;
-        longName?: string;
-        shortName?: string;
-        symbol?: string;
-        exchange?: string;
-        currency?: string;
-      };
-    }>;
-    error?: { description?: string } | null;
-  };
+interface YahooSearchResponse {
+  quotes?: Array<{
+    symbol?: string;
+    shortname?: string;
+    longname?: string;
+    quoteType?: string;
+    typeDisp?: string;
+    exchange?: string;
+    exchDisp?: string;
+    sector?: string;
+    sectorDisp?: string;
+    industry?: string;
+    industryDisp?: string;
+  }>;
+  count?: number;
 }
 
-function normalizeSectorName(raw: string): string {
-  // Yahoo returns keys like "realestate", "consumer_cyclical"
-  const map: Record<string, string> = {
-    realestate: 'Real Estate',
-    consumer_cyclical: 'Consumer Cyclical',
-    consumer_defensive: 'Consumer Defensive',
-    basic_materials: 'Basic Materials',
-    communication_services: 'Communication Services',
-    financial_services: 'Financial Services',
-    healthcare: 'Healthcare',
-    industrials: 'Industrials',
-    technology: 'Technology',
-    energy: 'Energy',
-    utilities: 'Utilities',
-  };
-  if (map[raw]) return map[raw];
-  // Title-case fallback
-  return raw
-    .replace(/[_-]+/g, ' ')
-    .replace(/\b\w/g, c => c.toUpperCase())
-    .trim();
+// -- Public API ------------------------------------------------------------
+
+export interface FetchMetadataOptions {
+  /** Optional ISIN to derive country code from when Yahoo doesn't return one. */
+  isin?: string;
 }
-
-function parseSectorWeightings(raw: YahooQuoteSummaryRaw): SectorWeight[] | undefined {
-  const arr = raw?.quoteSummary?.result?.[0]?.topHoldings?.sectorWeightings;
-  if (!Array.isArray(arr) || arr.length === 0) return undefined;
-
-  const result: SectorWeight[] = [];
-  for (const item of arr) {
-    if (!item || typeof item !== 'object') continue;
-    for (const [key, val] of Object.entries(item)) {
-      let weight: number | undefined;
-      if (typeof val === 'number') weight = val;
-      else if (val && typeof val === 'object' && typeof val.raw === 'number') weight = val.raw;
-      if (weight === undefined || isNaN(weight) || weight <= 0) continue;
-      result.push({ sector: normalizeSectorName(key), weight });
-    }
-  }
-
-  return result.length > 0 ? result : undefined;
-}
-
-function parseMetadata(ticker: string, raw: YahooQuoteSummaryRaw): AssetMetadata {
-  const result = raw?.quoteSummary?.result?.[0];
-  const summary = result?.summaryProfile;
-  const fund = result?.fundProfile;
-  const quote = result?.quoteType;
-
-  return {
-    ticker: ticker.toUpperCase(),
-    quoteType: quote?.quoteType,
-    longName: quote?.longName,
-    shortName: quote?.shortName,
-    currency: quote?.currency,
-    exchange: quote?.exchange,
-    sector: summary?.sector,
-    industry: summary?.industry,
-    country: summary?.country,
-    fundFamily: fund?.family,
-    category: fund?.categoryName,
-    sectorWeightings: parseSectorWeightings(raw),
-    regionWeightings: undefined, // Yahoo doesn't reliably expose region weights
-    fetchedAt: new Date().toISOString(),
-  };
-}
-
-// -- Public API -------------------------------------------------------------
 
 /**
  * Fetch metadata for a single ticker. Returns cached data if fresh.
  *
- * Errors are returned in the `error` field rather than thrown, so callers can
- * keep rendering with partial coverage.
+ * Errors are surfaced in `error` rather than thrown so callers can keep
+ * rendering with partial coverage.
  */
-export async function fetchAssetMetadata(ticker: string): Promise<AssetMetadata> {
+export async function fetchAssetMetadata(
+  ticker: string,
+  opts: FetchMetadataOptions = {},
+): Promise<AssetMetadata> {
   const clean = ticker.trim().toUpperCase();
   if (!clean) {
     return { ticker: '', fetchedAt: new Date().toISOString(), error: 'Empty ticker' };
   }
 
   const cached = readFromStorage(clean);
-  if (cached) return cached;
+  if (cached) {
+    if (!cached.country && opts.isin) {
+      const code = isinToCountryCode(opts.isin);
+      if (code) return { ...cached, country: code };
+    }
+    return cached;
+  }
 
   if (!hasRateLimitCapacity()) {
     return {
@@ -218,28 +163,53 @@ export async function fetchAssetMetadata(ticker: string): Promise<AssetMetadata>
   }
 
   try {
-    const data = await yahooFetch<YahooQuoteSummaryRaw>(
-      `/v10/finance/quoteSummary/${encodeURIComponent(clean)}?modules=${MODULES}`,
+    const data = await yahooFetch<YahooSearchResponse>(
+      `/v1/finance/search?q=${encodeURIComponent(clean)}&quotesCount=1&newsCount=0&enableFuzzyQuery=false&enableNavLinks=false`,
     );
 
-    if (data?.quoteSummary?.error) {
-      const desc = data.quoteSummary.error.description || 'Unknown error';
+    // Prefer an exact symbol match; Yahoo occasionally returns near-matches first.
+    const quotes = data?.quotes ?? [];
+    const match =
+      quotes.find(q => (q.symbol || '').toUpperCase() === clean) ?? quotes[0];
+
+    if (!match) {
       return {
         ticker: clean,
         fetchedAt: new Date().toISOString(),
-        error: `Yahoo Finance error: ${desc}`,
+        error: 'No data returned from Yahoo Finance search',
       };
     }
 
-    if (!data?.quoteSummary?.result?.[0]) {
-      return {
-        ticker: clean,
-        fetchedAt: new Date().toISOString(),
-        error: 'No data returned from Yahoo Finance',
-      };
+    const quoteType = match.quoteType?.toUpperCase();
+    const meta: AssetMetadata = {
+      ticker: clean,
+      quoteType,
+      longName: match.longname,
+      shortName: match.shortname,
+      exchange: match.exchDisp || match.exchange,
+      sector: match.sectorDisp || match.sector,
+      industry: match.industryDisp || match.industry,
+      fetchedAt: new Date().toISOString(),
+    };
+
+    // ETFs: fill in provider / region theme / sector theme from the long name.
+    if (quoteType === 'ETF' || quoteType === 'MUTUALFUND') {
+      const etf = inferEtfInfo(match.longname, match.shortname);
+      if (etf.provider) meta.fundFamily = etf.provider;
+      if (etf.regionTheme) meta.country = etf.regionTheme; // used by continent/region
+      if (!meta.sector && etf.sectorTheme) meta.sector = etf.sectorTheme;
+      if (etf.regionTheme) {
+        const regionWeightings: RegionWeight[] = [{ region: etf.regionTheme, weight: 1 }];
+        meta.regionWeightings = regionWeightings;
+      }
     }
 
-    const meta = parseMetadata(clean, data);
+    // Stocks: ISIN prefix → country code (Yahoo search doesn't return country).
+    if (!meta.country && opts.isin) {
+      const code = isinToCountryCode(opts.isin);
+      if (code) meta.country = code;
+    }
+
     writeToStorage(clean, meta);
     return meta;
   } catch (err) {
@@ -258,11 +228,13 @@ export async function fetchAssetMetadata(ticker: string): Promise<AssetMetadata>
 }
 
 /**
- * Fetch metadata for multiple tickers sequentially (to respect the per-request
- * throttle in `yahooFetch`). Returns a ticker → metadata map.
+ * Fetch metadata for multiple tickers sequentially (respects the per-request
+ * throttle in `yahooFetch`). Optional `isinByTicker` augments stock metadata
+ * with ISIN-derived country.
  */
 export async function fetchAssetMetadataBatch(
   tickers: string[],
+  isinByTicker: Record<string, string | undefined> = {},
 ): Promise<Record<string, AssetMetadata>> {
   const unique = [
     ...new Set(tickers.filter(t => t && t.trim().length > 0).map(t => t.trim().toUpperCase())),
@@ -270,20 +242,16 @@ export async function fetchAssetMetadataBatch(
 
   const out: Record<string, AssetMetadata> = {};
   for (const ticker of unique) {
-    out[ticker] = await fetchAssetMetadata(ticker);
+    out[ticker] = await fetchAssetMetadata(ticker, { isin: isinByTicker[ticker] });
   }
   return out;
 }
 
-// Re-exported for tests
 export const _internal = {
-  parseMetadata,
-  parseSectorWeightings,
-  normalizeSectorName,
   cacheKey,
   CACHE_PREFIX,
   CACHE_TTL_MS,
+  CACHE_VERSION,
 };
 
-/** Region weight type is re-exported here so callers don't have to import the type file. */
 export type { RegionWeight };

--- a/src/utils/yahooMetadata.ts
+++ b/src/utils/yahooMetadata.ts
@@ -1,0 +1,289 @@
+/**
+ * Yahoo Finance metadata fetcher
+ *
+ * Fetches per-ticker metadata (sector, country, fund family, sector weightings…)
+ * via Yahoo Finance `quoteSummary` endpoint and caches results in localStorage
+ * with a 7-day TTL.
+ *
+ * Used by the Portfolio Breakdown page to slice the portfolio across multiple
+ * dimensions. Goes through the shared `yahooFetch` so it respects the global
+ * rate limit.
+ */
+
+import { AssetMetadata, SectorWeight, RegionWeight } from '../types/portfolioBreakdown';
+import { yahooFetch, hasRateLimitCapacity, YahooRateLimitError } from './yahooProxy';
+
+const MODULES = ['summaryProfile', 'fundProfile', 'topHoldings', 'quoteType'].join(',');
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const CACHE_PREFIX = 'fire-tools:asset-metadata:';
+const CACHE_VERSION = 1;
+
+interface CachedEntry {
+  v: number;
+  data: AssetMetadata;
+  expiresAt: number;
+}
+
+// In-memory mirror so we don't hit localStorage repeatedly within a session.
+const memoryCache = new Map<string, AssetMetadata>();
+
+function cacheKey(ticker: string): string {
+  return `${CACHE_PREFIX}${ticker.toUpperCase()}`;
+}
+
+function readFromStorage(ticker: string): AssetMetadata | null {
+  const mem = memoryCache.get(ticker.toUpperCase());
+  if (mem) return mem;
+
+  if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+    return null;
+  }
+
+  try {
+    const raw = localStorage.getItem(cacheKey(ticker));
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as CachedEntry;
+    if (parsed.v !== CACHE_VERSION) return null;
+    if (Date.now() >= parsed.expiresAt) {
+      localStorage.removeItem(cacheKey(ticker));
+      return null;
+    }
+
+    memoryCache.set(ticker.toUpperCase(), parsed.data);
+    return parsed.data;
+  } catch (err) {
+    console.error('Failed to read asset metadata cache', err);
+    return null;
+  }
+}
+
+function writeToStorage(ticker: string, data: AssetMetadata): void {
+  memoryCache.set(ticker.toUpperCase(), data);
+  if (typeof localStorage === 'undefined' || typeof localStorage.setItem !== 'function') {
+    return;
+  }
+
+  try {
+    const entry: CachedEntry = {
+      v: CACHE_VERSION,
+      data,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    };
+    localStorage.setItem(cacheKey(ticker), JSON.stringify(entry));
+  } catch (err) {
+    // Storage quota or privacy mode — non-fatal.
+    console.error('Failed to write asset metadata cache', err);
+  }
+}
+
+/** Clear all cached metadata (in-memory and localStorage). */
+export function clearAssetMetadataCache(): void {
+  memoryCache.clear();
+  if (typeof localStorage === 'undefined' || typeof localStorage.key !== 'function') {
+    return;
+  }
+  try {
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(CACHE_PREFIX)) toRemove.push(key);
+    }
+    toRemove.forEach(k => localStorage.removeItem(k));
+  } catch (err) {
+    console.error('Failed to clear asset metadata cache', err);
+  }
+}
+
+// -- Yahoo response parsing -------------------------------------------------
+
+interface YahooQuoteSummaryRaw {
+  quoteSummary?: {
+    result?: Array<{
+      summaryProfile?: {
+        sector?: string;
+        industry?: string;
+        country?: string;
+      };
+      fundProfile?: {
+        family?: string;
+        categoryName?: string;
+        legalType?: string;
+      };
+      topHoldings?: {
+        sectorWeightings?: Array<Record<string, { raw?: number } | number>>;
+      };
+      quoteType?: {
+        quoteType?: string;
+        longName?: string;
+        shortName?: string;
+        symbol?: string;
+        exchange?: string;
+        currency?: string;
+      };
+    }>;
+    error?: { description?: string } | null;
+  };
+}
+
+function normalizeSectorName(raw: string): string {
+  // Yahoo returns keys like "realestate", "consumer_cyclical"
+  const map: Record<string, string> = {
+    realestate: 'Real Estate',
+    consumer_cyclical: 'Consumer Cyclical',
+    consumer_defensive: 'Consumer Defensive',
+    basic_materials: 'Basic Materials',
+    communication_services: 'Communication Services',
+    financial_services: 'Financial Services',
+    healthcare: 'Healthcare',
+    industrials: 'Industrials',
+    technology: 'Technology',
+    energy: 'Energy',
+    utilities: 'Utilities',
+  };
+  if (map[raw]) return map[raw];
+  // Title-case fallback
+  return raw
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase())
+    .trim();
+}
+
+function parseSectorWeightings(raw: YahooQuoteSummaryRaw): SectorWeight[] | undefined {
+  const arr = raw?.quoteSummary?.result?.[0]?.topHoldings?.sectorWeightings;
+  if (!Array.isArray(arr) || arr.length === 0) return undefined;
+
+  const result: SectorWeight[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== 'object') continue;
+    for (const [key, val] of Object.entries(item)) {
+      let weight: number | undefined;
+      if (typeof val === 'number') weight = val;
+      else if (val && typeof val === 'object' && typeof val.raw === 'number') weight = val.raw;
+      if (weight === undefined || isNaN(weight) || weight <= 0) continue;
+      result.push({ sector: normalizeSectorName(key), weight });
+    }
+  }
+
+  return result.length > 0 ? result : undefined;
+}
+
+function parseMetadata(ticker: string, raw: YahooQuoteSummaryRaw): AssetMetadata {
+  const result = raw?.quoteSummary?.result?.[0];
+  const summary = result?.summaryProfile;
+  const fund = result?.fundProfile;
+  const quote = result?.quoteType;
+
+  return {
+    ticker: ticker.toUpperCase(),
+    quoteType: quote?.quoteType,
+    longName: quote?.longName,
+    shortName: quote?.shortName,
+    currency: quote?.currency,
+    exchange: quote?.exchange,
+    sector: summary?.sector,
+    industry: summary?.industry,
+    country: summary?.country,
+    fundFamily: fund?.family,
+    category: fund?.categoryName,
+    sectorWeightings: parseSectorWeightings(raw),
+    regionWeightings: undefined, // Yahoo doesn't reliably expose region weights
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// -- Public API -------------------------------------------------------------
+
+/**
+ * Fetch metadata for a single ticker. Returns cached data if fresh.
+ *
+ * Errors are returned in the `error` field rather than thrown, so callers can
+ * keep rendering with partial coverage.
+ */
+export async function fetchAssetMetadata(ticker: string): Promise<AssetMetadata> {
+  const clean = ticker.trim().toUpperCase();
+  if (!clean) {
+    return { ticker: '', fetchedAt: new Date().toISOString(), error: 'Empty ticker' };
+  }
+
+  const cached = readFromStorage(clean);
+  if (cached) return cached;
+
+  if (!hasRateLimitCapacity()) {
+    return {
+      ticker: clean,
+      fetchedAt: new Date().toISOString(),
+      error: 'Yahoo Finance daily rate limit reached',
+    };
+  }
+
+  try {
+    const data = await yahooFetch<YahooQuoteSummaryRaw>(
+      `/v10/finance/quoteSummary/${encodeURIComponent(clean)}?modules=${MODULES}`,
+    );
+
+    if (data?.quoteSummary?.error) {
+      const desc = data.quoteSummary.error.description || 'Unknown error';
+      return {
+        ticker: clean,
+        fetchedAt: new Date().toISOString(),
+        error: `Yahoo Finance error: ${desc}`,
+      };
+    }
+
+    if (!data?.quoteSummary?.result?.[0]) {
+      return {
+        ticker: clean,
+        fetchedAt: new Date().toISOString(),
+        error: 'No data returned from Yahoo Finance',
+      };
+    }
+
+    const meta = parseMetadata(clean, data);
+    writeToStorage(clean, meta);
+    return meta;
+  } catch (err) {
+    const message =
+      err instanceof YahooRateLimitError
+        ? err.message
+        : err instanceof Error
+        ? err.message
+        : 'Fetch failed';
+    return {
+      ticker: clean,
+      fetchedAt: new Date().toISOString(),
+      error: message,
+    };
+  }
+}
+
+/**
+ * Fetch metadata for multiple tickers sequentially (to respect the per-request
+ * throttle in `yahooFetch`). Returns a ticker → metadata map.
+ */
+export async function fetchAssetMetadataBatch(
+  tickers: string[],
+): Promise<Record<string, AssetMetadata>> {
+  const unique = [
+    ...new Set(tickers.filter(t => t && t.trim().length > 0).map(t => t.trim().toUpperCase())),
+  ];
+
+  const out: Record<string, AssetMetadata> = {};
+  for (const ticker of unique) {
+    out[ticker] = await fetchAssetMetadata(ticker);
+  }
+  return out;
+}
+
+// Re-exported for tests
+export const _internal = {
+  parseMetadata,
+  parseSectorWeightings,
+  normalizeSectorName,
+  cacheKey,
+  CACHE_PREFIX,
+  CACHE_TTL_MS,
+};
+
+/** Region weight type is re-exported here so callers don't have to import the type file. */
+export type { RegionWeight };

--- a/tests/components/PortfolioBreakdownPage.test.tsx
+++ b/tests/components/PortfolioBreakdownPage.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Stub cookie storage so we can control returned assets/settings
+vi.mock('../../src/utils/cookieStorage', () => ({
+  loadAssetAllocation: vi.fn(() => ({
+    assets: [
+      {
+        id: '1',
+        name: 'Vanguard Total Stock',
+        ticker: 'VTI',
+        assetClass: 'STOCKS',
+        subAssetType: 'ETF',
+        currentValue: 1000,
+        targetMode: 'PERCENTAGE',
+        targetPercent: 100,
+        originalCurrency: 'USD',
+      },
+      {
+        id: '2',
+        name: 'Apartment',
+        ticker: '',
+        assetClass: 'REAL_ESTATE',
+        subAssetType: 'PROPERTY',
+        currentValue: 200000,
+        targetMode: 'PERCENTAGE',
+        targetPercent: 100,
+        originalCurrency: 'EUR',
+      },
+    ],
+    assetClassTargets: undefined,
+  })),
+}));
+
+vi.mock('../../src/utils/cookieSettings', () => ({
+  loadSettings: vi.fn(() => ({
+    accountName: 'Tester',
+    privacyMode: false,
+    currencySettings: { defaultCurrency: 'EUR', fallbackRates: {}, useApiRates: false, lastApiUpdate: null },
+    fireAssetClassInclusion: {},
+    includePrimaryResidenceInFIRE: true,
+  })),
+  saveSettings: vi.fn(),
+}));
+
+// Mock the metadata fetch so no network is touched
+vi.mock('../../src/utils/yahooMetadata', () => ({
+  fetchAssetMetadataBatch: vi.fn(async (tickers: string[]) => {
+    const out: Record<string, unknown> = {};
+    for (const t of tickers) {
+      out[t.toUpperCase()] = {
+        ticker: t.toUpperCase(),
+        sector: 'Technology',
+        country: 'United States',
+        exchange: 'NMS',
+        fundFamily: 'Vanguard',
+        quoteType: 'ETF',
+        fetchedAt: new Date().toISOString(),
+      };
+    }
+    return out;
+  }),
+  clearAssetMetadataCache: vi.fn(),
+}));
+
+import { PortfolioBreakdownPage } from '../../src/components/PortfolioBreakdownPage';
+
+describe('PortfolioBreakdownPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the page header and portfolio value', async () => {
+    render(
+      <MemoryRouter>
+        <PortfolioBreakdownPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: /Portfolio Breakdown/i })).toBeTruthy();
+    // Sum of mocked assets = 201_000
+    await waitFor(() => {
+      expect(screen.getByText(/Portfolio Value/i)).toBeTruthy();
+    });
+  });
+
+  it('renders breakdown charts (titles) for every dimension', async () => {
+    render(
+      <MemoryRouter>
+        <PortfolioBreakdownPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /By Currency/i })).toBeTruthy();
+    });
+
+    expect(screen.getByRole('heading', { name: /By Holding/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /By Sector/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /By Continent/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /By Region/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /By Market/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /By ETF Provider/i })).toBeTruthy();
+  });
+
+  it('shows a back link to Asset Allocation', () => {
+    render(
+      <MemoryRouter>
+        <PortfolioBreakdownPage />
+      </MemoryRouter>,
+    );
+
+    const links = screen.getAllByRole('link', { name: /Asset Allocation/i });
+    expect(links.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/components/PortfolioBreakdownPage.test.tsx
+++ b/tests/components/PortfolioBreakdownPage.test.tsx
@@ -104,6 +104,26 @@ describe('PortfolioBreakdownPage', () => {
     expect(screen.getByRole('heading', { name: /By ETF Provider/i })).toBeTruthy();
   });
 
+  it('fetches metadata for tickers that exist on initial render (no async-load race)', async () => {
+    const { fetchAssetMetadataBatch } = await import('../../src/utils/yahooMetadata');
+    render(
+      <MemoryRouter>
+        <PortfolioBreakdownPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchAssetMetadataBatch).toHaveBeenCalled();
+    });
+    // The first (and only) call must include the ticker that was already in
+    // the saved allocation. If the page loads assets asynchronously, the
+    // first call would happen with an empty array and metadata would never
+    // populate.
+    const firstCall = (fetchAssetMetadataBatch as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0];
+    expect(firstCall[0]).toContain('VTI');
+  });
+
   it('shows a back link to Asset Allocation', () => {
     render(
       <MemoryRouter>

--- a/tests/utils/cookieSettings.test.ts
+++ b/tests/utils/cookieSettings.test.ts
@@ -341,4 +341,31 @@ describe('Cookie Settings utilities', () => {
       expect(result.errors).toContain('Date format must be "DD/MM/YYYY", "MM/DD/YYYY", or "YYYY-MM-DD"');
     });
   });
+
+  describe('experimental features', () => {
+    it('defaults portfolioBreakdown to false', () => {
+      expect(DEFAULT_SETTINGS.experimentalFeatures.portfolioBreakdown).toBe(false);
+    });
+
+    it('preserves enabled experimental flags through save/load roundtrip', () => {
+      const updated: UserSettings = {
+        ...DEFAULT_SETTINGS,
+        experimentalFeatures: { portfolioBreakdown: true },
+      };
+      saveSettings(updated);
+      const loaded = loadSettings();
+      expect(loaded.experimentalFeatures.portfolioBreakdown).toBe(true);
+    });
+
+    it('back-fills experimentalFeatures when missing in saved cookie', () => {
+      // Simulate an older cookie that pre-dated the experimentalFeatures field.
+      const legacy = { ...DEFAULT_SETTINGS } as Partial<UserSettings>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (legacy as any).experimentalFeatures;
+      saveSettings(legacy as UserSettings);
+      const loaded = loadSettings();
+      expect(loaded.experimentalFeatures).toBeDefined();
+      expect(loaded.experimentalFeatures.portfolioBreakdown).toBe(false);
+    });
+  });
 });

--- a/tests/utils/countryToRegion.test.ts
+++ b/tests/utils/countryToRegion.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  lookupCountry,
+  getContinent,
+  getRegion,
+  COUNTRY_REGION_TABLE,
+} from '../../src/utils/countryToRegion';
+
+describe('countryToRegion', () => {
+  describe('lookupCountry', () => {
+    it('looks up by ISO code (uppercase)', () => {
+      const info = lookupCountry('US');
+      expect(info?.countryName).toBe('United States');
+      expect(info?.continent).toBe('North America');
+    });
+
+    it('looks up by ISO code (lowercase)', () => {
+      const info = lookupCountry('us');
+      expect(info?.countryName).toBe('United States');
+    });
+
+    it('looks up by full name', () => {
+      const info = lookupCountry('United Kingdom');
+      expect(info?.countryCode).toBe('GB');
+      expect(info?.region).toBe('Western Europe');
+    });
+
+    it('looks up via common alias', () => {
+      expect(lookupCountry('USA')?.countryCode).toBe('US');
+      expect(lookupCountry('UK')?.countryCode).toBe('GB');
+      expect(lookupCountry('Russian Federation')?.countryCode).toBe('RU');
+    });
+
+    it('is case-insensitive on names', () => {
+      const info = lookupCountry('united states');
+      expect(info?.countryCode).toBe('US');
+    });
+
+    it('returns undefined for unknown country', () => {
+      expect(lookupCountry('Atlantis')).toBeUndefined();
+      expect(lookupCountry('')).toBeUndefined();
+      expect(lookupCountry(undefined)).toBeUndefined();
+      expect(lookupCountry(null)).toBeUndefined();
+    });
+  });
+
+  describe('getContinent / getRegion', () => {
+    it('returns continent for known country', () => {
+      expect(getContinent('Germany')).toBe('Europe');
+      expect(getContinent('JP')).toBe('Asia');
+      expect(getContinent('Australia')).toBe('Oceania');
+    });
+
+    it('returns finer-grained region', () => {
+      expect(getRegion('Germany')).toBe('Western Europe');
+      expect(getRegion('Italy')).toBe('Southern Europe');
+      expect(getRegion('Japan')).toBe('East Asia');
+      expect(getRegion('India')).toBe('South Asia');
+    });
+
+    it('returns "Unknown" for unmatched input', () => {
+      expect(getContinent('Atlantis')).toBe('Unknown');
+      expect(getRegion('Atlantis')).toBe('Unknown');
+      expect(getContinent(undefined)).toBe('Unknown');
+    });
+  });
+
+  it('table covers the major economies a portfolio is likely to reference', () => {
+    const codes = COUNTRY_REGION_TABLE.map(c => c.countryCode);
+    for (const required of ['US', 'GB', 'DE', 'JP', 'CA', 'AU', 'CH', 'FR', 'IT', 'IE', 'LU', 'CN', 'IN']) {
+      expect(codes).toContain(required);
+    }
+  });
+});

--- a/tests/utils/etfHeuristics.test.ts
+++ b/tests/utils/etfHeuristics.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { inferEtfInfo, isinToCountryCode } from '../../src/utils/etfHeuristics';
+
+describe('etfHeuristics', () => {
+  describe('isinToCountryCode', () => {
+    it('returns first two letters of valid ISIN as uppercase', () => {
+      expect(isinToCountryCode('US0378331005')).toBe('US');
+      expect(isinToCountryCode('IE00BK5BQT80')).toBe('IE');
+      expect(isinToCountryCode('de0007164600')).toBe('DE');
+    });
+
+    it('returns undefined for non-ISIN-shaped input', () => {
+      expect(isinToCountryCode('')).toBeUndefined();
+      expect(isinToCountryCode(undefined)).toBeUndefined();
+      expect(isinToCountryCode('A')).toBeUndefined();
+      expect(isinToCountryCode('12FOO')).toBeUndefined();
+    });
+  });
+
+  describe('inferEtfInfo', () => {
+    it('infers provider from longname', () => {
+      expect(inferEtfInfo('Vanguard FTSE All-World UCITS ETF').provider).toBe('Vanguard');
+      expect(inferEtfInfo('iShares Core MSCI World UCITS ETF').provider).toBe('iShares');
+      expect(inferEtfInfo('SPDR S&P 500 ETF Trust').provider).toBe('SPDR');
+      expect(inferEtfInfo('Xtrackers MSCI Emerging Markets').provider).toBe('Xtrackers');
+      expect(inferEtfInfo('Amundi Prime All Country World').provider).toBe('Amundi');
+      expect(inferEtfInfo('Invesco QQQ Trust').provider).toBe('Invesco');
+    });
+
+    it('infers global region from "All-World" / "World" names', () => {
+      expect(inferEtfInfo('Vanguard FTSE All-World UCITS ETF').regionTheme).toBe('Global');
+      expect(inferEtfInfo('iShares MSCI World').regionTheme).toBe('Global');
+      expect(inferEtfInfo('SPDR ACWI ETF').regionTheme).toBe('Global');
+    });
+
+    it('infers United States from S&P 500 / Nasdaq / US names', () => {
+      expect(inferEtfInfo('SPDR S&P 500 ETF').regionTheme).toBe('United States');
+      expect(inferEtfInfo('Invesco QQQ NASDAQ-100').regionTheme).toBe('United States');
+      expect(inferEtfInfo('iShares Russell 2000 ETF').regionTheme).toBe('United States');
+    });
+
+    it('infers Emerging Markets from EM names', () => {
+      expect(inferEtfInfo('iShares Core MSCI Emerging Markets').regionTheme).toBe('Emerging Markets');
+      expect(inferEtfInfo('Xtrackers MSCI EM Asia').regionTheme).toBe('Emerging Markets');
+    });
+
+    it('infers Europe from Stoxx / DAX / FTSE 100 etc.', () => {
+      expect(inferEtfInfo('Lyxor Euro Stoxx 50 UCITS ETF').regionTheme).toBe('Europe');
+      expect(inferEtfInfo('iShares Core DAX UCITS').regionTheme).toBe('Europe');
+      expect(inferEtfInfo('Vanguard FTSE 100').regionTheme).toBe('Europe');
+    });
+
+    it('infers Japan / China / India', () => {
+      expect(inferEtfInfo('iShares Core Nikkei 225').regionTheme).toBe('Japan');
+      expect(inferEtfInfo('iShares MSCI China').regionTheme).toBe('China');
+      expect(inferEtfInfo('iShares MSCI India').regionTheme).toBe('India');
+    });
+
+    it('detects bond focus for fixed income ETFs', () => {
+      const info = inferEtfInfo('iShares Euro Govt Bond 7-10 yr UCITS ETF');
+      expect(info.assetFocus).toBe('Bond');
+      expect(info.sectorTheme).toBe('Government Bonds');
+    });
+
+    it('detects gold and other commodities', () => {
+      expect(inferEtfInfo('iShares Physical Gold ETC').sectorTheme).toBe('Gold');
+      expect(inferEtfInfo('WisdomTree Silver').sectorTheme).toBe('Silver');
+    });
+
+    it('detects REIT / real estate focus', () => {
+      const info = inferEtfInfo('Vanguard Global REIT UCITS ETF');
+      expect(info.assetFocus).toBe('Real Estate');
+      expect(info.sectorTheme).toBe('Real Estate');
+    });
+
+    it('detects sector-themed equity ETFs', () => {
+      expect(inferEtfInfo('iShares S&P 500 Information Technology').sectorTheme).toBe('Technology');
+      expect(inferEtfInfo('Vanguard Health Care ETF').sectorTheme).toBe('Healthcare');
+      expect(inferEtfInfo('Financial Select Sector SPDR Fund').sectorTheme).toBe('Financial Services');
+    });
+
+    it('falls back to "<Region> Equity" sectorTheme when only a region is matched', () => {
+      const info = inferEtfInfo('Vanguard FTSE All-World UCITS ETF');
+      expect(info.sectorTheme).toBe('Global Equity');
+      expect(info.assetFocus).toBe('Equity');
+    });
+
+    it('returns empty object when no patterns match', () => {
+      const info = inferEtfInfo('Unknown Random Holding Inc.');
+      expect(info.provider).toBeUndefined();
+      expect(info.regionTheme).toBeUndefined();
+      expect(info.sectorTheme).toBeUndefined();
+    });
+
+    it('handles undefined/empty input', () => {
+      expect(inferEtfInfo(undefined)).toEqual({});
+      expect(inferEtfInfo('')).toEqual({});
+    });
+  });
+});

--- a/tests/utils/portfolioBreakdownCalculator.test.ts
+++ b/tests/utils/portfolioBreakdownCalculator.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeBreakdown,
+  computeAllBreakdowns,
+  uniqueTickers,
+  selectActiveAssets,
+  activePortfolioValue,
+} from '../../src/utils/portfolioBreakdownCalculator';
+import { Asset } from '../../src/types/assetAllocation';
+import { AssetMetadata } from '../../src/types/portfolioBreakdown';
+
+function makeAsset(overrides: Partial<Asset>): Asset {
+  return {
+    id: 'a-' + Math.random().toString(36).slice(2),
+    name: 'Test Asset',
+    ticker: 'TEST',
+    assetClass: 'STOCKS',
+    subAssetType: 'ETF',
+    currentValue: 1000,
+    targetMode: 'PERCENTAGE',
+    targetPercent: 100,
+    ...overrides,
+  };
+}
+
+function makeMeta(overrides: Partial<AssetMetadata> & { ticker: string }): AssetMetadata {
+  return {
+    fetchedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('portfolioBreakdownCalculator', () => {
+  describe('selectActiveAssets / activePortfolioValue', () => {
+    it('excludes OFF and zero-value assets', () => {
+      const assets = [
+        makeAsset({ id: '1', currentValue: 1000 }),
+        makeAsset({ id: '2', currentValue: 0 }),
+        makeAsset({ id: '3', currentValue: 500, targetMode: 'OFF' }),
+        makeAsset({ id: '4', currentValue: 2000 }),
+      ];
+      expect(selectActiveAssets(assets)).toHaveLength(2);
+      expect(activePortfolioValue(assets)).toBe(3000);
+    });
+  });
+
+  describe('uniqueTickers', () => {
+    it('returns deduplicated uppercase tickers, ignoring empty', () => {
+      const assets = [
+        makeAsset({ id: '1', ticker: 'vti' }),
+        makeAsset({ id: '2', ticker: 'VTI' }),
+        makeAsset({ id: '3', ticker: '' }),
+        makeAsset({ id: '4', ticker: 'spy', currentValue: 500 }),
+      ];
+      expect(uniqueTickers(assets).sort()).toEqual(['SPY', 'VTI']);
+    });
+  });
+
+  describe('byCurrency', () => {
+    it('groups by originalCurrency, defaulting to EUR', () => {
+      const assets = [
+        makeAsset({ id: '1', currentValue: 1000, originalCurrency: 'USD' }),
+        makeAsset({ id: '2', currentValue: 2000, originalCurrency: 'USD' }),
+        makeAsset({ id: '3', currentValue: 1500, originalCurrency: 'EUR' }),
+        makeAsset({ id: '4', currentValue: 500 }), // missing -> EUR
+      ];
+      const result = computeBreakdown({ assets, metadataByTicker: {}, dimension: 'currency' });
+      const usd = result.entries.find(e => e.label === 'USD');
+      const eur = result.entries.find(e => e.label === 'EUR');
+      expect(usd?.value).toBe(3000);
+      expect(eur?.value).toBe(2000);
+      expect(result.totalValue).toBe(5000);
+    });
+  });
+
+  describe('byHolding', () => {
+    it('one entry per asset, sorted by value desc', () => {
+      const assets = [
+        makeAsset({ id: '1', name: 'Vanguard S&P 500', currentValue: 5000 }),
+        makeAsset({ id: '2', name: 'Apple', currentValue: 1000 }),
+        makeAsset({ id: '3', name: 'Tesla', currentValue: 3000 }),
+      ];
+      const result = computeBreakdown({ assets, metadataByTicker: {}, dimension: 'holding' });
+      expect(result.entries.map(e => e.label)).toEqual(['Vanguard S&P 500', 'Tesla', 'Apple']);
+    });
+  });
+
+  describe('bySector', () => {
+    it('expands ETF sector weightings proportionally to asset value', () => {
+      const assets = [
+        makeAsset({ id: '1', ticker: 'VTI', currentValue: 1000 }),
+      ];
+      const metadata: Record<string, AssetMetadata> = {
+        VTI: makeMeta({
+          ticker: 'VTI',
+          sectorWeightings: [
+            { sector: 'Technology', weight: 0.3 },
+            { sector: 'Healthcare', weight: 0.2 },
+            { sector: 'Financial Services', weight: 0.5 },
+          ],
+        }),
+      };
+      const result = computeBreakdown({ assets, metadataByTicker: metadata, dimension: 'sector' });
+      const tech = result.entries.find(e => e.label === 'Technology');
+      const fin = result.entries.find(e => e.label === 'Financial Services');
+      expect(tech?.value).toBeCloseTo(300);
+      expect(fin?.value).toBeCloseTo(500);
+      // Total should equal the source asset value
+      expect(result.entries.reduce((s, e) => s + e.value, 0)).toBeCloseTo(1000);
+    });
+
+    it('uses stock sector when no sectorWeightings available', () => {
+      const assets = [makeAsset({ id: '1', ticker: 'AAPL', currentValue: 500 })];
+      const metadata = {
+        AAPL: makeMeta({ ticker: 'AAPL', sector: 'Technology' }),
+      };
+      const result = computeBreakdown({ assets, metadataByTicker: metadata, dimension: 'sector' });
+      expect(result.entries[0].label).toBe('Technology');
+      expect(result.entries[0].value).toBe(500);
+    });
+
+    it('falls back to asset class label for non-ticker assets', () => {
+      const assets = [
+        makeAsset({
+          id: '1',
+          ticker: '',
+          name: 'Apartment',
+          assetClass: 'REAL_ESTATE',
+          subAssetType: 'PROPERTY',
+          currentValue: 250_000,
+        }),
+        makeAsset({
+          id: '2',
+          ticker: '',
+          name: 'Checking',
+          assetClass: 'CASH',
+          subAssetType: 'CHECKING_ACCOUNT',
+          currentValue: 5_000,
+        }),
+      ];
+      const result = computeBreakdown({ assets, metadataByTicker: {}, dimension: 'sector' });
+      const labels = result.entries.map(e => e.label).sort();
+      expect(labels).toContain('Cash');
+      expect(labels).toContain('Real Estate');
+    });
+  });
+
+  describe('byContinent / byRegion', () => {
+    it('derives continent from metadata.country', () => {
+      const assets = [
+        makeAsset({ id: '1', ticker: 'AAPL', currentValue: 1000 }),
+        makeAsset({ id: '2', ticker: 'TSM', currentValue: 500 }),
+        makeAsset({ id: '3', ticker: 'SAP.DE', currentValue: 2000 }),
+      ];
+      const metadata: Record<string, AssetMetadata> = {
+        AAPL: makeMeta({ ticker: 'AAPL', country: 'United States' }),
+        TSM: makeMeta({ ticker: 'TSM', country: 'Taiwan' }),
+        'SAP.DE': makeMeta({ ticker: 'SAP.DE', country: 'Germany' }),
+      };
+      const continent = computeBreakdown({ assets, metadataByTicker: metadata, dimension: 'continent' });
+      const continentLabels = continent.entries.map(e => e.label).sort();
+      expect(continentLabels).toEqual(['Asia', 'Europe', 'North America']);
+
+      const region = computeBreakdown({ assets, metadataByTicker: metadata, dimension: 'region' });
+      const regionLabels = region.entries.map(e => e.label).sort();
+      expect(regionLabels).toEqual(['East Asia', 'North America', 'Western Europe']);
+    });
+
+    it('falls back to asset class label when country unknown', () => {
+      const assets = [makeAsset({ id: '1', ticker: 'XYZ', currentValue: 1000 })];
+      const metadata = { XYZ: makeMeta({ ticker: 'XYZ' }) };
+      const result = computeBreakdown({ assets, metadataByTicker: metadata, dimension: 'continent' });
+      expect(result.entries[0].label).toBe('Stocks');
+    });
+  });
+
+  describe('byMarket', () => {
+    it('groups by exchange name', () => {
+      const assets = [
+        makeAsset({ id: '1', ticker: 'AAPL', currentValue: 1000 }),
+        makeAsset({ id: '2', ticker: 'MSFT', currentValue: 500 }),
+        makeAsset({ id: '3', ticker: 'VOD.L', currentValue: 800 }),
+      ];
+      const metadata = {
+        AAPL: makeMeta({ ticker: 'AAPL', exchange: 'NASDAQ' }),
+        MSFT: makeMeta({ ticker: 'MSFT', exchange: 'NASDAQ' }),
+        'VOD.L': makeMeta({ ticker: 'VOD.L', exchange: 'LSE' }),
+      };
+      const result = computeBreakdown({ assets, metadataByTicker: metadata, dimension: 'market' });
+      const nasdaq = result.entries.find(e => e.label === 'NASDAQ');
+      expect(nasdaq?.value).toBe(1500);
+    });
+  });
+
+  describe('byEtfProvider', () => {
+    it('groups by fundFamily, labels stocks as Direct holding', () => {
+      const assets = [
+        makeAsset({ id: '1', ticker: 'VTI', currentValue: 1000 }),
+        makeAsset({ id: '2', ticker: 'VOO', currentValue: 500 }),
+        makeAsset({ id: '3', ticker: 'IVV', currentValue: 700 }),
+        makeAsset({ id: '4', ticker: 'AAPL', currentValue: 300 }),
+      ];
+      const metadata: Record<string, AssetMetadata> = {
+        VTI: makeMeta({ ticker: 'VTI', fundFamily: 'Vanguard', quoteType: 'ETF' }),
+        VOO: makeMeta({ ticker: 'VOO', fundFamily: 'Vanguard', quoteType: 'ETF' }),
+        IVV: makeMeta({ ticker: 'IVV', fundFamily: 'iShares', quoteType: 'ETF' }),
+        AAPL: makeMeta({ ticker: 'AAPL', quoteType: 'EQUITY' }),
+      };
+      const result = computeBreakdown({ assets, metadataByTicker: metadata, dimension: 'etfProvider' });
+      const vanguard = result.entries.find(e => e.label === 'Vanguard');
+      const ishares = result.entries.find(e => e.label === 'iShares');
+      const direct = result.entries.find(e => e.label === 'Direct holding');
+      expect(vanguard?.value).toBe(1500);
+      expect(ishares?.value).toBe(700);
+      expect(direct?.value).toBe(300);
+    });
+  });
+
+  describe('computeAllBreakdowns', () => {
+    it('produces a result for every dimension', () => {
+      const assets = [makeAsset({ id: '1', ticker: 'AAPL', currentValue: 1000 })];
+      const metadata = { AAPL: makeMeta({ ticker: 'AAPL', sector: 'Technology', country: 'United States', exchange: 'NASDAQ' }) };
+      const all = computeAllBreakdowns(assets, metadata);
+      expect(Object.keys(all).sort()).toEqual([
+        'continent',
+        'currency',
+        'etfProvider',
+        'holding',
+        'market',
+        'region',
+        'sector',
+      ]);
+    });
+
+    it('handles empty portfolio gracefully', () => {
+      const all = computeAllBreakdowns([], {});
+      for (const result of Object.values(all)) {
+        expect(result.entries).toHaveLength(0);
+        expect(result.totalValue).toBe(0);
+      }
+    });
+  });
+
+  describe('color stability', () => {
+    it('reuses asset-class palette for etfProvider when label matches an asset class', () => {
+      const assets = [
+        makeAsset({
+          id: '1',
+          ticker: '',
+          name: 'Apartment',
+          assetClass: 'REAL_ESTATE',
+          subAssetType: 'PROPERTY',
+          currentValue: 100_000,
+        }),
+      ];
+      const result = computeBreakdown({ assets, metadataByTicker: {}, dimension: 'etfProvider' });
+      // 'Real Estate' bucket should use the canonical REAL_ESTATE palette color
+      expect(result.entries[0].label).toBe('Real Estate');
+      expect(result.entries[0].color).toBe('#9C27B0');
+    });
+  });
+});

--- a/tests/utils/yahooMetadata.test.ts
+++ b/tests/utils/yahooMetadata.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock yahooProxy BEFORE importing the module under test so the mock is
-// used during evaluation.
 vi.mock('../../src/utils/yahooProxy', () => {
   return {
     yahooFetch: vi.fn(),
@@ -19,7 +17,6 @@ import {
   fetchAssetMetadata,
   fetchAssetMetadataBatch,
   clearAssetMetadataCache,
-  _internal,
 } from '../../src/utils/yahooMetadata';
 import { yahooFetch, hasRateLimitCapacity } from '../../src/utils/yahooProxy';
 
@@ -33,92 +30,134 @@ describe('yahooMetadata', () => {
     clearAssetMetadataCache();
   });
 
-  describe('parseSectorWeightings', () => {
-    it('normalizes Yahoo sector keys', () => {
-      expect(_internal.normalizeSectorName('realestate')).toBe('Real Estate');
-      expect(_internal.normalizeSectorName('consumer_cyclical')).toBe('Consumer Cyclical');
-      expect(_internal.normalizeSectorName('technology')).toBe('Technology');
-    });
-
-    it('parses the array-of-objects shape with raw values', () => {
-      const result = _internal.parseSectorWeightings({
-        quoteSummary: {
-          result: [
-            {
-              topHoldings: {
-                sectorWeightings: [
-                  { technology: { raw: 0.3 } },
-                  { healthcare: { raw: 0.2 } },
-                  { financial_services: { raw: 0.5 } },
-                ],
-              },
-            },
-          ],
-        },
-      });
-      expect(result).toHaveLength(3);
-      expect(result?.find(s => s.sector === 'Technology')?.weight).toBeCloseTo(0.3);
-    });
-
-    it('returns undefined when no weightings are present', () => {
-      expect(_internal.parseSectorWeightings({})).toBeUndefined();
-    });
-  });
-
-  describe('fetchAssetMetadata', () => {
-    it('returns parsed metadata on success and caches it', async () => {
+  describe('fetchAssetMetadata (search endpoint)', () => {
+    it('parses sector / industry / exchange / longName for an EQUITY', async () => {
       mockedFetch.mockResolvedValueOnce({
-        quoteSummary: {
-          result: [
-            {
-              summaryProfile: {
-                sector: 'Technology',
-                industry: 'Consumer Electronics',
-                country: 'United States',
-              },
-              fundProfile: { family: 'Apple Inc' },
-              topHoldings: { sectorWeightings: [] },
-              quoteType: {
-                quoteType: 'EQUITY',
-                longName: 'Apple Inc.',
-                exchange: 'NMS',
-                currency: 'USD',
-              },
-            },
-          ],
-        },
+        quotes: [
+          {
+            symbol: 'AAPL',
+            shortname: 'Apple Inc.',
+            longname: 'Apple Inc.',
+            quoteType: 'EQUITY',
+            exchange: 'NMS',
+            exchDisp: 'NASDAQ',
+            sector: 'Technology',
+            sectorDisp: 'Technology',
+            industry: 'Consumer Electronics',
+            industryDisp: 'Consumer Electronics',
+          },
+        ],
       });
 
       const meta = await fetchAssetMetadata('AAPL');
       expect(meta.error).toBeUndefined();
       expect(meta.ticker).toBe('AAPL');
+      expect(meta.quoteType).toBe('EQUITY');
       expect(meta.sector).toBe('Technology');
-      expect(meta.country).toBe('United States');
-      expect(meta.exchange).toBe('NMS');
-      expect(meta.fundFamily).toBe('Apple Inc');
+      expect(meta.industry).toBe('Consumer Electronics');
+      expect(meta.exchange).toBe('NASDAQ');
+      expect(meta.longName).toBe('Apple Inc.');
+      expect(meta.country).toBeUndefined();
+    });
 
-      // Second call should hit the cache and not call yahooFetch again
-      const meta2 = await fetchAssetMetadata('aapl');
-      expect(meta2.sector).toBe('Technology');
+    it('derives country code from ISIN for stocks', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quotes: [
+          {
+            symbol: 'AAPL',
+            quoteType: 'EQUITY',
+            sector: 'Technology',
+            exchDisp: 'NASDAQ',
+          },
+        ],
+      });
+
+      const meta = await fetchAssetMetadata('AAPL', { isin: 'US0378331005' });
+      expect(meta.country).toBe('US');
+    });
+
+    it('applies ETF heuristics for an ETF', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quotes: [
+          {
+            symbol: 'VWCE.DE',
+            shortname: 'Vanguard FTSE All-World U.ETF R',
+            longname: 'Vanguard FTSE All-World UCITS ETF USD Accumulation',
+            quoteType: 'ETF',
+            exchange: 'GER',
+            exchDisp: 'XETRA',
+          },
+        ],
+      });
+
+      const meta = await fetchAssetMetadata('VWCE.DE');
+      expect(meta.quoteType).toBe('ETF');
+      expect(meta.fundFamily).toBe('Vanguard');
+      expect(meta.exchange).toBe('XETRA');
+      expect(meta.country).toBe('Global');
+      expect(meta.sector).toBe('Global Equity');
+      expect(meta.regionWeightings?.[0]).toEqual({ region: 'Global', weight: 1 });
+    });
+
+    it('caches successful results and reuses on second call', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quotes: [
+          {
+            symbol: 'AAPL',
+            quoteType: 'EQUITY',
+            sector: 'Technology',
+            exchDisp: 'NASDAQ',
+          },
+        ],
+      });
+
+      const first = await fetchAssetMetadata('AAPL');
+      const second = await fetchAssetMetadata('aapl');
+      expect(first.sector).toBe('Technology');
+      expect(second.sector).toBe('Technology');
       expect(mockedFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('returns an error object when rate limited', async () => {
+    it('layers ISIN-derived country onto cached entries that lacked one', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quotes: [
+          { symbol: 'AAPL', quoteType: 'EQUITY', sector: 'Technology' },
+        ],
+      });
+
+      const first = await fetchAssetMetadata('AAPL');
+      expect(first.country).toBeUndefined();
+
+      const second = await fetchAssetMetadata('AAPL', { isin: 'US0378331005' });
+      expect(second.country).toBe('US');
+      expect(mockedFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefers exact-symbol match in quotes array', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quotes: [
+          { symbol: 'AAPL.MX', quoteType: 'EQUITY', sector: 'Wrong' },
+          { symbol: 'AAPL', quoteType: 'EQUITY', sector: 'Technology' },
+        ],
+      });
+      const meta = await fetchAssetMetadata('AAPL');
+      expect(meta.sector).toBe('Technology');
+    });
+
+    it('returns an error when no quotes returned', async () => {
+      mockedFetch.mockResolvedValueOnce({ quotes: [] });
+      const meta = await fetchAssetMetadata('ZZZZ');
+      expect(meta.error).toMatch(/No data/i);
+    });
+
+    it('returns an error when rate limited', async () => {
       mockedCapacity.mockReturnValue(false);
       const meta = await fetchAssetMetadata('AAPL');
       expect(meta.error).toMatch(/rate limit/i);
       expect(mockedFetch).not.toHaveBeenCalled();
     });
 
-    it('returns an error object when Yahoo returns an error description', async () => {
-      mockedFetch.mockResolvedValueOnce({
-        quoteSummary: { error: { description: 'Quote not found' } },
-      });
-      const meta = await fetchAssetMetadata('NOPE');
-      expect(meta.error).toMatch(/Quote not found/);
-    });
-
-    it('returns an error object when fetch throws', async () => {
+    it('returns an error when fetch throws', async () => {
       mockedFetch.mockRejectedValueOnce(new Error('network kaboom'));
       const meta = await fetchAssetMetadata('AAPL');
       expect(meta.error).toBe('network kaboom');
@@ -132,21 +171,27 @@ describe('yahooMetadata', () => {
   });
 
   describe('fetchAssetMetadataBatch', () => {
-    it('fetches unique tickers and returns a keyed map', async () => {
+    it('passes per-ticker ISIN through for country derivation', async () => {
       mockedFetch.mockResolvedValue({
-        quoteSummary: {
-          result: [
-            {
-              summaryProfile: { sector: 'Technology' },
-              quoteType: { quoteType: 'EQUITY' },
-            },
-          ],
-        },
+        quotes: [
+          { symbol: 'AAPL', quoteType: 'EQUITY', sector: 'Technology' },
+        ],
       });
-
-      const out = await fetchAssetMetadataBatch(['aapl', 'AAPL', '', 'msft']);
-      expect(Object.keys(out).sort()).toEqual(['AAPL', 'MSFT']);
+      const out = await fetchAssetMetadataBatch(
+        ['AAPL', 'MSFT'],
+        { AAPL: 'US0378331005', MSFT: 'US5949181045' },
+      );
+      expect(out.AAPL.country).toBe('US');
+      expect(out.MSFT.country).toBe('US');
       expect(mockedFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates tickers', async () => {
+      mockedFetch.mockResolvedValue({
+        quotes: [{ symbol: 'AAPL', quoteType: 'EQUITY', sector: 'Technology' }],
+      });
+      const out = await fetchAssetMetadataBatch(['aapl', 'AAPL', '']);
+      expect(Object.keys(out)).toEqual(['AAPL']);
     });
   });
 });

--- a/tests/utils/yahooMetadata.test.ts
+++ b/tests/utils/yahooMetadata.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock yahooProxy BEFORE importing the module under test so the mock is
+// used during evaluation.
+vi.mock('../../src/utils/yahooProxy', () => {
+  return {
+    yahooFetch: vi.fn(),
+    hasRateLimitCapacity: vi.fn(() => true),
+    YahooRateLimitError: class extends Error {
+      constructor(msg: string) {
+        super(msg);
+        this.name = 'YahooRateLimitError';
+      }
+    },
+  };
+});
+
+import {
+  fetchAssetMetadata,
+  fetchAssetMetadataBatch,
+  clearAssetMetadataCache,
+  _internal,
+} from '../../src/utils/yahooMetadata';
+import { yahooFetch, hasRateLimitCapacity } from '../../src/utils/yahooProxy';
+
+const mockedFetch = vi.mocked(yahooFetch);
+const mockedCapacity = vi.mocked(hasRateLimitCapacity);
+
+describe('yahooMetadata', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedCapacity.mockReturnValue(true);
+    clearAssetMetadataCache();
+  });
+
+  describe('parseSectorWeightings', () => {
+    it('normalizes Yahoo sector keys', () => {
+      expect(_internal.normalizeSectorName('realestate')).toBe('Real Estate');
+      expect(_internal.normalizeSectorName('consumer_cyclical')).toBe('Consumer Cyclical');
+      expect(_internal.normalizeSectorName('technology')).toBe('Technology');
+    });
+
+    it('parses the array-of-objects shape with raw values', () => {
+      const result = _internal.parseSectorWeightings({
+        quoteSummary: {
+          result: [
+            {
+              topHoldings: {
+                sectorWeightings: [
+                  { technology: { raw: 0.3 } },
+                  { healthcare: { raw: 0.2 } },
+                  { financial_services: { raw: 0.5 } },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      expect(result).toHaveLength(3);
+      expect(result?.find(s => s.sector === 'Technology')?.weight).toBeCloseTo(0.3);
+    });
+
+    it('returns undefined when no weightings are present', () => {
+      expect(_internal.parseSectorWeightings({})).toBeUndefined();
+    });
+  });
+
+  describe('fetchAssetMetadata', () => {
+    it('returns parsed metadata on success and caches it', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quoteSummary: {
+          result: [
+            {
+              summaryProfile: {
+                sector: 'Technology',
+                industry: 'Consumer Electronics',
+                country: 'United States',
+              },
+              fundProfile: { family: 'Apple Inc' },
+              topHoldings: { sectorWeightings: [] },
+              quoteType: {
+                quoteType: 'EQUITY',
+                longName: 'Apple Inc.',
+                exchange: 'NMS',
+                currency: 'USD',
+              },
+            },
+          ],
+        },
+      });
+
+      const meta = await fetchAssetMetadata('AAPL');
+      expect(meta.error).toBeUndefined();
+      expect(meta.ticker).toBe('AAPL');
+      expect(meta.sector).toBe('Technology');
+      expect(meta.country).toBe('United States');
+      expect(meta.exchange).toBe('NMS');
+      expect(meta.fundFamily).toBe('Apple Inc');
+
+      // Second call should hit the cache and not call yahooFetch again
+      const meta2 = await fetchAssetMetadata('aapl');
+      expect(meta2.sector).toBe('Technology');
+      expect(mockedFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an error object when rate limited', async () => {
+      mockedCapacity.mockReturnValue(false);
+      const meta = await fetchAssetMetadata('AAPL');
+      expect(meta.error).toMatch(/rate limit/i);
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns an error object when Yahoo returns an error description', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quoteSummary: { error: { description: 'Quote not found' } },
+      });
+      const meta = await fetchAssetMetadata('NOPE');
+      expect(meta.error).toMatch(/Quote not found/);
+    });
+
+    it('returns an error object when fetch throws', async () => {
+      mockedFetch.mockRejectedValueOnce(new Error('network kaboom'));
+      const meta = await fetchAssetMetadata('AAPL');
+      expect(meta.error).toBe('network kaboom');
+    });
+
+    it('handles empty ticker without calling fetch', async () => {
+      const meta = await fetchAssetMetadata('   ');
+      expect(meta.error).toBe('Empty ticker');
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchAssetMetadataBatch', () => {
+    it('fetches unique tickers and returns a keyed map', async () => {
+      mockedFetch.mockResolvedValue({
+        quoteSummary: {
+          result: [
+            {
+              summaryProfile: { sector: 'Technology' },
+              quoteType: { quoteType: 'EQUITY' },
+            },
+          ],
+        },
+      });
+
+      const out = await fetchAssetMetadataBatch(['aapl', 'AAPL', '', 'msft']);
+      expect(Object.keys(out).sort()).toEqual(['AAPL', 'MSFT']);
+      expect(mockedFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
Closes #206

## Summary

Adds a new `/portfolio-breakdown` page that slices the **current** portfolio across multiple dimensions, addressing the lack of visibility beyond asset class.

### Dimensions
- **Currency** — from `asset.originalCurrency`
- **Holding** — per-asset
- **Sector** — ETFs use weighted Yahoo `topHoldings.sectorWeightings`; individual stocks use `summaryProfile.sector`
- **Continent / Region** — derived from `summaryProfile.country` via an ISO/name → region map
- **Market** — `quoteType.exchange` (NASDAQ, LSE, Xetra…)
- **ETF Provider** — `fundProfile.family` (Vanguard, iShares…). Stocks group under *Direct holding*

Non-ticker assets (real estate, cash, vehicles, collectibles, art) bucket by their asset-class label in dimensions where they can't be classified.

### Architecture
- Metadata fetched via Yahoo Finance `quoteSummary` through the existing rate-limited `yahooFetch` proxy
- Cached in `localStorage` for 7 days (`fire-tools:asset-metadata:` prefix)
- Page is reached from the main nav and from a button on the Asset Allocation page's Graphs section

### Files
**New**
- `src/types/portfolioBreakdown.ts`
- `src/utils/yahooMetadata.ts`
- `src/utils/countryToRegion.ts`
- `src/utils/portfolioBreakdownCalculator.ts`
- `src/hooks/useAssetMetadata.ts`
- `src/components/PortfolioBreakdownPage.tsx` (+ CSS)
- `src/components/BreakdownChart.tsx`

**Modified**
- `src/App.tsx` (route + nav link)
- `src/components/AssetAllocationPage.tsx` (link to new page)
- `src/components/AssetAllocationManager.css` (link styling)
- `README.md` (feature entry)

### Tests
- `tests/utils/countryToRegion.test.ts` (10)
- `tests/utils/yahooMetadata.test.ts` (9 — mocked Yahoo)
- `tests/utils/portfolioBreakdownCalculator.test.ts` (14 — all dimensions, ETF expansion, fallbacks)
- `tests/components/PortfolioBreakdownPage.test.tsx` (3 — render smoke tests)

All 962 tests pass, `npm run build` succeeds.

### Out of scope
- Editing allocations from this page
- Historical breakdown over time
- Manual sector/region overrides per asset (potential follow-up)