### PR TITLE
feat: experimental PDF expense/income import (#207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Track your portfolio allocation across stocks, bonds, real estate, commodities, 
 **🍩 Portfolio Breakdown** *(experimental — disabled by default)*  
 Slice your current portfolio across multiple dimensions — currency, holding, sector, continent, region, market (exchange), and ETF provider — to spot concentration risk and diversification gaps. Stock sector and exchange come from Yahoo Finance's anonymous search endpoint; stock country is derived from the ISIN prefix. For ETFs (where Yahoo's holdings endpoint requires authentication), the provider, region theme, and asset focus are inferred from the fund's name. Metadata is cached locally for 7 days to minimise API calls. Enable it under **Settings → Experimental Features**.
 
+**📄 PDF Expense / Income Import** *(experimental — disabled by default)*  
+Upload receipts, invoices, bank / credit-card statements, or payslips and the Expense Tracker turns them into editable transactions before they're committed. PDFs are parsed **fully in your browser** with `pdfjs-dist` — nothing is uploaded anywhere. An **optional**, opt-in OpenAI-compatible LLM step (OpenAI, Azure OpenAI, Ollama, LM Studio, OpenRouter, …) can re-categorize the parsed rows; only the extracted descriptions/amounts are sent, never the PDF bytes, and the heuristic results are used on any error. Enable under **Settings → Experimental Features**. Full details in [`docs/pdf-import.md`](docs/pdf-import.md).
+
 **💵 DCA Helper**  
 Plan your dollar-cost averaging strategy with built-in calculations that help you invest systematically and reduce market timing risk.
 

