### PR TITLE
feat(website): add legal and attribution section to footer

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -168,7 +168,14 @@
     </main>
 
     <footer class="site-footer">
-      <p>MIT-licensed · Built by <a href="https://github.com/mbianchidev" rel="noopener">@mbianchidev</a> and contributors.</p>
+      <nav class="footer-legal" aria-label="Legal">
+        <a href="./demo/privacy-policy">Privacy Policy</a>
+        <span class="footer-sep" aria-hidden="true">·</span>
+        <a href="./demo/cookie-policy">Cookie Policy</a>
+      </nav>
+      <p class="footer-attrib">
+        Radically OSS. MIT license · Built by <a href="https://github.com/mbianchidev" rel="noopener">@mbianchidev</a>
+      </p>
     </footer>
   </body>
 </html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -265,3 +265,21 @@ main { max-width: 1100px; margin: 0 auto; padding: 3rem 1.5rem; }
   border-top: 1px solid var(--border);
   font-size: 0.9rem;
 }
+
+.footer-legal {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.footer-sep {
+  color: var(--muted);
+  opacity: 0.6;
+}
+
+.footer-attrib {
+  margin: 0;
+}


### PR DESCRIPTION
Closes #232.

Mirrors the app's policy links on the landing page footer and adds the project attribution line.

## Changes
- `website/index.html`: Footer now contains a legal nav (Privacy Policy · Cookie Policy) and an attribution paragraph.
- `website/styles.css`: Added `.footer-legal`, `.footer-sep`, `.footer-attrib` rules.

## Behavior
- Policy links use relative paths `./demo/privacy-policy` and `./demo/cookie-policy`, which resolve to the SPA routes both in production (`/fire-tools/demo/...`) and in local preview.
- Attribution: `Radically OSS. MIT license · Built by @mbianchidev` (GitHub profile link).

## Test
Static page, no automated tests. Verified by inspecting rendered HTML/CSS locally (`python3 -m http.server` in `website/`).