--- a/docs/pdf-import.md
+++ b/docs/pdf-import.md
@@ -1,0 +1,68 @@
+# PDF Expense / Income Import (Experimental)
+
+The Expense Tracker can read **receipts**, **invoices**, **bank / credit-card statements**, and **payslips** straight from PDF files and turn them into transactions.
+
+This feature is **experimental** and **off by default**. Enable it under **Settings → Experimental Features → PDF expense/income import**.
+
+## How it works
+
+1. You pick one or more PDF files in the *Import PDF* dialog.
+2. The PDF is parsed **in your browser** using [`pdfjs-dist`](https://github.com/mozilla/pdf.js). Nothing is uploaded anywhere.
+3. Heuristic parsers extract transactions:
+   - **Receipt** — single expense with the line marked *Total / Totale / Importo totale / …*
+   - **Invoice** — single expense with the *Grand total / Importo totale*
+   - **Payslip** — single income with the *Net pay / Importo netto / Stipendio netto / …*
+   - **Bank statement** — every line that starts with a date and has an amount becomes a transaction. Negative amounts (or "debit"-style keywords) become expenses; positive amounts (or "credit / stipendio / bonifico in entrata" keywords) become income.
+4. Detected transactions land in an **editable review table**. You can:
+   - Toggle each row on/off.
+   - Change the kind (income ↔ expense).
+   - Edit the date, description, amount, category, expense type (need/want) or income source.
+5. Confirm to push the included rows into the current Expense Tracker.
+
+The doc-type dropdown lets you override the auto-detected parser if it picks the wrong one.
+
+## Optional AI categorization
+
+If a heuristic category is wrong (e.g. an obscure merchant), an **optional** LLM step can re-categorize the rows.
+
+- You provide an **OpenAI-compatible** `/chat/completions` endpoint, an API key, and a model name in *Settings → Experimental Features*.
+- Works with **OpenAI**, **Azure OpenAI**, **Ollama** (`http://localhost:11434/v1`), **LM Studio**, **OpenRouter**, **Together**, etc.
+- It only runs when you tick **Use AI categorization** inside the import dialog for that import.
+- Only the parsed transaction descriptions, kinds, amounts, and currencies are sent — never the raw PDF bytes.
+- If the request fails, times out, or returns invalid JSON, the heuristic results are used unchanged.
+
+### Example endpoints
+
+| Provider     | Base URL                                  | Model example     |
+| ------------ | ----------------------------------------- | ----------------- |
+| OpenAI       | `https://api.openai.com/v1`               | `gpt-4o-mini`     |
+| Azure OpenAI | `https://<resource>.openai.azure.com/openai/deployments/<deployment>` (append `?api-version=…` as needed) | your deployment id |
+| Ollama       | `http://localhost:11434/v1`               | `llama3.1:8b`     |
+| LM Studio    | `http://localhost:1234/v1`                | local model id    |
+| OpenRouter   | `https://openrouter.ai/api/v1`            | `openai/gpt-4o-mini` |
+
+## Privacy
+
+- **No PDF bytes ever leave your device.** Parsing happens fully in the browser.
+- **No network calls at all** unless you (a) configure the LLM endpoint **and** (b) tick *Use AI categorization* for an import.
+- The API key is stored encrypted with the rest of your settings (AES-256 in a cookie scoped to your browser).
+- You can clear everything via *Settings → Data Management → Reset All Data*.
+
+## Limitations
+
+Heuristic parsing is intentionally conservative and will never be 100% accurate. Expect to:
+
+- Hand-fix rows highlighted as **low confidence** (light-orange background).
+- Override the doc-type dropdown for unusual layouts.
+- Edit categories for niche merchants, or use the optional LLM step.
+
+Scanned PDFs (image-only, no text layer) are **not supported**. Run them through an OCR tool first to get a text-bearing PDF.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| "No transactions detected" | Wrong doc-type or unusual layout | Pick the correct doc type from the dropdown. |
+| All rows have wrong dates | Locale mismatch (DD/MM vs MM/DD) | Edit each row's date manually before confirming. |
+| LLM categorization does nothing | Endpoint/key not set, or model name wrong | Re-check the three fields in Settings. |
+| Build error about `?url` import | Vite version too old | This feature needs Vite 5+ (already pinned in the project). |

--- a/docs/pdf-import.md
+++ b/docs/pdf-import.md
@@ -26,7 +26,7 @@ The doc-type dropdown lets you override the auto-detected parser if it picks the
 If a heuristic category is wrong (e.g. an obscure merchant), an **optional** LLM step can re-categorize the rows.
 
 - You provide an **OpenAI-compatible** `/chat/completions` endpoint, an API key, and a model name in *Settings → Experimental Features*.
-- Works with **OpenAI**, **Azure OpenAI**, **Ollama** (`http://localhost:11434/v1`), **LM Studio**, **OpenRouter**, **Together**, etc.
+- Works with **OpenAI**, **Azure OpenAI**, hosted aggregators (**OpenRouter**, **Together**, …), and — most importantly for privacy — **self-hosted open-source models** running locally via **Ollama** (`http://localhost:11434/v1`), **LM Studio** (`http://localhost:1234/v1`), **llama.cpp**, **vLLM**, etc. For local servers, any non-empty API-key value works.
 - It only runs when you tick **Use AI categorization** inside the import dialog for that import.
 - Only the parsed transaction descriptions, kinds, amounts, and currencies are sent — never the raw PDF bytes.
 - If the request fails, times out, or returns invalid JSON, the heuristic results are used unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/dom": "^10.4.1",
         "crypto-js": "^4.2.0",
         "js-cookie": "^3.0.7",
+        "pdfjs-dist": "^5.7.284",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-is": "^19.2.6",
@@ -399,6 +400,256 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2039,6 +2290,18 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.7.284",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
+      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.100"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@testing-library/dom": "^10.4.1",
     "crypto-js": "^4.2.0",
     "js-cookie": "^3.0.7",
+    "pdfjs-dist": "^5.7.284",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-is": "^19.2.6",

--- a/src/components/ExpenseTrackerPage.tsx
+++ b/src/components/ExpenseTrackerPage.tsx
@@ -55,6 +55,7 @@ import { MaterialIcon } from './MaterialIcon';
 import { ScrollToTopButton } from './ScrollToTopButton';
 import { PrivacyBlur } from './PrivacyBlur';
 import { CategoryManagerDialog } from './CategoryManagerDialog';
+import { PDFImportDialog } from './PDFImportDialog';
 import './ExpenseTrackerPage.css';
 
 // Month names for display
@@ -151,6 +152,11 @@ export function ExpenseTrackerPage() {
   const [showExpenseForm, setShowExpenseForm] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<IncomeEntry | ExpenseEntry | null>(null);
   const [showCategoryManager, setShowCategoryManager] = useState(false);
+  const [showPdfImport, setShowPdfImport] = useState(false);
+  const [pdfImportEnabled, setPdfImportEnabled] = useState<boolean>(() => {
+    return Boolean(loadSettings().experimentalFeatures?.pdfImport);
+  });
+  const [llmConfig, setLlmConfig] = useState(() => loadSettings().llmCategorization);
   
   // Filter/sort state
   const [filter, setFilter] = useState<TransactionFilter>({});
@@ -190,6 +196,8 @@ export function ExpenseTrackerPage() {
       const settings = loadSettings();
       setDateFormat(settings.dateFormat);
       setIsPrivacyMode(settings.privacyMode);
+      setPdfImportEnabled(Boolean(settings.experimentalFeatures?.pdfImport));
+      setLlmConfig(settings.llmCategorization);
     };
     
     window.addEventListener('storage', handleStorageChange);
@@ -1014,6 +1022,15 @@ export function ExpenseTrackerPage() {
                 <button className="btn-add expense" onClick={() => setShowExpenseForm(true)}>
                   <MaterialIcon name="add" /> Add Expense
                 </button>
+                {pdfImportEnabled && (
+                  <button
+                    className="btn-add"
+                    onClick={() => setShowPdfImport(true)}
+                    aria-label="Import transactions from PDF"
+                  >
+                    <MaterialIcon name="picture_as_pdf" /> Import PDF
+                  </button>
+                )}
               </div>
             </div>
 
@@ -1520,6 +1537,19 @@ export function ExpenseTrackerPage() {
             currency={data.currency}
             defaultDate={`${selectedYear}-${String(selectedMonth).padStart(2, '0')}-01`}
             searchThreshold={searchThreshold}
+          />
+        )}
+
+        {/* PDF Import Dialog (experimental) */}
+        {showPdfImport && pdfImportEnabled && (
+          <PDFImportDialog
+            onClose={() => setShowPdfImport(false)}
+            onAddIncome={handleAddIncome}
+            onAddExpense={handleAddExpense}
+            defaultCurrency={data.currency}
+            customCategories={data.customCategories}
+            categoryOverrides={data.categoryOverrides}
+            llmConfig={llmConfig}
           />
         )}
 

--- a/src/components/PDFImportDialog.css
+++ b/src/components/PDFImportDialog.css
@@ -6,6 +6,7 @@
   max-height: 90vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .pdf-import-dialog .dialog-form {
@@ -13,23 +14,63 @@
   flex-direction: column;
   gap: 1rem;
   overflow-y: auto;
+  min-height: 0;
 }
 
+/* Controls row: doc-type + file picker + AI toggle */
 .pdf-import-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: flex-end;
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(220px, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+}
+
+@media (max-width: 720px) {
+  .pdf-import-controls {
+    grid-template-columns: 1fr;
+  }
 }
 
 .pdf-import-controls .form-group {
   margin-bottom: 0;
+  min-width: 0;
 }
 
+.pdf-import-controls .form-group input[type="file"] {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* AI toggle: checkbox stays small, label wraps inside the cell */
 .pdf-import-llm-toggle {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
+  padding: 0.4rem 0;
+  max-width: 320px;
+}
+
+.pdf-import-llm-toggle input[type="checkbox"] {
+  width: auto !important;
+  flex: 0 0 auto;
+  margin: 0.25rem 0 0 0;
+  accent-color: var(--accent-primary);
+}
+
+.pdf-import-llm-toggle label {
+  margin: 0 !important;
+  display: block !important;
+  line-height: 1.3;
+  font-size: 0.9rem;
+  cursor: pointer;
+  word-break: break-word;
+}
+
+.pdf-import-llm-toggle .pdf-row-meta {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
 }
 
 .pdf-import-status {
@@ -37,12 +78,12 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
-  color: #6b7280;
+  color: var(--text-secondary);
   min-height: 1.5em;
 }
 
 .pdf-import-status.error {
-  color: #dc2626;
+  color: #f87171;
 }
 
 .pdf-import-summary {
@@ -51,13 +92,15 @@
   font-size: 0.9rem;
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
-  background: #f3f4f6;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
 }
 
 .pdf-import-table-wrapper {
-  overflow-x: auto;
-  border: 1px solid #e5e7eb;
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
+  max-height: 55vh;
 }
 
 .pdf-import-table {
@@ -69,13 +112,14 @@
 .pdf-import-table th,
 .pdf-import-table td {
   padding: 0.5rem 0.6rem;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--border-subtle);
   text-align: left;
   vertical-align: middle;
 }
 
 .pdf-import-table th {
-  background: #f9fafb;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
   font-weight: 600;
   position: sticky;
   top: 0;
@@ -87,7 +131,7 @@
 }
 
 .pdf-import-table tr.low-confidence td {
-  background: #fff7ed;
+  background: rgba(251, 146, 60, 0.08);
 }
 
 .pdf-import-table input[type="text"],
@@ -96,10 +140,17 @@
 .pdf-import-table select {
   width: 100%;
   padding: 0.3rem 0.4rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-subtle);
   border-radius: 4px;
   font-size: 0.85rem;
   box-sizing: border-box;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.pdf-import-table input[type="checkbox"] {
+  width: auto !important;
+  accent-color: var(--accent-primary);
 }
 
 .pdf-import-table .col-include {
@@ -123,15 +174,15 @@
 
 .pdf-import-table .pdf-row-meta {
   font-size: 0.75rem;
-  color: #6b7280;
+  color: var(--text-secondary);
   margin-top: 0.2rem;
 }
 
 .pdf-import-empty {
   padding: 1.5rem;
   text-align: center;
-  color: #6b7280;
-  border: 1px dashed #d1d5db;
+  color: var(--text-secondary);
+  border: 1px dashed var(--border-subtle);
   border-radius: 8px;
 }
 

--- a/src/components/PDFImportDialog.css
+++ b/src/components/PDFImportDialog.css
@@ -1,0 +1,143 @@
+/* PDF Import Dialog — extends the shared .dialog-* styles */
+
+.pdf-import-dialog {
+  max-width: 1100px;
+  width: 95vw;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.pdf-import-dialog .dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+}
+
+.pdf-import-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.pdf-import-controls .form-group {
+  margin-bottom: 0;
+}
+
+.pdf-import-llm-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pdf-import-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #6b7280;
+  min-height: 1.5em;
+}
+
+.pdf-import-status.error {
+  color: #dc2626;
+}
+
+.pdf-import-summary {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  background: #f3f4f6;
+}
+
+.pdf-import-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.pdf-import-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.pdf-import-table th,
+.pdf-import-table td {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.pdf-import-table th {
+  background: #f9fafb;
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.pdf-import-table tr.excluded td {
+  opacity: 0.45;
+}
+
+.pdf-import-table tr.low-confidence td {
+  background: #fff7ed;
+}
+
+.pdf-import-table input[type="text"],
+.pdf-import-table input[type="number"],
+.pdf-import-table input[type="date"],
+.pdf-import-table select {
+  width: 100%;
+  padding: 0.3rem 0.4rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  box-sizing: border-box;
+}
+
+.pdf-import-table .col-include {
+  width: 36px;
+  text-align: center;
+}
+
+.pdf-import-table .col-amount {
+  width: 110px;
+}
+
+.pdf-import-table .col-kind,
+.pdf-import-table .col-date {
+  width: 130px;
+}
+
+.pdf-import-table .col-category,
+.pdf-import-table .col-extra {
+  width: 160px;
+}
+
+.pdf-import-table .pdf-row-meta {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: 0.2rem;
+}
+
+.pdf-import-empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: #6b7280;
+  border: 1px dashed #d1d5db;
+  border-radius: 8px;
+}
+
+.pdf-import-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+}

--- a/src/components/PDFImportDialog.css
+++ b/src/components/PDFImportDialog.css
@@ -50,6 +50,16 @@
   max-width: 320px;
 }
 
+.pdf-import-llm-toggle.is-disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pdf-import-llm-toggle.is-disabled label,
+.pdf-import-llm-toggle.is-disabled input {
+  cursor: not-allowed;
+}
+
 .pdf-import-llm-toggle input[type="checkbox"] {
   width: auto !important;
   flex: 0 0 auto;
@@ -71,6 +81,20 @@
   margin-top: 0.2rem;
   font-size: 0.75rem;
   color: var(--text-secondary);
+}
+
+.pdf-import-llm-toggle .disabled-tag {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
 }
 
 .pdf-import-status {

--- a/src/components/PDFImportDialog.css
+++ b/src/components/PDFImportDialog.css
@@ -1,34 +1,31 @@
-/* PDF Import Dialog — extends the shared .dialog-* styles */
+/* PDF Import Dialog — extends the shared .dialog-* styles.
+   Selector uses .dialog.pdf-import-dialog (specificity 0,2,0) to win
+   over the global .dialog (0,1,0) rule that sets max-width: 500px. */
 
-.pdf-import-dialog {
+.dialog.pdf-import-dialog {
   max-width: 1100px;
-  width: 95vw;
+  width: min(95vw, 1100px);
   max-height: 90vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-.pdf-import-dialog .dialog-form {
+.dialog.pdf-import-dialog .dialog-form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
   overflow-y: auto;
   min-height: 0;
+  align-items: stretch;
 }
 
-/* Controls row: doc-type + file picker + AI toggle */
+/* Controls stack vertically — same pattern as the rest of the app's
+   dialogs. No grid, no flex-wrap surprises on narrow viewports. */
 .pdf-import-controls {
-  display: grid;
-  grid-template-columns: minmax(180px, 240px) minmax(220px, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  align-items: end;
-}
-
-@media (max-width: 720px) {
-  .pdf-import-controls {
-    grid-template-columns: 1fr;
-  }
 }
 
 .pdf-import-controls .form-group {
@@ -39,20 +36,26 @@
 .pdf-import-controls .form-group input[type="file"] {
   width: 100%;
   box-sizing: border-box;
+  padding: 0.5rem;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 2px solid var(--border-subtle);
+  border-radius: 6px;
 }
 
-/* AI toggle: checkbox stays small, label wraps inside the cell */
+/* AI toggle row */
 .pdf-import-llm-toggle {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.4rem 0;
-  max-width: 320px;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-tertiary);
 }
 
 .pdf-import-llm-toggle.is-disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .pdf-import-llm-toggle.is-disabled label,
@@ -63,38 +66,40 @@
 .pdf-import-llm-toggle input[type="checkbox"] {
   width: auto !important;
   flex: 0 0 auto;
-  margin: 0.25rem 0 0 0;
+  margin: 0.2rem 0 0 0;
   accent-color: var(--accent-primary);
 }
 
 .pdf-import-llm-toggle label {
   margin: 0 !important;
   display: block !important;
-  line-height: 1.3;
+  line-height: 1.35;
   font-size: 0.9rem;
   cursor: pointer;
-  word-break: break-word;
+  color: var(--text-primary);
+  flex: 1 1 auto;
 }
 
 .pdf-import-llm-toggle .pdf-row-meta {
   display: block;
-  margin-top: 0.2rem;
-  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  font-size: 0.78rem;
   color: var(--text-secondary);
 }
 
 .pdf-import-llm-toggle .disabled-tag {
   display: inline-block;
-  margin-left: 0.4rem;
-  padding: 0.05rem 0.4rem;
+  margin-left: 0.5rem;
+  padding: 0.05rem 0.45rem;
   border-radius: 999px;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  background: var(--bg-tertiary);
+  background: var(--bg-elevated);
   color: var(--text-secondary);
   border: 1px solid var(--border-subtle);
+  vertical-align: middle;
 }
 
 .pdf-import-status {
@@ -111,8 +116,6 @@
 }
 
 .pdf-import-summary {
-  display: flex;
-  gap: 1rem;
   font-size: 0.9rem;
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
@@ -124,7 +127,7 @@
   overflow: auto;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  max-height: 55vh;
+  max-height: 50vh;
 }
 
 .pdf-import-table {

--- a/src/components/PDFImportDialog.tsx
+++ b/src/components/PDFImportDialog.tsx
@@ -124,11 +124,14 @@ export function PDFImportDialog({
       }
 
       setDrafts(final);
-      setStatus(
-        final.length === 0
-          ? 'No transactions detected. Try a different document type.'
-          : `Detected ${final.length} transaction${final.length === 1 ? '' : 's'}. Review and confirm below.`,
-      );
+      const allZero = final.length > 0 && final.every(d => !(d.amount > 0));
+      if (final.length === 0) {
+        setStatus('No transactions detected. Try a different document type.');
+      } else if (allZero) {
+        setStatus(`Detected ${final.length} row${final.length === 1 ? '' : 's'} but every amount is 0 — looks like a blank template. Fill the amounts in and re-upload, or edit each row below before importing.`);
+      } else {
+        setStatus(`Detected ${final.length} transaction${final.length === 1 ? '' : 's'}. Review and confirm below.`);
+      }
     } finally {
       setBusy(false);
     }

--- a/src/components/PDFImportDialog.tsx
+++ b/src/components/PDFImportDialog.tsx
@@ -54,6 +54,10 @@ const DOC_TYPE_OPTIONS: { value: PdfDocType; label: string }[] = [
   { value: 'payslip', label: 'Payslip' },
 ];
 
+function appendError(prev: string, msg: string): string {
+  return prev ? `${prev}\n${msg}` : msg;
+}
+
 export function PDFImportDialog({
   onClose,
   onAddIncome,
@@ -93,13 +97,18 @@ export function PDFImportDialog({
         try {
           const extracted = await extractor(file);
           const { drafts: parsed } = parsePdf(extracted, docType, defaultCurrency);
+          if (parsed.length === 0 && extracted.lines.length === 0) {
+            setError(prev => appendError(prev,
+              `"${file.name}" has no extractable text (it may be a scanned image — run it through OCR first).`));
+          } else if (parsed.length === 0) {
+            setError(prev => appendError(prev,
+              `No transactions found in "${file.name}". Try a different document type.`));
+          }
           collected.push(...parsed);
         } catch (err) {
           console.error('Failed to parse PDF', file.name, err);
-          setError(prev =>
-            prev
-              ? `${prev}\nFailed to read "${file.name}".`
-              : `Failed to read "${file.name}".`);
+          const reason = err instanceof Error ? err.message : 'unknown error';
+          setError(prev => appendError(prev, `Failed to read "${file.name}": ${reason}`));
         }
       }
 
@@ -230,7 +239,7 @@ export function PDFImportDialog({
 
           <div className={`pdf-import-status${error ? ' error' : ''}`} role="status" aria-live="polite">
             {busy && <MaterialIcon name="hourglass_top" size="small" />}
-            <span>{error || status}</span>
+            <span style={{ whiteSpace: 'pre-line' }}>{error || status}</span>
           </div>
 
           {drafts.length > 0 && (

--- a/src/components/PDFImportDialog.tsx
+++ b/src/components/PDFImportDialog.tsx
@@ -221,7 +221,7 @@ export function PDFImportDialog({
               <label htmlFor="pdf-use-llm">
                 Use AI categorization
                 {!llmConfigured && (
-                  <span className="pdf-row-meta"> — configure an OpenAI-compatible endpoint in Settings first.</span>
+                  <span className="pdf-row-meta">Configure an OpenAI-compatible endpoint in Settings first.</span>
                 )}
               </label>
             </div>

--- a/src/components/PDFImportDialog.tsx
+++ b/src/components/PDFImportDialog.tsx
@@ -1,0 +1,366 @@
+/**
+ * Experimental PDF import dialog.
+ *
+ * Lets the user upload one or more PDF files, runs heuristic parsing (and an
+ * optional opt-in LLM categorization step), then shows an editable preview
+ * table so the user can fix and confirm before transactions are committed.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ExpenseCategory,
+  ExpenseEntry,
+  ExpenseType,
+  IncomeEntry,
+  IncomeSource,
+  INCOME_SOURCES,
+  NO_CATEGORY_ID,
+  CategoryInfo,
+  getAllCategories,
+  CustomCategory,
+  CategoryOverride,
+} from '../types/expenseTracker';
+import { SupportedCurrency } from '../types/currency';
+import {
+  LlmCategorizationConfig,
+  ParsedTransactionDraft,
+  PdfDocType,
+} from '../types/pdfImport';
+import { extractPdfText } from '../utils/pdfTextExtractor';
+import { parsePdf } from '../utils/pdfHeuristics';
+import { categorizeWithLlm } from '../utils/llmCategorizer';
+import { MaterialIcon } from './MaterialIcon';
+import './PDFImportDialog.css';
+
+interface PDFImportDialogProps {
+  onClose: () => void;
+  onAddIncome: (income: Omit<IncomeEntry, 'id' | 'type'>) => void;
+  onAddExpense: (expense: Omit<ExpenseEntry, 'id' | 'type'>) => void;
+  defaultCurrency: SupportedCurrency;
+  customCategories?: CustomCategory[];
+  categoryOverrides?: CategoryOverride[];
+  llmConfig?: LlmCategorizationConfig;
+  /** Injected for tests. Defaults to {@link extractPdfText}. */
+  extractor?: (file: File) => Promise<import('../utils/pdfTextExtractor').ExtractedPdf>;
+  /** Injected for tests. */
+  categorizer?: typeof categorizeWithLlm;
+}
+
+const DOC_TYPE_OPTIONS: { value: PdfDocType; label: string }[] = [
+  { value: 'auto', label: 'Auto-detect' },
+  { value: 'receipt', label: 'Receipt' },
+  { value: 'invoice', label: 'Invoice' },
+  { value: 'bank_statement', label: 'Bank / credit-card statement' },
+  { value: 'payslip', label: 'Payslip' },
+];
+
+export function PDFImportDialog({
+  onClose,
+  onAddIncome,
+  onAddExpense,
+  defaultCurrency,
+  customCategories = [],
+  categoryOverrides = [],
+  llmConfig,
+  extractor = extractPdfText,
+  categorizer = categorizeWithLlm,
+}: PDFImportDialogProps) {
+  const [docType, setDocType] = useState<PdfDocType>('auto');
+  const [useLlm, setUseLlm] = useState<boolean>(false);
+  const [drafts, setDrafts] = useState<ParsedTransactionDraft[]>([]);
+  const [status, setStatus] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [busy, setBusy] = useState<boolean>(false);
+
+  const categories: CategoryInfo[] = useMemo(
+    () => getAllCategories(customCategories, categoryOverrides),
+    [customCategories, categoryOverrides],
+  );
+
+  const llmConfigured = Boolean(
+    llmConfig?.baseUrl && llmConfig?.apiKey && llmConfig?.model,
+  );
+
+  const handleFiles = useCallback(async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setBusy(true);
+    setError('');
+    setStatus(`Reading ${files.length} file${files.length === 1 ? '' : 's'}…`);
+
+    const collected: ParsedTransactionDraft[] = [];
+    try {
+      for (const file of Array.from(files)) {
+        try {
+          const extracted = await extractor(file);
+          const { drafts: parsed } = parsePdf(extracted, docType, defaultCurrency);
+          collected.push(...parsed);
+        } catch (err) {
+          console.error('Failed to parse PDF', file.name, err);
+          setError(prev =>
+            prev
+              ? `${prev}\nFailed to read "${file.name}".`
+              : `Failed to read "${file.name}".`);
+        }
+      }
+
+      let final = collected;
+      if (useLlm && llmConfigured && collected.length > 0) {
+        setStatus('Running LLM categorization…');
+        try {
+          final = await categorizer(collected, llmConfig!, categories);
+        } catch (err) {
+          console.error('LLM categorization failed', err);
+          setError('LLM categorization failed — using heuristic results.');
+        }
+      }
+
+      setDrafts(final);
+      setStatus(
+        final.length === 0
+          ? 'No transactions detected. Try a different document type.'
+          : `Detected ${final.length} transaction${final.length === 1 ? '' : 's'}. Review and confirm below.`,
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [docType, defaultCurrency, useLlm, llmConfigured, llmConfig, categories, extractor, categorizer]);
+
+  const updateDraft = (id: string, patch: Partial<ParsedTransactionDraft>) => {
+    setDrafts(prev => prev.map(d => (d.id === id ? { ...d, ...patch } : d)));
+  };
+
+  const handleConfirm = () => {
+    const toCommit = drafts.filter(d => d.include);
+    const invalid = toCommit.find(d => !d.date || !(d.amount > 0));
+    if (invalid) {
+      setError('Each included row needs a date and an amount greater than zero.');
+      return;
+    }
+    let incomeCount = 0;
+    let expenseCount = 0;
+    for (const d of toCommit) {
+      if (d.kind === 'income') {
+        onAddIncome({
+          date: d.date,
+          amount: d.amount,
+          description: d.description || 'PDF import',
+          currency: d.currency,
+          source: (d.suggestedIncomeSource ?? 'OTHER') as IncomeSource,
+        });
+        incomeCount++;
+      } else {
+        onAddExpense({
+          date: d.date,
+          amount: d.amount,
+          description: d.description || 'PDF import',
+          currency: d.currency,
+          category: (d.suggestedCategory ?? NO_CATEGORY_ID) as ExpenseCategory,
+          expenseType: (d.suggestedExpenseType ?? 'WANT') as ExpenseType,
+        });
+        expenseCount++;
+      }
+    }
+    setStatus(`Imported ${incomeCount} income + ${expenseCount} expense entries.`);
+    onClose();
+  };
+
+  const totalIncluded = drafts.filter(d => d.include).length;
+
+  return (
+    <div className="dialog-overlay" onClick={onClose}>
+      <div
+        className="dialog pdf-import-dialog"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pdf-import-title"
+      >
+        <div className="dialog-header">
+          <h2 id="pdf-import-title">
+            <MaterialIcon name="picture_as_pdf" /> Import from PDF (experimental)
+          </h2>
+          <button className="dialog-close" onClick={onClose} aria-label="Close dialog">×</button>
+        </div>
+
+        <div className="dialog-form">
+          <div className="pdf-import-controls">
+            <div className="form-group">
+              <label htmlFor="pdf-doc-type">Document type</label>
+              <select
+                id="pdf-doc-type"
+                value={docType}
+                onChange={e => setDocType(e.target.value as PdfDocType)}
+                disabled={busy}
+              >
+                {DOC_TYPE_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="pdf-files">PDF files</label>
+              <input
+                id="pdf-files"
+                type="file"
+                accept="application/pdf,.pdf"
+                multiple
+                disabled={busy}
+                onChange={e => handleFiles(e.target.files)}
+              />
+            </div>
+
+            <div className="form-group pdf-import-llm-toggle">
+              <input
+                id="pdf-use-llm"
+                type="checkbox"
+                checked={useLlm && llmConfigured}
+                disabled={!llmConfigured || busy}
+                onChange={e => setUseLlm(e.target.checked)}
+              />
+              <label htmlFor="pdf-use-llm">
+                Use AI categorization
+                {!llmConfigured && (
+                  <span className="pdf-row-meta"> — configure an OpenAI-compatible endpoint in Settings first.</span>
+                )}
+              </label>
+            </div>
+          </div>
+
+          <div className={`pdf-import-status${error ? ' error' : ''}`} role="status" aria-live="polite">
+            {busy && <MaterialIcon name="hourglass_top" size="small" />}
+            <span>{error || status}</span>
+          </div>
+
+          {drafts.length > 0 && (
+            <>
+              <div className="pdf-import-summary">
+                <span><strong>{totalIncluded}</strong> of {drafts.length} rows will be imported.</span>
+              </div>
+
+              <div className="pdf-import-table-wrapper">
+                <table className="pdf-import-table" aria-label="Detected transactions">
+                  <thead>
+                    <tr>
+                      <th className="col-include" aria-label="Include row">✓</th>
+                      <th className="col-kind">Kind</th>
+                      <th className="col-date">Date</th>
+                      <th>Description</th>
+                      <th className="col-amount">Amount</th>
+                      <th className="col-category">Category / Source</th>
+                      <th className="col-extra">Type</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {drafts.map(d => (
+                      <tr
+                        key={d.id}
+                        className={`${d.include ? '' : 'excluded '}${d.confidence < 0.6 ? 'low-confidence' : ''}`.trim()}
+                      >
+                        <td className="col-include">
+                          <input
+                            type="checkbox"
+                            checked={d.include}
+                            onChange={e => updateDraft(d.id, { include: e.target.checked })}
+                            aria-label={`Include ${d.description}`}
+                          />
+                        </td>
+                        <td>
+                          <select
+                            value={d.kind}
+                            onChange={e => updateDraft(d.id, { kind: e.target.value as 'income' | 'expense' })}
+                          >
+                            <option value="income">Income</option>
+                            <option value="expense">Expense</option>
+                          </select>
+                        </td>
+                        <td>
+                          <input
+                            type="date"
+                            value={d.date}
+                            onChange={e => updateDraft(d.id, { date: e.target.value })}
+                          />
+                        </td>
+                        <td>
+                          <input
+                            type="text"
+                            value={d.description}
+                            onChange={e => updateDraft(d.id, { description: e.target.value })}
+                          />
+                          <div className="pdf-row-meta">
+                            {d.sourceFile} · {d.docType}
+                            {d.llmEnriched ? ' · AI' : ''}
+                          </div>
+                        </td>
+                        <td>
+                          <input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            value={d.amount}
+                            onChange={e => updateDraft(d.id, { amount: Number(e.target.value) })}
+                          />
+                        </td>
+                        <td>
+                          {d.kind === 'expense' ? (
+                            <select
+                              value={(d.suggestedCategory as string) ?? NO_CATEGORY_ID}
+                              onChange={e => updateDraft(d.id, { suggestedCategory: e.target.value })}
+                            >
+                              {categories.map(c => (
+                                <option key={c.id} value={c.id}>{c.name}</option>
+                              ))}
+                            </select>
+                          ) : (
+                            <select
+                              value={d.suggestedIncomeSource ?? 'OTHER'}
+                              onChange={e => updateDraft(d.id, { suggestedIncomeSource: e.target.value as IncomeSource })}
+                            >
+                              {INCOME_SOURCES.map(s => (
+                                <option key={s.id} value={s.id}>{s.name}</option>
+                              ))}
+                            </select>
+                          )}
+                        </td>
+                        <td>
+                          {d.kind === 'expense' ? (
+                            <select
+                              value={d.suggestedExpenseType ?? 'WANT'}
+                              onChange={e => updateDraft(d.id, { suggestedExpenseType: e.target.value as ExpenseType })}
+                            >
+                              <option value="NEED">Need</option>
+                              <option value="WANT">Want</option>
+                            </select>
+                          ) : (
+                            <span className="pdf-row-meta">—</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+
+          {!busy && drafts.length === 0 && !error && !status && (
+            <div className="pdf-import-empty">
+              Choose one or more PDF files to start. Nothing is uploaded anywhere — parsing happens in your browser.
+            </div>
+          )}
+
+          <div className="pdf-import-actions">
+            <button className="action-btn" onClick={onClose} disabled={busy}>Cancel</button>
+            <button
+              className="action-btn primary"
+              onClick={handleConfirm}
+              disabled={busy || totalIncluded === 0}
+            >
+              <MaterialIcon name="check" /> Import {totalIncluded > 0 ? `(${totalIncluded})` : ''}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PDFImportDialog.tsx
+++ b/src/components/PDFImportDialog.tsx
@@ -210,7 +210,7 @@ export function PDFImportDialog({
               />
             </div>
 
-            <div className="form-group pdf-import-llm-toggle">
+            <div className={`form-group pdf-import-llm-toggle${llmConfigured ? '' : ' is-disabled'}`}>
               <input
                 id="pdf-use-llm"
                 type="checkbox"
@@ -220,8 +220,9 @@ export function PDFImportDialog({
               />
               <label htmlFor="pdf-use-llm">
                 Use AI categorization
+                {!llmConfigured && <span className="disabled-tag">Disabled</span>}
                 {!llmConfigured && (
-                  <span className="pdf-row-meta">Configure an OpenAI-compatible endpoint in Settings first.</span>
+                  <span className="pdf-row-meta">Configure an OpenAI-compatible endpoint in Settings → Experimental Features to enable.</span>
                 )}
               </label>
             </div>

--- a/src/components/SettingsPage.css
+++ b/src/components/SettingsPage.css
@@ -228,7 +228,8 @@
 }
 
 .setting-item input[type="text"],
-.setting-item input[type="number"] {
+.setting-item input[type="number"],
+.setting-item input[type="password"] {
   width: 100%;
   padding: 0.75rem 1rem;
   border: 2px solid var(--border-subtle);
@@ -237,6 +238,7 @@
   border-radius: var(--radius-md);
   font-size: 1rem;
   transition: all var(--transition-base);
+  box-sizing: border-box;
 }
 
 .setting-item input:focus {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1006,6 +1006,86 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                 </div>
                 <span className="setting-help">Enable the Portfolio Breakdown page in navigation</span>
               </div>
+
+              <div className="setting-item">
+                <div className="label-with-tooltip">
+                  <label htmlFor="experimentalPdfImport">PDF expense/income import</label>
+                  <Tooltip content="Adds an 'Import PDF' button in the Expense Tracker. PDFs (receipts, invoices, bank/credit-card statements, payslips) are parsed fully in your browser. An optional AI categorization step uses an OpenAI-compatible endpoint that you configure below — only enable that if you trust the endpoint with your transaction descriptions.">
+                    <span className="info-icon" aria-label="More information">i</span>
+                  </Tooltip>
+                </div>
+                <div className="toggle-group">
+                  <button
+                    className={`toggle-btn ${!settings.experimentalFeatures?.pdfImport ? 'active' : ''}`}
+                    onClick={() => handleSettingChange('experimentalFeatures', { ...settings.experimentalFeatures, pdfImport: false })}
+                  >
+                    Disabled
+                  </button>
+                  <button
+                    className={`toggle-btn ${settings.experimentalFeatures?.pdfImport ? 'active' : ''}`}
+                    onClick={() => handleSettingChange('experimentalFeatures', { ...settings.experimentalFeatures, pdfImport: true })}
+                  >
+                    Enabled
+                  </button>
+                </div>
+                <span className="setting-help">Parse receipts, invoices, bank statements, and payslips locally. No network calls unless you opt into AI categorization.</span>
+              </div>
+
+              {settings.experimentalFeatures?.pdfImport && (
+                <div className="setting-item">
+                  <div className="label-with-tooltip">
+                    <label>AI categorization (optional)</label>
+                    <Tooltip content="Optional OpenAI-compatible endpoint used only when you tick 'Use AI categorization' inside the PDF import dialog. Compatible with OpenAI, Azure OpenAI, Ollama, LM Studio, OpenRouter, etc. Leave blank to keep everything heuristic.">
+                      <span className="info-icon" aria-label="More information">i</span>
+                    </Tooltip>
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="llmBaseUrl">Base URL</label>
+                    <input
+                      id="llmBaseUrl"
+                      type="text"
+                      placeholder="https://api.openai.com/v1"
+                      value={settings.llmCategorization?.baseUrl ?? ''}
+                      onChange={(e) => handleSettingChange('llmCategorization', {
+                        baseUrl: e.target.value,
+                        apiKey: settings.llmCategorization?.apiKey ?? '',
+                        model: settings.llmCategorization?.model ?? '',
+                      })}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="llmApiKey">API key</label>
+                    <input
+                      id="llmApiKey"
+                      type="password"
+                      placeholder="sk-…"
+                      value={settings.llmCategorization?.apiKey ?? ''}
+                      onChange={(e) => handleSettingChange('llmCategorization', {
+                        baseUrl: settings.llmCategorization?.baseUrl ?? '',
+                        apiKey: e.target.value,
+                        model: settings.llmCategorization?.model ?? '',
+                      })}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="llmModel">Model</label>
+                    <input
+                      id="llmModel"
+                      type="text"
+                      placeholder="gpt-4o-mini"
+                      value={settings.llmCategorization?.model ?? ''}
+                      onChange={(e) => handleSettingChange('llmCategorization', {
+                        baseUrl: settings.llmCategorization?.baseUrl ?? '',
+                        apiKey: settings.llmCategorization?.apiKey ?? '',
+                        model: e.target.value,
+                      })}
+                    />
+                  </div>
+                  <span className="setting-help">
+                    Stored encrypted with your other settings. Only used when you tick "Use AI categorization" in the PDF import dialog.
+                  </span>
+                </div>
+              )}
             </div>
           )}
         </section>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1028,23 +1028,26 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                     Enabled
                   </button>
                 </div>
-                <span className="setting-help">Parse receipts, invoices, bank statements, and payslips locally. No network calls unless you opt into AI categorization.</span>
+                <span className="setting-help">Parse receipts, invoices, bank statements, and payslips locally. No network calls unless you opt into AI categorization — which itself can be pointed at a self-hosted open-source model so nothing leaves your machine.</span>
               </div>
 
               {settings.experimentalFeatures?.pdfImport && (
                 <div className="setting-item">
                   <div className="label-with-tooltip">
                     <label>AI categorization (optional)</label>
-                    <Tooltip content="Optional OpenAI-compatible endpoint used only when you tick 'Use AI categorization' inside the PDF import dialog. Compatible with OpenAI, Azure OpenAI, Ollama, LM Studio, OpenRouter, etc. Leave blank to keep everything heuristic.">
+                    <Tooltip content="Optional OpenAI-compatible endpoint used only when you tick 'Use AI categorization' inside the PDF import dialog. Works with OpenAI and Azure OpenAI, with hosted aggregators like OpenRouter or Together, and — importantly — with self-hosted open-source models you run yourself via Ollama, LM Studio, llama.cpp, vLLM, or any other server that exposes an OpenAI-compatible /chat/completions endpoint. Leave blank to keep everything heuristic.">
                       <span className="info-icon" aria-label="More information">i</span>
                     </Tooltip>
                   </div>
+                  <p className="setting-help" style={{ marginTop: 0, marginBottom: '0.75rem' }}>
+                    Plug in any OpenAI-compatible endpoint — cloud (OpenAI, Azure OpenAI, OpenRouter, Together…) or a <strong>self-hosted open-source model</strong> via Ollama, LM Studio, llama.cpp, vLLM, etc. For fully local categorization, point Base URL at e.g. <code>http://localhost:11434/v1</code>, leave the API key as any non-empty string, and use a model you've already pulled (<code>llama3.1:8b</code>, <code>qwen2.5</code>, …).
+                  </p>
                   <div className="form-group">
                     <label htmlFor="llmBaseUrl">Base URL</label>
                     <input
                       id="llmBaseUrl"
                       type="text"
-                      placeholder="https://api.openai.com/v1"
+                      placeholder="https://api.openai.com/v1 or http://localhost:11434/v1"
                       value={settings.llmCategorization?.baseUrl ?? ''}
                       onChange={(e) => handleSettingChange('llmCategorization', {
                         baseUrl: e.target.value,
@@ -1058,7 +1061,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                     <input
                       id="llmApiKey"
                       type="password"
-                      placeholder="sk-…"
+                      placeholder="sk-… (any non-empty value for local servers)"
                       value={settings.llmCategorization?.apiKey ?? ''}
                       onChange={(e) => handleSettingChange('llmCategorization', {
                         baseUrl: settings.llmCategorization?.baseUrl ?? '',
@@ -1072,7 +1075,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                     <input
                       id="llmModel"
                       type="text"
-                      placeholder="gpt-4o-mini"
+                      placeholder="gpt-4o-mini, llama3.1:8b, qwen2.5, …"
                       value={settings.llmCategorization?.model ?? ''}
                       onChange={(e) => handleSettingChange('llmCategorization', {
                         baseUrl: settings.llmCategorization?.baseUrl ?? '',

--- a/src/types/pdfImport.ts
+++ b/src/types/pdfImport.ts
@@ -1,0 +1,76 @@
+/**
+ * Types for the experimental PDF expense/income import feature.
+ *
+ * All PDF parsing happens client-side. The optional LLM categorization step
+ * is opt-in and uses a user-supplied OpenAI-compatible endpoint.
+ */
+
+import { SupportedCurrency } from './currency';
+import {
+  ExpenseCategory,
+  ExpenseType,
+  IncomeSource,
+} from './expenseTracker';
+
+/** Supported document types for heuristic parsing. */
+export type PdfDocType =
+  | 'auto'
+  | 'receipt'
+  | 'invoice'
+  | 'bank_statement'
+  | 'payslip';
+
+/** Kind of transaction extracted from the PDF. */
+export type ParsedKind = 'income' | 'expense';
+
+/**
+ * A single transaction draft produced by the heuristic parser (and optionally
+ * refined by the LLM step). The user reviews and edits this before it is
+ * committed to the expense tracker.
+ */
+export interface ParsedTransactionDraft {
+  /** Stable local id used by the review UI. */
+  id: string;
+  /** Income vs expense. Detected from doc type / sign / keywords. */
+  kind: ParsedKind;
+  /** ISO date string (YYYY-MM-DD). Empty string if the parser could not find one. */
+  date: string;
+  /** Absolute amount (always non-negative). */
+  amount: number;
+  /** Detected currency, falls back to tracker currency if unknown. */
+  currency?: SupportedCurrency;
+  /** Free-form description (merchant, line item, payslip period, etc.). */
+  description: string;
+  /** Optional suggested expense category (built-in id or custom id). */
+  suggestedCategory?: ExpenseCategory | string;
+  /** Need vs want classification when kind === 'expense'. */
+  suggestedExpenseType?: ExpenseType;
+  /** Suggested income source when kind === 'income'. */
+  suggestedIncomeSource?: IncomeSource;
+  /** Document type that produced this row. */
+  docType: Exclude<PdfDocType, 'auto'>;
+  /** Source PDF file name (for the review UI). */
+  sourceFile: string;
+  /** The raw text line the parser used (for the review UI). */
+  rawLine?: string;
+  /** Whether the row should be imported. Defaults to true. */
+  include: boolean;
+  /** Confidence score in [0, 1]. Used to highlight low-confidence rows. */
+  confidence: number;
+  /** True once the LLM step has updated the suggested category/type. */
+  llmEnriched?: boolean;
+}
+
+/**
+ * Optional configuration for the LLM-powered categorization step. The user
+ * supplies an OpenAI-compatible endpoint (OpenAI, Azure OpenAI, Ollama,
+ * LM Studio, OpenRouter, etc.) and a model name.
+ */
+export interface LlmCategorizationConfig {
+  /** Base URL of the OpenAI-compatible API (no trailing /chat/completions). */
+  baseUrl: string;
+  /** API key. Stored encrypted with the rest of user settings. */
+  apiKey: string;
+  /** Model identifier (e.g. "gpt-4o-mini", "llama3:8b"). */
+  model: string;
+}

--- a/src/utils/cookieSettings.ts
+++ b/src/utils/cookieSettings.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CURRENCY_SETTINGS,
 } from '../types/currency';
 import { AssetClass } from '../types/assetAllocation';
+import { LlmCategorizationConfig } from '../types/pdfImport';
 import { encryptData, decryptData } from './cookieEncryption';
 
 export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD';
@@ -21,10 +22,14 @@ export interface ExperimentalFeatures {
   /** Portfolio Breakdown page — slices the current portfolio by currency,
    *  holding, sector, region, market, and ETF provider. */
   portfolioBreakdown: boolean;
+  /** PDF import in the Expense Tracker — parse receipts, invoices,
+   *  bank/credit-card statements, and payslips into transactions. */
+  pdfImport: boolean;
 }
 
 export const DEFAULT_EXPERIMENTAL_FEATURES: ExperimentalFeatures = {
   portfolioBreakdown: false,
+  pdfImport: false,
 };
 
 export interface UserSettings {
@@ -39,6 +44,9 @@ export interface UserSettings {
   includePrimaryResidenceInFIRE: boolean;
   searchThreshold: number;
   experimentalFeatures: ExperimentalFeatures;
+  /** Optional OpenAI-compatible LLM config for PDF import categorization.
+   *  Stored encrypted with the rest of the settings. */
+  llmCategorization?: LlmCategorizationConfig;
 }
 
 export const DEFAULT_FIRE_ASSET_CLASS_INCLUSION: Record<AssetClass, boolean> = {

--- a/src/utils/llmCategorizer.ts
+++ b/src/utils/llmCategorizer.ts
@@ -1,0 +1,180 @@
+/**
+ * Optional LLM-powered categorization for the PDF import experimental feature.
+ *
+ * Calls a user-supplied OpenAI-compatible /chat/completions endpoint (works
+ * with OpenAI, Azure OpenAI, Ollama, LM Studio, OpenRouter, etc.). Never
+ * called unless the user has explicitly configured it AND opted in for the
+ * current import. Fails gracefully — returns the original drafts on any error.
+ */
+
+import {
+  ExpenseCategory,
+  CategoryInfo,
+  IncomeSource,
+} from '../types/expenseTracker';
+import {
+  LlmCategorizationConfig,
+  ParsedTransactionDraft,
+} from '../types/pdfImport';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface LlmResponseItem {
+  id: string;
+  category?: string;
+  expenseType?: 'NEED' | 'WANT';
+  incomeSource?: IncomeSource;
+}
+
+function buildSystemPrompt(categories: CategoryInfo[]): string {
+  const list = categories
+    .map(c => `- ${c.id}: ${c.name}`)
+    .join('\n');
+  return [
+    'You are a careful financial assistant that classifies bank/receipt transactions.',
+    'For each transaction return a JSON object with these fields:',
+    '  - id: string (echo the input id verbatim)',
+    '  - category: one of the category IDs below (use NO_CATEGORY if unsure). Only used for expenses.',
+    '  - expenseType: "NEED" or "WANT" (only for expenses).',
+    '  - incomeSource: one of SALARY, FREELANCE, BUSINESS, INVESTMENTS, RENTAL, PENSION, SOCIAL_SECURITY, BONUS, GIFT, OTHER (only for incomes).',
+    'Available category IDs:',
+    list,
+    'Respond with strictly valid JSON of shape { "results": LlmResponseItem[] }. No prose.',
+  ].join('\n');
+}
+
+function buildUserPrompt(drafts: ParsedTransactionDraft[]): string {
+  const compact = drafts.map(d => ({
+    id: d.id,
+    kind: d.kind,
+    amount: d.amount,
+    currency: d.currency,
+    description: d.description,
+    rawLine: d.rawLine,
+  }));
+  return `Classify these transactions:\n${JSON.stringify(compact)}`;
+}
+
+/**
+ * Apply LLM categorization to a list of parsed transaction drafts.
+ *
+ * @param drafts        Drafts produced by the heuristic parsers.
+ * @param config        User-supplied LLM endpoint config.
+ * @param categories    Live category list (built-in + custom + overrides).
+ * @param fetchImpl     Injectable fetch (used by tests).
+ * @returns             Drafts with `suggestedCategory` / `suggestedExpenseType` /
+ *                      `suggestedIncomeSource` and `llmEnriched` updated. On
+ *                      any error returns the input drafts unchanged.
+ */
+export async function categorizeWithLlm(
+  drafts: ParsedTransactionDraft[],
+  config: LlmCategorizationConfig,
+  categories: CategoryInfo[],
+  options: {
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  } = {},
+): Promise<ParsedTransactionDraft[]> {
+  if (drafts.length === 0) return drafts;
+  if (!config?.baseUrl || !config?.apiKey || !config?.model) return drafts;
+
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch?.bind(globalThis);
+  if (!fetchImpl) return drafts;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  if (options.signal) {
+    options.signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  try {
+    const url = `${config.baseUrl.replace(/\/+$/, '')}/chat/completions`;
+    const body = {
+      model: config.model,
+      response_format: { type: 'json_object' },
+      temperature: 0,
+      messages: [
+        { role: 'system', content: buildSystemPrompt(categories) },
+        { role: 'user', content: buildUserPrompt(drafts) },
+      ],
+    };
+
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      console.error(`LLM categorization failed: HTTP ${res.status}`);
+      return drafts;
+    }
+
+    const json = await res.json();
+    const content: string | undefined =
+      json?.choices?.[0]?.message?.content ?? json?.choices?.[0]?.text;
+    if (typeof content !== 'string') return drafts;
+
+    const parsed = safeParseJson(content);
+    if (!parsed || !Array.isArray(parsed.results)) return drafts;
+
+    const results: LlmResponseItem[] = parsed.results;
+    const byId = new Map(results.map(r => [r.id, r]));
+    const allCategoryIds = new Set(categories.map(c => c.id));
+
+    return drafts.map(draft => {
+      const r = byId.get(draft.id);
+      if (!r) return draft;
+      const next: ParsedTransactionDraft = { ...draft, llmEnriched: true };
+      if (draft.kind === 'expense') {
+        if (r.category && allCategoryIds.has(r.category)) {
+          next.suggestedCategory = r.category as ExpenseCategory | string;
+        }
+        if (r.expenseType === 'NEED' || r.expenseType === 'WANT') {
+          next.suggestedExpenseType = r.expenseType;
+        }
+      } else if (draft.kind === 'income') {
+        if (r.incomeSource && isIncomeSource(r.incomeSource)) {
+          next.suggestedIncomeSource = r.incomeSource;
+        }
+      }
+      return next;
+    });
+  } catch (error) {
+    console.error('LLM categorization error:', error);
+    return drafts;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function safeParseJson(content: string): { results?: LlmResponseItem[] } | null {
+  try {
+    return JSON.parse(content);
+  } catch {
+    // Some models wrap JSON in code fences — strip and retry.
+    const stripped = content
+      .replace(/^```(?:json)?/i, '')
+      .replace(/```\s*$/i, '')
+      .trim();
+    try {
+      return JSON.parse(stripped);
+    } catch {
+      return null;
+    }
+  }
+}
+
+const INCOME_SOURCES: ReadonlySet<IncomeSource> = new Set<IncomeSource>([
+  'SALARY', 'FREELANCE', 'BUSINESS', 'INVESTMENTS', 'RENTAL',
+  'PENSION', 'SOCIAL_SECURITY', 'BONUS', 'GIFT', 'OTHER',
+]);
+
+function isIncomeSource(value: string): value is IncomeSource {
+  return INCOME_SOURCES.has(value as IncomeSource);
+}

--- a/src/utils/pdfHeuristics.ts
+++ b/src/utils/pdfHeuristics.ts
@@ -441,7 +441,7 @@ export function parseInvoice(
   }];
 }
 
-const NET_PAY_LABELS_RE = /(net\s*pay|net\s*amount|net\s*salary|take[\-\s]*home|net\s*income|netto\s*a\s*pagare|stipendio\s*netto|importo\s*netto|salaire\s*net|sueldo\s*neto)/i;
+const NET_PAY_LABELS_RE = /(total\s*net\s*pay(?:ment)?|net\s*pay(?:ment)?|net\s*amount|net\s*salary|take[\-\s]*home(?:\s*pay)?|net\s*income|netto\s*a\s*pagare|stipendio\s*netto|importo\s*netto|salaire\s*net|sueldo\s*neto|nettolohn|netto\s*lohn)/i;
 
 export function parsePayslip(
   extracted: ExtractedPdf,
@@ -451,36 +451,54 @@ export function parsePayslip(
 
   let netLine: string | null = null;
   let netAmount: number | null = null;
-  for (const line of lines) {
-    if (NET_PAY_LABELS_RE.test(line)) {
-      const amt = parseAmount(line);
-      if (amt !== null && amt > 0) {
-        netLine = line;
-        netAmount = amt;
-        break;
+  let labelOnlyMatch = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!NET_PAY_LABELS_RE.test(line)) continue;
+    // First try: amount on the same line.
+    const same = parseAmount(line);
+    if (same !== null) {
+      netLine = line;
+      netAmount = same;
+      if (Math.abs(same) > 0.001) break;
+    }
+    // Fallback: scan the next few lines for an amount.
+    for (let j = i + 1; j < Math.min(i + 4, lines.length); j++) {
+      const candidate = parseAmount(lines[j]);
+      if (candidate !== null) {
+        netLine = `${line} → ${lines[j]}`;
+        netAmount = candidate;
+        labelOnlyMatch = true;
+        if (Math.abs(candidate) > 0.001) break;
       }
     }
+    if (netAmount !== null && Math.abs(netAmount) > 0.001) break;
   }
 
   if (netAmount === null) return [];
 
+  const isZero = Math.abs(netAmount) < 0.001;
   const date = findFirstDate(extracted.fullText) ?? '';
   const description = deriveDescription(extracted, 'Salary');
   const currency = detectCurrency(extracted.fullText) ?? fallbackCurrency;
 
+  // Templates often have only zero placeholders. Surface them as a low-
+  // confidence, opt-out-by-default draft so the user knows what we found
+  // and can either fill the amount in or skip the row.
   return [{
     id: genId(),
     kind: 'income',
     date,
-    amount: netAmount,
+    amount: Math.abs(netAmount),
     currency,
-    description,
+    description: isZero ? `${description} (template?)` : description,
     suggestedIncomeSource: 'SALARY' as IncomeSource,
     docType: 'payslip',
     sourceFile: extracted.fileName,
     rawLine: netLine ?? undefined,
-    include: true,
-    confidence: date ? 0.8 : 0.6,
+    include: !isZero,
+    confidence: isZero ? 0.1 : (labelOnlyMatch ? 0.6 : (date ? 0.8 : 0.6)),
   }];
 }
 

--- a/src/utils/pdfHeuristics.ts
+++ b/src/utils/pdfHeuristics.ts
@@ -1,0 +1,609 @@
+/**
+ * Heuristic parsers for the experimental PDF expense/income import feature.
+ *
+ * Pure functions over already-extracted PDF text. Each parser is conservative
+ * and emits a confidence score; low-confidence rows are surfaced to the user
+ * in the review dialog so they can fix or exclude them.
+ */
+
+import { SupportedCurrency } from '../types/currency';
+import {
+  ExpenseCategory,
+  ExpenseType,
+  IncomeSource,
+} from '../types/expenseTracker';
+import {
+  ParsedTransactionDraft,
+  PdfDocType,
+} from '../types/pdfImport';
+import type { ExtractedPdf } from './pdfTextExtractor';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MONTHS: Record<string, number> = {
+  jan: 1, january: 1, gen: 1, gennaio: 1, ene: 1, enero: 1,
+  feb: 2, february: 2, febbraio: 2, febrero: 2,
+  mar: 3, march: 3, marzo: 3,
+  apr: 4, april: 4, aprile: 4, abr: 4, abril: 4,
+  may: 5, mag: 5, maggio: 5, mayo: 5, mai: 5,
+  jun: 6, june: 6, giu: 6, giugno: 6, junio: 6, juin: 6,
+  jul: 7, july: 7, lug: 7, luglio: 7, jul_es: 7, julio: 7, juil: 7,
+  aug: 8, august: 8, ago: 8, agosto: 8, aoû: 8, août: 8,
+  sep: 9, sept: 9, september: 9, set: 9, settembre: 9, septembre: 9, septiembre: 9, sept_es: 9,
+  oct: 10, october: 10, ott: 10, ottobre: 10, octubre: 10, octobre: 10,
+  nov: 11, november: 11, novembre: 11, noviembre: 11,
+  dec: 12, december: 12, dic: 12, dicembre: 12, diciembre: 12, déc: 12, decembre: 12,
+};
+
+const ISO_DATE_RE = /\b(\d{4})-(\d{2})-(\d{2})\b/;
+const DMY_DATE_RE = /\b(\d{1,2})[\/.\-](\d{1,2})[\/.\-](\d{2,4})\b/;
+const TEXT_DATE_RE = /\b(\d{1,2})\s+([A-Za-zàâéèêëîïôûüçñ]+)\.?\s+(\d{2,4})\b/;
+
+/** Parse a date string in many common formats. Returns ISO YYYY-MM-DD or null. */
+export function parseDate(input: string, prefer: 'dmy' | 'mdy' = 'dmy'): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+
+  const iso = trimmed.match(ISO_DATE_RE);
+  if (iso) {
+    const y = Number(iso[1]);
+    const m = Number(iso[2]);
+    const d = Number(iso[3]);
+    if (isValidYmd(y, m, d)) return formatYmd(y, m, d);
+  }
+
+  const dmy = trimmed.match(DMY_DATE_RE);
+  if (dmy) {
+    const a = Number(dmy[1]);
+    const b = Number(dmy[2]);
+    let y = Number(dmy[3]);
+    if (y < 100) y += 2000;
+    // Prefer DMY by default, but if first part > 12 it must be DMY,
+    // if second part > 12 it must be MDY.
+    let day: number;
+    let month: number;
+    if (a > 12) {
+      day = a;
+      month = b;
+    } else if (b > 12) {
+      month = a;
+      day = b;
+    } else if (prefer === 'mdy') {
+      month = a;
+      day = b;
+    } else {
+      day = a;
+      month = b;
+    }
+    if (isValidYmd(y, month, day)) return formatYmd(y, month, day);
+  }
+
+  const text = trimmed.match(TEXT_DATE_RE);
+  if (text) {
+    const day = Number(text[1]);
+    const monthName = text[2].toLowerCase();
+    let y = Number(text[3]);
+    if (y < 100) y += 2000;
+    const month = MONTHS[monthName] ?? MONTHS[monthName.slice(0, 3)];
+    if (month && isValidYmd(y, month, day)) return formatYmd(y, month, day);
+  }
+
+  return null;
+}
+
+function isValidYmd(y: number, m: number, d: number): boolean {
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > 31) return false;
+  if (y < 1900 || y > 2100) return false;
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+
+function formatYmd(y: number, m: number, d: number): string {
+  return `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+}
+
+const AMOUNT_TOKEN_RE = /-?\d{1,3}(?:[.,\s]\d{3})*(?:[.,]\d{1,2})|-?\d+(?:[.,]\d{1,2})|-?\d+/g;
+
+/**
+ * Parse an amount string in EU (1.234,56) or US (1,234.56) format.
+ * Returns null if no numeric value can be parsed.
+ */
+export function parseAmount(input: string): number | null {
+  if (!input) return null;
+  const stripped = input.replace(/[€$£¥]|EUR|USD|GBP|CHF|JPY|AUD|CAD/gi, '').trim();
+  // Find the rightmost number-like token to handle "Total: 1.234,56".
+  const matches = stripped.match(AMOUNT_TOKEN_RE);
+  if (!matches || matches.length === 0) return null;
+  const raw = matches[matches.length - 1];
+  return parseNumberToken(raw);
+}
+
+function parseNumberToken(raw: string): number | null {
+  const cleaned = raw.replace(/\s/g, '');
+  const lastComma = cleaned.lastIndexOf(',');
+  const lastDot = cleaned.lastIndexOf('.');
+  let normalized: string;
+  if (lastComma === -1 && lastDot === -1) {
+    normalized = cleaned;
+  } else if (lastComma > lastDot) {
+    // Comma is decimal separator (EU format)
+    normalized = cleaned.replace(/\./g, '').replace(',', '.');
+  } else {
+    // Dot is decimal separator (US format)
+    normalized = cleaned.replace(/,/g, '');
+  }
+  const n = Number(normalized);
+  return Number.isFinite(n) ? n : null;
+}
+
+const CURRENCY_SYMBOL_MAP: Record<string, SupportedCurrency> = {
+  '€': 'EUR',
+  '$': 'USD',
+  '£': 'GBP',
+  '¥': 'JPY',
+};
+
+const CURRENCY_CODE_RE = /\b(EUR|USD|GBP|CHF|JPY|AUD|CAD)\b/;
+
+export function detectCurrency(text: string): SupportedCurrency | undefined {
+  const code = text.match(CURRENCY_CODE_RE);
+  if (code) return code[1] as SupportedCurrency;
+  for (const [sym, cur] of Object.entries(CURRENCY_SYMBOL_MAP)) {
+    if (text.includes(sym)) return cur;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Doc-type detection
+// ---------------------------------------------------------------------------
+
+const PAYSLIP_KEYWORDS = [
+  'payslip', 'pay slip', 'pay statement', 'wage slip', 'salary slip',
+  'net pay', 'gross pay', 'employer', 'employee', 'pay period',
+  'busta paga', 'cedolino', 'stipendio netto', 'retribuzione',
+  'fiche de paie', 'bulletin de paie', 'salaire net',
+  'nomina', 'sueldo neto',
+];
+const INVOICE_KEYWORDS = [
+  'invoice', 'invoice number', 'invoice no', 'invoice date',
+  'fattura', 'numero fattura', 'partita iva',
+  'facture', 'facture n', 'numéro de facture',
+  'factura', 'factura n', 'número de factura',
+];
+const RECEIPT_KEYWORDS = [
+  'receipt', 'thank you for your purchase', 'thank you for shopping',
+  'scontrino', 'ricevuta',
+  'reçu', 'ticket de caisse',
+  'recibo',
+];
+const STATEMENT_KEYWORDS = [
+  'account statement', 'statement of account', 'transaction history',
+  'opening balance', 'closing balance', 'available balance',
+  'estratto conto', 'movimenti', 'saldo iniziale', 'saldo finale',
+  'relevé de compte', 'solde initial', 'solde final',
+  'extracto de cuenta', 'saldo inicial', 'saldo final',
+];
+
+export function autoDetectDocType(text: string): Exclude<PdfDocType, 'auto'> {
+  const lower = text.toLowerCase();
+  const scores: Record<Exclude<PdfDocType, 'auto'>, number> = {
+    payslip: countKeywords(lower, PAYSLIP_KEYWORDS),
+    invoice: countKeywords(lower, INVOICE_KEYWORDS),
+    receipt: countKeywords(lower, RECEIPT_KEYWORDS),
+    bank_statement: countKeywords(lower, STATEMENT_KEYWORDS),
+  };
+  let best: Exclude<PdfDocType, 'auto'> = 'receipt';
+  let bestScore = 0;
+  for (const [type, score] of Object.entries(scores) as [Exclude<PdfDocType, 'auto'>, number][]) {
+    if (score > bestScore) {
+      best = type;
+      bestScore = score;
+    }
+  }
+  // Heuristic fallback: if we cannot identify any keywords, try to detect
+  // a bank statement by row density (many lines starting with a date).
+  if (bestScore === 0) {
+    let dateRowCount = 0;
+    for (const line of text.split('\n')) {
+      if (/^\s*(?:\d{1,2}[\/.\-]\d{1,2}(?:[\/.\-]\d{2,4})?|\d{4}-\d{2}-\d{2})\b/.test(line)) {
+        dateRowCount++;
+      }
+    }
+    if (dateRowCount >= 3) return 'bank_statement';
+  }
+  return best;
+}
+
+function countKeywords(text: string, keywords: string[]): number {
+  let n = 0;
+  for (const kw of keywords) {
+    if (text.includes(kw)) n++;
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Category heuristics
+// ---------------------------------------------------------------------------
+
+interface CategoryRule {
+  category: ExpenseCategory;
+  expenseType: ExpenseType;
+  patterns: RegExp[];
+}
+
+const CATEGORY_RULES: CategoryRule[] = [
+  {
+    category: 'GROCERIES',
+    expenseType: 'NEED',
+    patterns: [/supermarket|grocer|esselunga|coop|carrefour|lidl|aldi|tesco|sainsbury|whole\s*foods|trader\s*joe|kroger|walmart|conad|pam|penny|eurospin/i],
+  },
+  {
+    category: 'DINING_OUT',
+    expenseType: 'WANT',
+    patterns: [/restaurant|ristorante|pizzeria|trattoria|osteria|pub|bar\b|caf[ée]|starbucks|mcdonald|burger|kfc|subway|dining|deliveroo|uber\s*eats|just\s*eat/i],
+  },
+  {
+    category: 'TRANSPORTATION',
+    expenseType: 'NEED',
+    patterns: [/uber|lyft|taxi|cab\b|metro|subway\s*card|train|trenitalia|italo|sncf|renfe|bus|tram|gasoline|fuel|benzina|gas\s*station|petrol|shell|eni|q8|esso|tamoil|agip|bp\b|texaco|chevron|exxon/i],
+  },
+  {
+    category: 'UTILITIES',
+    expenseType: 'NEED',
+    patterns: [/electric(?:ity)?|power\s*bill|gas\s*bill|water\s*bill|utility|utilities|enel|iren|hera|a2a|edf|engie|british\s*gas|comcast|verizon|wifi|broadband|internet\s*bill/i],
+  },
+  {
+    category: 'HOUSING',
+    expenseType: 'NEED',
+    patterns: [/rent\b|mortgage|landlord|affitto|mutuo|hoa\s*fee|condominio|loyer/i],
+  },
+  {
+    category: 'HEALTHCARE',
+    expenseType: 'NEED',
+    patterns: [/pharmacy|farmacia|drugstore|hospital|ospedale|clinic|clinica|doctor|medico|dentist|dentista|optician|ottico/i],
+  },
+  {
+    category: 'INSURANCE',
+    expenseType: 'NEED',
+    patterns: [/insurance|assicurazione|allianz|axa|generali|unipol|geico|state\s*farm/i],
+  },
+  {
+    category: 'SUBSCRIPTIONS',
+    expenseType: 'WANT',
+    patterns: [/netflix|spotify|amazon\s*prime|disney\+?|apple\s*music|apple\s*tv|youtube\s*premium|github|microsoft\s*365|adobe|dropbox|icloud|google\s*one/i],
+  },
+  {
+    category: 'ENTERTAINMENT',
+    expenseType: 'WANT',
+    patterns: [/cinema|theater|theatre|concert|spotify|playstation|xbox|nintendo|steam|gog\.com|epic\s*games/i],
+  },
+  {
+    category: 'SHOPPING',
+    expenseType: 'WANT',
+    patterns: [/amazon\.|ebay|zalando|asos|h&m|zara|ikea|decathlon|nike|adidas|apple\s*store/i],
+  },
+  {
+    category: 'TRAVEL',
+    expenseType: 'WANT',
+    patterns: [/airbnb|booking\.com|hotel|albergo|hostel|airlines?|ryanair|easyjet|lufthansa|delta|united|british\s*airways/i],
+  },
+  {
+    category: 'PERSONAL_CARE',
+    expenseType: 'WANT',
+    patterns: [/barber|hairdress|parruccher|salon|spa\b|massage|cosmetic|sephora|douglas/i],
+  },
+  {
+    category: 'EDUCATION',
+    expenseType: 'NEED',
+    patterns: [/tuition|school\s*fees|università|university|college|udemy|coursera|edx|book\s*store|libreria/i],
+  },
+  {
+    category: 'FEES',
+    expenseType: 'NEED',
+    patterns: [/bank\s*fee|service\s*charge|atm\s*fee|interest\s*charge|commission|commissione/i],
+  },
+];
+
+export function categorizeExpense(description: string): {
+  category: ExpenseCategory;
+  expenseType: ExpenseType;
+} {
+  for (const rule of CATEGORY_RULES) {
+    for (const pattern of rule.patterns) {
+      if (pattern.test(description)) {
+        return { category: rule.category, expenseType: rule.expenseType };
+      }
+    }
+  }
+  return { category: 'NO_CATEGORY', expenseType: 'WANT' };
+}
+
+// ---------------------------------------------------------------------------
+// Total / amount extraction
+// ---------------------------------------------------------------------------
+
+const TOTAL_LABELS_RE = /^(?:grand\s*total|total\s*amount|amount\s*due|amount\s*paid|total\s*due|total|totale|totale\s*complessivo|importo\s*totale|importo\s*dovuto|montant\s*total|total\s*à\s*payer|importe\s*total|gesamt|gesamtbetrag|summe)\b/i;
+
+/** Find the most likely total line in a receipt/invoice. */
+function findTotalAmount(lines: string[]): { amount: number; rawLine: string } | null {
+  let best: { amount: number; rawLine: string; score: number } | null = null;
+
+  for (const line of lines) {
+    const labelMatch = line.match(TOTAL_LABELS_RE);
+    if (!labelMatch) continue;
+    const amount = parseAmount(line);
+    if (amount === null) continue;
+    // Prefer "grand total" / "total amount" over plain "total".
+    const score =
+      /grand\s*total|total\s*amount|importo\s*totale|gesamtbetrag/i.test(line) ? 3 :
+      /total|totale|importo|montant\s*total|importe\s*total/i.test(line) ? 2 : 1;
+    if (!best || score > best.score) {
+      best = { amount: Math.abs(amount), rawLine: line, score };
+    }
+  }
+
+  if (best) return { amount: best.amount, rawLine: best.rawLine };
+  return null;
+}
+
+function findFirstDate(text: string): string | null {
+  for (const line of text.split('\n')) {
+    const d = parseDate(line);
+    if (d) return d;
+  }
+  return null;
+}
+
+function deriveDescription(extracted: ExtractedPdf, fallback: string): string {
+  // Use the first non-trivial line as a description (typically the merchant
+  // or company name).
+  for (const line of extracted.lines) {
+    const t = line.text.trim();
+    if (t.length >= 3 && !/^[\d\s\W]+$/.test(t)) {
+      return t.slice(0, 120);
+    }
+  }
+  return fallback;
+}
+
+let counter = 0;
+function genId(): string {
+  counter += 1;
+  return `pdf-${Date.now().toString(36)}-${counter}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Per-doc-type parsers
+// ---------------------------------------------------------------------------
+
+export function parseReceipt(
+  extracted: ExtractedPdf,
+  fallbackCurrency?: SupportedCurrency,
+): ParsedTransactionDraft[] {
+  const lines = extracted.lines.map(l => l.text);
+  const total = findTotalAmount(lines);
+  if (!total) return [];
+
+  const date = findFirstDate(extracted.fullText) ?? '';
+  const description = deriveDescription(extracted, extracted.fileName.replace(/\.pdf$/i, ''));
+  const currency = detectCurrency(extracted.fullText) ?? fallbackCurrency;
+  const category = categorizeExpense(description);
+
+  return [{
+    id: genId(),
+    kind: 'expense',
+    date,
+    amount: total.amount,
+    currency,
+    description,
+    suggestedCategory: category.category,
+    suggestedExpenseType: category.expenseType,
+    docType: 'receipt',
+    sourceFile: extracted.fileName,
+    rawLine: total.rawLine,
+    include: true,
+    confidence: date ? 0.75 : 0.55,
+  }];
+}
+
+export function parseInvoice(
+  extracted: ExtractedPdf,
+  fallbackCurrency?: SupportedCurrency,
+): ParsedTransactionDraft[] {
+  const lines = extracted.lines.map(l => l.text);
+  const total = findTotalAmount(lines);
+  if (!total) return [];
+
+  const date = findFirstDate(extracted.fullText) ?? '';
+  const description = deriveDescription(extracted, 'Invoice');
+  const currency = detectCurrency(extracted.fullText) ?? fallbackCurrency;
+  const category = categorizeExpense(description);
+
+  return [{
+    id: genId(),
+    kind: 'expense',
+    date,
+    amount: total.amount,
+    currency,
+    description,
+    suggestedCategory: category.category,
+    suggestedExpenseType: category.expenseType,
+    docType: 'invoice',
+    sourceFile: extracted.fileName,
+    rawLine: total.rawLine,
+    include: true,
+    confidence: date ? 0.7 : 0.5,
+  }];
+}
+
+const NET_PAY_LABELS_RE = /(net\s*pay|net\s*amount|net\s*salary|take[\-\s]*home|net\s*income|netto\s*a\s*pagare|stipendio\s*netto|importo\s*netto|salaire\s*net|sueldo\s*neto)/i;
+
+export function parsePayslip(
+  extracted: ExtractedPdf,
+  fallbackCurrency?: SupportedCurrency,
+): ParsedTransactionDraft[] {
+  const lines = extracted.lines.map(l => l.text);
+
+  let netLine: string | null = null;
+  let netAmount: number | null = null;
+  for (const line of lines) {
+    if (NET_PAY_LABELS_RE.test(line)) {
+      const amt = parseAmount(line);
+      if (amt !== null && amt > 0) {
+        netLine = line;
+        netAmount = amt;
+        break;
+      }
+    }
+  }
+
+  if (netAmount === null) return [];
+
+  const date = findFirstDate(extracted.fullText) ?? '';
+  const description = deriveDescription(extracted, 'Salary');
+  const currency = detectCurrency(extracted.fullText) ?? fallbackCurrency;
+
+  return [{
+    id: genId(),
+    kind: 'income',
+    date,
+    amount: netAmount,
+    currency,
+    description,
+    suggestedIncomeSource: 'SALARY' as IncomeSource,
+    docType: 'payslip',
+    sourceFile: extracted.fileName,
+    rawLine: netLine ?? undefined,
+    include: true,
+    confidence: date ? 0.8 : 0.6,
+  }];
+}
+
+// Bank statement row regex: optional date at start, description, then one or two amounts at end.
+// We require at least one date and one amount on the same line.
+const ROW_DATE_RE = /^(?:\s*)(\d{1,2}[\/.\-]\d{1,2}(?:[\/.\-]\d{2,4})?|\d{4}-\d{2}-\d{2}|\d{1,2}\s+[A-Za-zàâéèêëîïôûüçñ]+\.?\s+\d{2,4})\b/;
+
+export function parseBankStatement(
+  extracted: ExtractedPdf,
+  fallbackCurrency?: SupportedCurrency,
+): ParsedTransactionDraft[] {
+  const drafts: ParsedTransactionDraft[] = [];
+  const currency = detectCurrency(extracted.fullText) ?? fallbackCurrency;
+  // Determine the statement year from headers when only DD/MM (no year) is present.
+  const headerYearMatch = extracted.fullText.match(/\b(20\d{2})\b/);
+  const headerYear = headerYearMatch ? Number(headerYearMatch[1]) : new Date().getFullYear();
+
+  for (const line of extracted.lines) {
+    const text = line.text;
+    const dateMatch = text.match(ROW_DATE_RE);
+    if (!dateMatch) continue;
+
+    let date = parseDate(dateMatch[1]);
+    if (!date) {
+      // Try with the inferred header year for short dates.
+      const short = dateMatch[1].match(/^(\d{1,2})[\/.\-](\d{1,2})$/);
+      if (short) {
+        const d = Number(short[1]);
+        const m = Number(short[2]);
+        if (isValidYmd(headerYear, m, d)) date = formatYmd(headerYear, m, d);
+      }
+    }
+    if (!date) continue;
+
+    // Extract all amount-like tokens.
+    const amountTokens = text.match(/-?\d{1,3}(?:[.,\s]\d{3})*(?:[.,]\d{1,2})|-?\d+(?:[.,]\d{1,2})/g);
+    if (!amountTokens || amountTokens.length === 0) continue;
+    // Skip the date itself if it looked like a number.
+    const numericCandidates = amountTokens
+      .map(t => ({ raw: t, value: parseNumberToken(t) }))
+      .filter(c => c.value !== null && Math.abs(c.value!) >= 0.01);
+    if (numericCandidates.length === 0) continue;
+    // Use the last numeric token on the line as the transaction amount.
+    const last = numericCandidates[numericCandidates.length - 1];
+    const amount = last.value!;
+
+    // Description = the part of the line between the date and the amount.
+    const dateEnd = (text.indexOf(dateMatch[1]) + dateMatch[1].length);
+    const amountStart = text.lastIndexOf(last.raw);
+    let description = text.slice(dateEnd, amountStart).trim();
+    if (!description) description = text.trim();
+    description = description.replace(/\s+/g, ' ').slice(0, 120);
+
+    // Heuristic: negative amount = expense, positive = income.
+    const kind: 'income' | 'expense' = amount < 0 ? 'expense' : 'income';
+    // Some statements present expenses in a debit column without a minus sign;
+    // we infer this by keyword.
+    const debitHint = /debit|addebito|prelievo|pagamento|spesa|withdraw/i.test(description);
+    const creditHint = /credit|accredito|stipendio|salary|bonifico\s*in|deposit/i.test(description);
+
+    let finalKind: 'income' | 'expense' = kind;
+    if (amount > 0 && debitHint && !creditHint) finalKind = 'expense';
+    if (amount < 0 && creditHint && !debitHint) finalKind = 'income';
+
+    const absAmount = Math.abs(amount);
+    let suggestedCategory: ExpenseCategory | undefined;
+    let suggestedExpenseType: ExpenseType | undefined;
+    let suggestedIncomeSource: IncomeSource | undefined;
+    if (finalKind === 'expense') {
+      const cat = categorizeExpense(description);
+      suggestedCategory = cat.category;
+      suggestedExpenseType = cat.expenseType;
+    } else if (/salary|stipendio|payroll/i.test(description)) {
+      suggestedIncomeSource = 'SALARY';
+    } else if (/dividend|interest|investment|cedola/i.test(description)) {
+      suggestedIncomeSource = 'INVESTMENTS';
+    } else if (/rent\s*income|affitto\s*incassato/i.test(description)) {
+      suggestedIncomeSource = 'RENTAL';
+    } else {
+      suggestedIncomeSource = 'OTHER';
+    }
+
+    drafts.push({
+      id: genId(),
+      kind: finalKind,
+      date,
+      amount: absAmount,
+      currency,
+      description,
+      suggestedCategory,
+      suggestedExpenseType,
+      suggestedIncomeSource,
+      docType: 'bank_statement',
+      sourceFile: extracted.fileName,
+      rawLine: text,
+      include: true,
+      confidence: 0.65,
+    });
+  }
+
+  return drafts;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export function parsePdf(
+  extracted: ExtractedPdf,
+  docType: PdfDocType,
+  fallbackCurrency?: SupportedCurrency,
+): { drafts: ParsedTransactionDraft[]; resolvedDocType: Exclude<PdfDocType, 'auto'> } {
+  const resolved: Exclude<PdfDocType, 'auto'> =
+    docType === 'auto' ? autoDetectDocType(extracted.fullText) : docType;
+
+  switch (resolved) {
+    case 'receipt':
+      return { drafts: parseReceipt(extracted, fallbackCurrency), resolvedDocType: resolved };
+    case 'invoice':
+      return { drafts: parseInvoice(extracted, fallbackCurrency), resolvedDocType: resolved };
+    case 'payslip':
+      return { drafts: parsePayslip(extracted, fallbackCurrency), resolvedDocType: resolved };
+    case 'bank_statement':
+      return { drafts: parseBankStatement(extracted, fallbackCurrency), resolvedDocType: resolved };
+  }
+}

--- a/src/utils/pdfTextExtractor.ts
+++ b/src/utils/pdfTextExtractor.ts
@@ -5,7 +5,10 @@
  * the heuristic parsers can match transaction rows.
  *
  * pdfjs-dist is loaded dynamically so that importing this module does not
- * pull the (browser-only) PDF engine into jsdom / SSR contexts.
+ * pull the (browser-only) PDF engine into jsdom / SSR contexts. The worker
+ * is instantiated via Vite's `?worker` helper which produces a real Web
+ * Worker constructor with the correct `type: 'module'` — required because
+ * pdfjs v5 only ships an ESM worker bundle.
  */
 
 export interface PdfTextLine {
@@ -35,11 +38,16 @@ async function loadPdfJs() {
   const pdfjsLib = await import('pdfjs-dist');
   if (!workerConfigured) {
     try {
-      const workerUrlModule = await import('pdfjs-dist/build/pdf.worker.min.mjs?url');
-      pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrlModule.default;
+      // Vite's `?worker` returns a Worker constructor with the correct
+      // module type. Handing pdfjs a workerPort skips its internal
+      // `new Worker(workerSrc)` call (which loads a classic worker and
+      // fails on the ESM-only pdfjs v5 worker bundle).
+      const WorkerCtor = (await import('pdfjs-dist/build/pdf.worker.min.mjs?worker')).default;
+      pdfjsLib.GlobalWorkerOptions.workerPort = new WorkerCtor();
       workerConfigured = true;
     } catch (error) {
       console.error('Failed to configure pdfjs worker:', error);
+      throw new Error('PDF engine could not be initialised. Please reload and try again.');
     }
   }
   return pdfjsLib;
@@ -88,18 +96,25 @@ function groupItemsIntoLines(
 
 /**
  * Extract text and line layout from a PDF File. Throws if the file is not a
- * valid PDF or cannot be parsed.
+ * valid PDF or cannot be parsed. If the PDF has no text layer (e.g. a
+ * scan), an empty result is returned so callers can show a helpful message.
  */
 export async function extractPdfText(file: File): Promise<ExtractedPdf> {
   const pdfjsLib = await loadPdfJs();
   const buffer = await file.arrayBuffer();
-  const pdf = await pdfjsLib.getDocument({ data: buffer }).promise;
+  const pdf = await pdfjsLib.getDocument({ data: new Uint8Array(buffer) }).promise;
 
   const allLines: PdfTextLine[] = [];
-  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
-    const page = await pdf.getPage(pageNum);
-    const textContent = await page.getTextContent();
-    allLines.push(...groupItemsIntoLines(textContent.items, pageNum));
+  try {
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      allLines.push(...groupItemsIntoLines(textContent.items, pageNum));
+      page.cleanup();
+    }
+  } finally {
+    await pdf.cleanup().catch(() => undefined);
+    await pdf.destroy().catch(() => undefined);
   }
 
   const fullText = allLines.map(l => l.text).join('\n');

--- a/src/utils/pdfTextExtractor.ts
+++ b/src/utils/pdfTextExtractor.ts
@@ -1,0 +1,114 @@
+/**
+ * PDF text extraction using pdfjs-dist.
+ *
+ * Runs fully in the browser, no network calls. Output is line-grouped so that
+ * the heuristic parsers can match transaction rows.
+ *
+ * pdfjs-dist is loaded dynamically so that importing this module does not
+ * pull the (browser-only) PDF engine into jsdom / SSR contexts.
+ */
+
+export interface PdfTextLine {
+  /** Page number (1-indexed). */
+  page: number;
+  /** Approximate Y position used to group items into lines. */
+  y: number;
+  /** Concatenated text content of the line. */
+  text: string;
+}
+
+export interface ExtractedPdf {
+  fileName: string;
+  /** Plain text — useful for keyword detection (e.g. "Net pay"). */
+  fullText: string;
+  /** Line-grouped text — used by transactional parsers. */
+  lines: PdfTextLine[];
+  /** Detected page count. */
+  pageCount: number;
+}
+
+let workerConfigured = false;
+
+async function loadPdfJs() {
+  // Dynamic import so jsdom-based tests (which don't have DOMMatrix) only pay
+  // for pdfjs when they actually need it.
+  const pdfjsLib = await import('pdfjs-dist');
+  if (!workerConfigured) {
+    try {
+      const workerUrlModule = await import('pdfjs-dist/build/pdf.worker.min.mjs?url');
+      pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrlModule.default;
+      workerConfigured = true;
+    } catch (error) {
+      console.error('Failed to configure pdfjs worker:', error);
+    }
+  }
+  return pdfjsLib;
+}
+
+/**
+ * Group pdfjs text items into visual lines. pdfjs returns items with a
+ * transform matrix; we use the y component as the line grouping key.
+ */
+function groupItemsIntoLines(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  items: any[],
+  pageNum: number,
+): PdfTextLine[] {
+  const lineMap = new Map<number, { y: number; parts: { x: number; str: string }[] }>();
+
+  for (const item of items) {
+    if (typeof item.str !== 'string' || item.str.trim() === '') continue;
+    const transform = item.transform as number[] | undefined;
+    if (!transform || transform.length < 6) continue;
+    // Round y so that items on the same line group together even with sub-px noise.
+    const y = Math.round(transform[5]);
+    const x = transform[4];
+    const existing = lineMap.get(y);
+    if (existing) {
+      existing.parts.push({ x, str: item.str });
+    } else {
+      lineMap.set(y, { y, parts: [{ x, str: item.str }] });
+    }
+  }
+
+  const lines: PdfTextLine[] = [];
+  // Sort top→bottom (higher y is higher on the page in PDF coordinates).
+  const sortedYs = Array.from(lineMap.keys()).sort((a, b) => b - a);
+  for (const y of sortedYs) {
+    const entry = lineMap.get(y)!;
+    entry.parts.sort((a, b) => a.x - b.x);
+    const text = entry.parts.map(p => p.str).join(' ').replace(/\s+/g, ' ').trim();
+    if (text) {
+      lines.push({ page: pageNum, y, text });
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Extract text and line layout from a PDF File. Throws if the file is not a
+ * valid PDF or cannot be parsed.
+ */
+export async function extractPdfText(file: File): Promise<ExtractedPdf> {
+  const pdfjsLib = await loadPdfJs();
+  const buffer = await file.arrayBuffer();
+  const pdf = await pdfjsLib.getDocument({ data: buffer }).promise;
+
+  const allLines: PdfTextLine[] = [];
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+    const page = await pdf.getPage(pageNum);
+    const textContent = await page.getTextContent();
+    allLines.push(...groupItemsIntoLines(textContent.items, pageNum));
+  }
+
+  const fullText = allLines.map(l => l.text).join('\n');
+
+  return {
+    fileName: file.name,
+    fullText,
+    lines: allLines,
+    pageCount: pdf.numPages,
+  };
+}
+

--- a/src/utils/pdfTextExtractor.ts
+++ b/src/utils/pdfTextExtractor.ts
@@ -32,7 +32,36 @@ export interface ExtractedPdf {
 
 let workerConfigured = false;
 
+/**
+ * Safari < 17.4 (and a few other older browsers) ship `ReadableStream` but
+ * not `ReadableStream.prototype[Symbol.asyncIterator]`. pdfjs v5 uses
+ * `for await … of` on internal streams, which crashes with
+ * "undefined is not a function (near '...value of readableStream...')".
+ * We install a tiny polyfill the first time the extractor is used.
+ */
+function ensureReadableStreamAsyncIterator(): void {
+  if (typeof ReadableStream === 'undefined') return;
+  const proto = ReadableStream.prototype as unknown as Record<symbol, unknown>;
+  if (proto[Symbol.asyncIterator]) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (proto as any)[Symbol.asyncIterator] = async function* asyncIterator(this: ReadableStream<unknown>) {
+    const reader = this.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return;
+        yield value;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (proto as any).values = (proto as any)[Symbol.asyncIterator];
+}
+
 async function loadPdfJs() {
+  ensureReadableStreamAsyncIterator();
   // Dynamic import so jsdom-based tests (which don't have DOMMatrix) only pay
   // for pdfjs when they actually need it.
   const pdfjsLib = await import('pdfjs-dist');

--- a/src/vite-asset-imports.d.ts
+++ b/src/vite-asset-imports.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Ambient declarations for asset imports that Vite resolves at build time.
+ */
+declare module '*?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*?worker&inline' {
+  const workerCtor: { new (): Worker };
+  export default workerCtor;
+}

--- a/src/vite-asset-imports.d.ts
+++ b/src/vite-asset-imports.d.ts
@@ -6,6 +6,11 @@ declare module '*?url' {
   export default src;
 }
 
+declare module '*?worker' {
+  const workerCtor: { new (): Worker };
+  export default workerCtor;
+}
+
 declare module '*?worker&inline' {
   const workerCtor: { new (): Worker };
   export default workerCtor;

--- a/tests/components/PDFImportDialog.test.tsx
+++ b/tests/components/PDFImportDialog.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PDFImportDialog } from '../../src/components/PDFImportDialog';
+import type { ExtractedPdf } from '../../src/utils/pdfTextExtractor';
+
+function makeExtracted(name: string, lines: string[]): ExtractedPdf {
+  return {
+    fileName: name,
+    fullText: lines.join('\n'),
+    lines: lines.map((text, i) => ({ page: 1, y: 1000 - i, text })),
+    pageCount: 1,
+  };
+}
+
+function makeFile(name: string): File {
+  return new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], name, { type: 'application/pdf' });
+}
+
+describe('PDFImportDialog', () => {
+  it('renders empty state and disables AI categorization when LLM not configured', () => {
+    const onClose = vi.fn();
+    const onAddIncome = vi.fn();
+    const onAddExpense = vi.fn();
+    render(
+      <PDFImportDialog
+        onClose={onClose}
+        onAddIncome={onAddIncome}
+        onAddExpense={onAddExpense}
+        defaultCurrency="EUR"
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    const aiCheckbox = screen.getByLabelText(/Use AI categorization/i) as HTMLInputElement;
+    expect(aiCheckbox.disabled).toBe(true);
+  });
+
+  it('parses uploaded PDF, lets the user exclude rows, and commits the rest', async () => {
+    const onClose = vi.fn();
+    const onAddIncome = vi.fn();
+    const onAddExpense = vi.fn();
+
+    const extractor = vi.fn().mockResolvedValue(makeExtracted('statement.pdf', [
+      'Account statement 2024',
+      '01/03/2024 Stipendio acme 2.500,00',
+      '03/03/2024 Esselunga -45,30',
+      '10/03/2024 Netflix -12,99',
+    ]));
+
+    render(
+      <PDFImportDialog
+        onClose={onClose}
+        onAddIncome={onAddIncome}
+        onAddExpense={onAddExpense}
+        defaultCurrency="EUR"
+        extractor={extractor}
+      />,
+    );
+
+    // Choose bank_statement so the dispatcher uses the row parser.
+    fireEvent.change(screen.getByLabelText(/Document type/i), { target: { value: 'bank_statement' } });
+
+    fireEvent.change(screen.getByLabelText(/PDF files/i), {
+      target: { files: [makeFile('statement.pdf')] },
+    });
+
+    await waitFor(() => expect(extractor).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText(/Detected 3 transactions/i)).toBeTruthy());
+
+    // Exclude the second row (Esselunga) by unchecking it.
+    const checkboxes = screen.getAllByRole('checkbox').filter(c => (c as HTMLInputElement).type === 'checkbox' && (c.getAttribute('aria-label') || '').toLowerCase().includes('include'));
+    // Find the Esselunga row checkbox.
+    const esselungaCheckbox = checkboxes.find(c => (c.getAttribute('aria-label') || '').toLowerCase().includes('esselunga'));
+    expect(esselungaCheckbox).toBeTruthy();
+    fireEvent.click(esselungaCheckbox!);
+
+    fireEvent.click(screen.getByRole('button', { name: /Import \(2\)/ }));
+
+    expect(onAddIncome).toHaveBeenCalledTimes(1);
+    expect(onAddExpense).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls the LLM categorizer when AI categorization is enabled', async () => {
+    const onClose = vi.fn();
+    const onAddIncome = vi.fn();
+    const onAddExpense = vi.fn();
+
+    const extractor = vi.fn().mockResolvedValue(makeExtracted('receipt.pdf', [
+      'Cafe Roma',
+      '15/03/2024',
+      'TOTAL €6,50',
+    ]));
+    const categorizer = vi.fn().mockImplementation(async (drafts) => drafts);
+
+    render(
+      <PDFImportDialog
+        onClose={onClose}
+        onAddIncome={onAddIncome}
+        onAddExpense={onAddExpense}
+        defaultCurrency="EUR"
+        extractor={extractor}
+        categorizer={categorizer}
+        llmConfig={{ baseUrl: 'http://localhost:11434/v1', apiKey: 'x', model: 'llama3' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Use AI categorization/i));
+    fireEvent.change(screen.getByLabelText(/PDF files/i), {
+      target: { files: [makeFile('receipt.pdf')] },
+    });
+
+    await waitFor(() => expect(categorizer).toHaveBeenCalledTimes(1));
+  });
+
+  it('skips files that fail to extract but keeps going', async () => {
+    const onClose = vi.fn();
+    const onAddIncome = vi.fn();
+    const onAddExpense = vi.fn();
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const extractor = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(makeExtracted('ok.pdf', [
+        'Cafe Roma', '15/03/2024', 'TOTAL €6,50',
+      ]));
+
+    render(
+      <PDFImportDialog
+        onClose={onClose}
+        onAddIncome={onAddIncome}
+        onAddExpense={onAddExpense}
+        defaultCurrency="EUR"
+        extractor={extractor}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Document type/i), { target: { value: 'receipt' } });
+    fireEvent.change(screen.getByLabelText(/PDF files/i), {
+      target: { files: [makeFile('bad.pdf'), makeFile('ok.pdf')] },
+    });
+
+    await waitFor(() => expect(extractor).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText(/Failed to read "bad.pdf"/i)).toBeTruthy());
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/utils/llmCategorizer.test.ts
+++ b/tests/utils/llmCategorizer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import { categorizeWithLlm } from '../../src/utils/llmCategorizer';
+import type { LlmCategorizationConfig, ParsedTransactionDraft } from '../../src/types/pdfImport';
+import { EXPENSE_CATEGORIES } from '../../src/types/expenseTracker';
+
+const config: LlmCategorizationConfig = {
+  baseUrl: 'https://api.openai.example/v1',
+  apiKey: 'sk-test',
+  model: 'gpt-test',
+};
+
+function expenseDraft(id: string, description: string): ParsedTransactionDraft {
+  return {
+    id,
+    kind: 'expense',
+    date: '2024-03-15',
+    amount: 12,
+    description,
+    docType: 'bank_statement',
+    sourceFile: 'x.pdf',
+    include: true,
+    confidence: 0.5,
+  };
+}
+
+function incomeDraft(id: string, description: string): ParsedTransactionDraft {
+  return {
+    id,
+    kind: 'income',
+    date: '2024-03-15',
+    amount: 2000,
+    description,
+    docType: 'bank_statement',
+    sourceFile: 'x.pdf',
+    include: true,
+    confidence: 0.5,
+  };
+}
+
+describe('categorizeWithLlm', () => {
+  it('returns input drafts when list is empty', async () => {
+    const result = await categorizeWithLlm([], config, EXPENSE_CATEGORIES);
+    expect(result).toEqual([]);
+  });
+
+  it('returns input drafts when config is incomplete', async () => {
+    const drafts = [expenseDraft('a', 'Some coffee')];
+    const result = await categorizeWithLlm(drafts, { baseUrl: '', apiKey: '', model: '' }, EXPENSE_CATEGORIES);
+    expect(result).toBe(drafts);
+  });
+
+  it('posts to /chat/completions with proper headers and parses JSON response', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                results: [
+                  { id: 'a', category: 'GROCERIES', expenseType: 'NEED' },
+                  { id: 'b', incomeSource: 'SALARY' },
+                ],
+              }),
+            },
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    const drafts = [expenseDraft('a', 'mystery merchant'), incomeDraft('b', 'payroll')];
+    const result = await categorizeWithLlm(drafts, config, EXPENSE_CATEGORIES, { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchImpl.mock.calls[0];
+    expect(url).toBe('https://api.openai.example/v1/chat/completions');
+    expect((opts as RequestInit).method).toBe('POST');
+    expect((opts as RequestInit).headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer sk-test',
+    });
+    expect(result[0].suggestedCategory).toBe('GROCERIES');
+    expect(result[0].suggestedExpenseType).toBe('NEED');
+    expect(result[0].llmEnriched).toBe(true);
+    expect(result[1].suggestedIncomeSource).toBe('SALARY');
+    expect(result[1].llmEnriched).toBe(true);
+  });
+
+  it('ignores unknown category ids returned by the LLM', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '{"results":[{"id":"a","category":"NOT_A_REAL_ID","expenseType":"NEED"}]}' } }],
+      }),
+    } as unknown as Response);
+
+    const drafts = [expenseDraft('a', 'x')];
+    const result = await categorizeWithLlm(drafts, config, EXPENSE_CATEGORIES, { fetchImpl });
+    expect(result[0].suggestedCategory).toBeUndefined();
+    expect(result[0].suggestedExpenseType).toBe('NEED');
+  });
+
+  it('falls back to input drafts when HTTP fails', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as unknown as Response);
+    const drafts = [expenseDraft('a', 'x')];
+    const result = await categorizeWithLlm(drafts, config, EXPENSE_CATEGORIES, { fetchImpl });
+    expect(result).toBe(drafts);
+  });
+
+  it('falls back when LLM returns non-JSON content', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'not json at all' } }] }),
+    } as unknown as Response);
+    const drafts = [expenseDraft('a', 'x')];
+    const result = await categorizeWithLlm(drafts, config, EXPENSE_CATEGORIES, { fetchImpl });
+    expect(result).toBe(drafts);
+  });
+
+  it('strips code fences from LLM output', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '```json\n{"results":[{"id":"a","category":"GROCERIES","expenseType":"NEED"}]}\n```' } }],
+      }),
+    } as unknown as Response);
+    const drafts = [expenseDraft('a', 'x')];
+    const result = await categorizeWithLlm(drafts, config, EXPENSE_CATEGORIES, { fetchImpl });
+    expect(result[0].suggestedCategory).toBe('GROCERIES');
+  });
+});

--- a/tests/utils/pdfHeuristics.test.ts
+++ b/tests/utils/pdfHeuristics.test.ts
@@ -225,6 +225,39 @@ describe('parsePayslip', () => {
     const extracted = makeExtracted('nope.pdf', ['no payroll info here']);
     expect(parsePayslip(extracted)).toHaveLength(0);
   });
+
+  it('matches Total net payment when amount is on a later line', () => {
+    const extracted = makeExtracted('two-line.pdf', [
+      'Payslip - March 2024',
+      'Employee John Doe',
+      '15/03/2024',
+      'Net pay',
+      'Some intervening line',
+      'Total net payment 2.500,00 EUR',
+    ]);
+    const result = parsePayslip(extracted);
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBeCloseTo(2500);
+    expect(result[0].kind).toBe('income');
+  });
+
+  it('emits a low-confidence opt-out row for blank templates', () => {
+    const extracted = makeExtracted('template.pdf', [
+      'Pay slip template',
+      'Employer placeholder',
+      'Pay period: insert date',
+      'Total gross payment $00.00',
+      'NET PAY',
+      'Bank details: insert bank',
+      'Total net payment $00.00',
+    ]);
+    const result = parsePayslip(extracted);
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBe(0);
+    expect(result[0].include).toBe(false);
+    expect(result[0].confidence).toBeLessThan(0.3);
+    expect(result[0].description.toLowerCase()).toContain('template');
+  });
 });
 
 describe('parseBankStatement', () => {

--- a/tests/utils/pdfHeuristics.test.ts
+++ b/tests/utils/pdfHeuristics.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autoDetectDocType,
+  categorizeExpense,
+  detectCurrency,
+  parseAmount,
+  parseBankStatement,
+  parseDate,
+  parseInvoice,
+  parsePayslip,
+  parsePdf,
+  parseReceipt,
+} from '../../src/utils/pdfHeuristics';
+import type { ExtractedPdf, PdfTextLine } from '../../src/utils/pdfTextExtractor';
+
+function makeExtracted(fileName: string, lines: string[]): ExtractedPdf {
+  const textLines: PdfTextLine[] = lines.map((text, i) => ({ page: 1, y: 1000 - i, text }));
+  return {
+    fileName,
+    fullText: lines.join('\n'),
+    lines: textLines,
+    pageCount: 1,
+  };
+}
+
+describe('parseDate', () => {
+  it('parses ISO dates', () => {
+    expect(parseDate('2024-03-15')).toBe('2024-03-15');
+  });
+
+  it('parses DMY dates with slashes (default)', () => {
+    expect(parseDate('15/03/2024')).toBe('2024-03-15');
+  });
+
+  it('parses DMY dates with dots', () => {
+    expect(parseDate('15.03.2024')).toBe('2024-03-15');
+  });
+
+  it('parses MDY when configured', () => {
+    expect(parseDate('03/15/2024', 'mdy')).toBe('2024-03-15');
+  });
+
+  it('detects DMY when day > 12 regardless of preference', () => {
+    expect(parseDate('25/03/2024', 'mdy')).toBe('2024-03-25');
+  });
+
+  it('parses 2-digit years', () => {
+    expect(parseDate('15/03/24')).toBe('2024-03-15');
+  });
+
+  it('parses textual English months', () => {
+    expect(parseDate('15 March 2024')).toBe('2024-03-15');
+  });
+
+  it('parses textual Italian months', () => {
+    expect(parseDate('15 marzo 2024')).toBe('2024-03-15');
+  });
+
+  it('returns null for invalid dates', () => {
+    expect(parseDate('99/99/9999')).toBeNull();
+    expect(parseDate('not a date')).toBeNull();
+  });
+});
+
+describe('parseAmount', () => {
+  it('parses EU format', () => {
+    expect(parseAmount('1.234,56')).toBeCloseTo(1234.56);
+  });
+
+  it('parses US format', () => {
+    expect(parseAmount('1,234.56')).toBeCloseTo(1234.56);
+  });
+
+  it('parses plain numbers', () => {
+    expect(parseAmount('1234.56')).toBeCloseTo(1234.56);
+    expect(parseAmount('1234,56')).toBeCloseTo(1234.56);
+  });
+
+  it('handles currency symbols and labels', () => {
+    expect(parseAmount('Total: €1.234,56')).toBeCloseTo(1234.56);
+    expect(parseAmount('$1,234.56 USD')).toBeCloseTo(1234.56);
+  });
+
+  it('handles negative amounts', () => {
+    expect(parseAmount('-99,50')).toBeCloseTo(-99.5);
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(parseAmount('no numbers here')).toBeNull();
+  });
+});
+
+describe('detectCurrency', () => {
+  it('detects from ISO code', () => {
+    expect(detectCurrency('Subtotal: 100 EUR')).toBe('EUR');
+    expect(detectCurrency('Subtotal: 100 USD')).toBe('USD');
+  });
+
+  it('detects from symbol', () => {
+    expect(detectCurrency('Total €123,45')).toBe('EUR');
+    expect(detectCurrency('Total $123.45')).toBe('USD');
+    expect(detectCurrency('Total £123.45')).toBe('GBP');
+  });
+
+  it('returns undefined when no signal', () => {
+    expect(detectCurrency('1234.56')).toBeUndefined();
+  });
+});
+
+describe('autoDetectDocType', () => {
+  it('detects payslip from net pay keyword', () => {
+    expect(autoDetectDocType('Pay statement\nGross pay: 3000\nNet pay: 2300')).toBe('payslip');
+  });
+
+  it('detects invoice from invoice number keyword', () => {
+    expect(autoDetectDocType('INVOICE\nInvoice number: 42\nInvoice date: 2024-03-15')).toBe('invoice');
+  });
+
+  it('detects receipt', () => {
+    expect(autoDetectDocType('Thank you for your purchase\nRECEIPT')).toBe('receipt');
+  });
+
+  it('detects bank statement', () => {
+    expect(autoDetectDocType('Account Statement\nOpening balance 1000\nClosing balance 950')).toBe('bank_statement');
+  });
+});
+
+describe('categorizeExpense', () => {
+  it('classifies groceries', () => {
+    expect(categorizeExpense('Esselunga SPA')).toEqual({ category: 'GROCERIES', expenseType: 'NEED' });
+  });
+
+  it('classifies dining out', () => {
+    expect(categorizeExpense('Ristorante La Pergola')).toEqual({ category: 'DINING_OUT', expenseType: 'WANT' });
+  });
+
+  it('classifies transportation', () => {
+    expect(categorizeExpense('Uber trip to airport')).toEqual({ category: 'TRANSPORTATION', expenseType: 'NEED' });
+  });
+
+  it('classifies subscriptions', () => {
+    expect(categorizeExpense('Netflix monthly')).toEqual({ category: 'SUBSCRIPTIONS', expenseType: 'WANT' });
+  });
+
+  it('falls back to NO_CATEGORY', () => {
+    expect(categorizeExpense('Some random merchant')).toEqual({ category: 'NO_CATEGORY', expenseType: 'WANT' });
+  });
+});
+
+describe('parseReceipt', () => {
+  it('extracts total + date + description', () => {
+    const extracted = makeExtracted('grocery.pdf', [
+      'ESSELUNGA SPA',
+      'Via Roma 10, Milano',
+      '15/03/2024 12:34',
+      'Pasta 2,50',
+      'Bread 1,80',
+      'Tomatoes 3,20',
+      'TOTAL €7,50',
+    ]);
+    const result = parseReceipt(extracted);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('expense');
+    expect(result[0].amount).toBeCloseTo(7.5);
+    expect(result[0].date).toBe('2024-03-15');
+    expect(result[0].currency).toBe('EUR');
+    expect(result[0].suggestedCategory).toBe('GROCERIES');
+    expect(result[0].suggestedExpenseType).toBe('NEED');
+  });
+
+  it('returns empty when no total found', () => {
+    const extracted = makeExtracted('blank.pdf', ['Some line', 'Another line']);
+    expect(parseReceipt(extracted)).toHaveLength(0);
+  });
+});
+
+describe('parseInvoice', () => {
+  it('extracts grand total preferentially', () => {
+    const extracted = makeExtracted('invoice.pdf', [
+      'ACME Corp',
+      'Invoice number: 42',
+      'Invoice date: 2024-03-15',
+      'Subtotal: 1000,00',
+      'VAT: 220,00',
+      'Grand total: €1.220,00',
+    ]);
+    const result = parseInvoice(extracted);
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBeCloseTo(1220);
+    expect(result[0].date).toBe('2024-03-15');
+    expect(result[0].kind).toBe('expense');
+  });
+});
+
+describe('parsePayslip', () => {
+  it('extracts net pay as income', () => {
+    const extracted = makeExtracted('payslip.pdf', [
+      'ACME Inc - Payroll',
+      'Pay period: March 2024',
+      '15/03/2024',
+      'Gross pay: 4000,00',
+      'Taxes: -1200,00',
+      'Net pay: 2.800,00 EUR',
+    ]);
+    const result = parsePayslip(extracted);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('income');
+    expect(result[0].amount).toBeCloseTo(2800);
+    expect(result[0].suggestedIncomeSource).toBe('SALARY');
+    expect(result[0].currency).toBe('EUR');
+  });
+
+  it('extracts Italian "Importo netto"', () => {
+    const extracted = makeExtracted('busta.pdf', [
+      'Busta Paga - Marzo 2024',
+      'Stipendio lordo: 4.000,00',
+      'Importo netto: 2.500,00',
+    ]);
+    const result = parsePayslip(extracted);
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBeCloseTo(2500);
+  });
+
+  it('returns empty when no net pay line is found', () => {
+    const extracted = makeExtracted('nope.pdf', ['no payroll info here']);
+    expect(parsePayslip(extracted)).toHaveLength(0);
+  });
+});
+
+describe('parseBankStatement', () => {
+  it('parses rows with signed amounts', () => {
+    const extracted = makeExtracted('statement.pdf', [
+      'Account statement 2024',
+      'Opening balance: 1.000,00',
+      '01/03/2024 Stipendio acme spa 2.500,00',
+      '03/03/2024 Esselunga -45,30',
+      '10/03/2024 Netflix -12,99',
+      'Closing balance: 3.441,71',
+    ]);
+    const result = parseBankStatement(extracted);
+    expect(result).toHaveLength(3);
+    const [salary, groceries, netflix] = result;
+    expect(salary.kind).toBe('income');
+    expect(salary.amount).toBeCloseTo(2500);
+    expect(salary.suggestedIncomeSource).toBe('SALARY');
+    expect(groceries.kind).toBe('expense');
+    expect(groceries.amount).toBeCloseTo(45.3);
+    expect(groceries.suggestedCategory).toBe('GROCERIES');
+    expect(netflix.suggestedCategory).toBe('SUBSCRIPTIONS');
+  });
+
+  it('uses keyword hints when amounts are unsigned', () => {
+    const extracted = makeExtracted('statement.pdf', [
+      'Statement 2024',
+      '05/03/2024 Pagamento POS Esselunga 45,30',
+      '20/03/2024 Bonifico in entrata stipendio 2500,00',
+    ]);
+    const result = parseBankStatement(extracted);
+    expect(result.find(r => r.description.includes('Esselunga'))?.kind).toBe('expense');
+    expect(result.find(r => r.description.includes('stipendio'))?.kind).toBe('income');
+  });
+
+  it('infers year from statement header for short dates', () => {
+    const extracted = makeExtracted('s.pdf', [
+      'Account statement 2023',
+      '05/03 Coffee shop 4,50',
+    ]);
+    const result = parseBankStatement(extracted);
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe('2023-03-05');
+  });
+});
+
+describe('parsePdf dispatcher', () => {
+  it('auto-detects and routes to the correct parser', () => {
+    const extracted = makeExtracted('p.pdf', [
+      'Pay statement March',
+      'Net pay: 2000,00 USD',
+      '15/03/2024',
+    ]);
+    const { drafts, resolvedDocType } = parsePdf(extracted, 'auto');
+    expect(resolvedDocType).toBe('payslip');
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].kind).toBe('income');
+  });
+
+  it('honors explicit doc type', () => {
+    const extracted = makeExtracted('r.pdf', [
+      'Cafe Roma',
+      '15/03/2024',
+      'TOTAL €6,50',
+    ]);
+    const { resolvedDocType } = parsePdf(extracted, 'receipt');
+    expect(resolvedDocType).toBe('receipt');
+  });
+
+  it('passes through fallback currency', () => {
+    const extracted = makeExtracted('p.pdf', [
+      'Cafe Roma',
+      '15/03/2024',
+      'TOTAL 6,50',
+    ]);
+    const { drafts } = parsePdf(extracted, 'receipt', 'GBP');
+    expect(drafts[0].currency).toBe('GBP');
+  });
+});


### PR DESCRIPTION
Closes #207.

## What

Opt-in **experimental feature** that lets users upload PDFs (receipts, invoices, bank / credit-card statements, payslips) and turn them into Expense Tracker transactions after a review step.

## How

- **Client-side text extraction** with \`pdfjs-dist\` (dynamic import — only loaded when needed, keeps jsdom tests happy).
- **Heuristic parsers** per doc-type plus an auto-detect dispatcher (\`src/utils/pdfHeuristics.ts\`).
- **Optional LLM categorization** via OpenAI-compatible \`/chat/completions\` endpoint (\`src/utils/llmCategorizer.ts\`). Works with OpenAI, Azure OpenAI, Ollama, LM Studio, OpenRouter, etc.
- **PDFImportDialog** with editable preview table, per-row include/exclude, low-confidence highlighting.
- **Settings**: new \`pdfImport\` experimental flag + LLM config (base URL / API key / model), stored encrypted with the rest of user settings.

## Privacy posture

- No PDF bytes ever leave the device.
- The LLM step only runs when the user has configured an endpoint **and** ticks *Use AI categorization* for that import. Only the extracted descriptions / amounts / currencies are sent; if anything fails (HTTP error, bad JSON, timeout) the heuristic results are used unchanged.

## Tests

- 50 new tests covering date/amount parsing, currency detection, auto-detect, all four doc-type parsers, dispatcher, LLM categorizer (mocked fetch + error fallback + code-fence stripping), and dialog flow (extractor errors, exclude row, AI toggle).
- Full suite: **1034 passing**.
- \`npm run build\` succeeds; pdfjs is code-split into its own chunk.

## Docs

- \`docs/pdf-import.md\` covers usage, supported doc types, privacy, troubleshooting, example LLM endpoints.
- README updated with a new bullet under Experimental Features.