### PR TITLE
Enforce English-only navbar labels (#233)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import './components/GuidedTour.css';
 import './components/NotificationBell.css';
 import { MaterialIcon } from './components/MaterialIcon';
 import { FireIcon } from './components/FireIcon';
+import { NAVBAR_LABELS } from './constants/navbarLabels';
 
 // Context for policy modal
 interface PolicyModalContextType {
@@ -57,80 +58,81 @@ export const usePolicyModal = () => useContext(PolicyModalContext);
 
 function Navigation({ accountName, showPortfolioBreakdown }: { accountName: string; showPortfolioBreakdown: boolean }) {
   const location = useLocation();
-  const { t } = useTranslation();
+  // Navbar labels are intentionally NOT routed through useTranslation — they
+  // must always render in English. See src/constants/navbarLabels.ts (#233).
   const [isOpen, setIsOpen] = useState(false);
-  
+
   const toggleMenu = () => setIsOpen(!isOpen);
   const closeMenu = () => setIsOpen(false);
-  
+
   return (
-    <nav className="app-nav" aria-label={t('nav.label')}>
-      <button 
-        className="nav-toggle" 
-        onClick={toggleMenu} 
-        aria-label={t('nav.toggle')}
+    <nav className="app-nav" aria-label={NAVBAR_LABELS.ariaLabel}>
+      <button
+        className="nav-toggle"
+        onClick={toggleMenu}
+        aria-label={NAVBAR_LABELS.toggle}
         aria-expanded={isOpen}
       >
         {isOpen ? <MaterialIcon name="close" /> : <MaterialIcon name="menu" />}
       </button>
       <div className={`nav-links ${isOpen ? 'open' : ''}`}>
-        <Link 
-          to="/" 
+        <Link
+          to="/"
           className={`nav-link ${location.pathname === '/' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/' ? 'page' : undefined}
         >
-          <MaterialIcon name="home" className="nav-icon" /> {t('nav.home')}
+          <MaterialIcon name="home" className="nav-icon" /> {NAVBAR_LABELS.home}
         </Link>
-        <Link 
-          to="/asset-allocation" 
+        <Link
+          to="/asset-allocation"
           className={`nav-link ${location.pathname === '/asset-allocation' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/asset-allocation' ? 'page' : undefined}
         >
-          <MaterialIcon name="pie_chart" className="nav-icon" /> {t('nav.assetAllocation')}
+          <MaterialIcon name="pie_chart" className="nav-icon" /> {NAVBAR_LABELS.assetAllocation}
         </Link>
         {showPortfolioBreakdown && (
-          <Link 
-            to="/portfolio-breakdown" 
+          <Link
+            to="/portfolio-breakdown"
             className={`nav-link ${location.pathname === '/portfolio-breakdown' ? 'active' : ''}`}
             onClick={closeMenu}
             aria-current={location.pathname === '/portfolio-breakdown' ? 'page' : undefined}
           >
-            <MaterialIcon name="donut_large" className="nav-icon" /> {t('nav.portfolioBreakdown')}
+            <MaterialIcon name="donut_large" className="nav-icon" /> {NAVBAR_LABELS.portfolioBreakdown}
           </Link>
         )}
-        <Link 
-          to="/expense-tracker" 
+        <Link
+          to="/expense-tracker"
           className={`nav-link ${location.pathname === '/expense-tracker' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/expense-tracker' ? 'page' : undefined}
         >
-          <MaterialIcon name="account_balance_wallet" className="nav-icon" /> {t('nav.cashflow')}
+          <MaterialIcon name="account_balance_wallet" className="nav-icon" /> {NAVBAR_LABELS.cashflow}
         </Link>
-        <Link 
-          to="/net-worth-tracker" 
+        <Link
+          to="/net-worth-tracker"
           className={`nav-link ${location.pathname === '/net-worth-tracker' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/net-worth-tracker' ? 'page' : undefined}
         >
-          <MaterialIcon name="trending_up" className="nav-icon" /> {t('nav.netWorth')}
+          <MaterialIcon name="trending_up" className="nav-icon" /> {NAVBAR_LABELS.netWorth}
         </Link>
-        <Link 
-          to="/fire-calculator" 
+        <Link
+          to="/fire-calculator"
           className={`nav-link ${location.pathname === '/fire-calculator' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/fire-calculator' ? 'page' : undefined}
         >
-          <MaterialIcon name="local_fire_department" className="nav-icon" /> {t('nav.fireCalculator')}
+          <MaterialIcon name="local_fire_department" className="nav-icon" /> {NAVBAR_LABELS.fireCalculator}
         </Link>
-        <Link 
-          to="/monte-carlo" 
+        <Link
+          to="/monte-carlo"
           className={`nav-link ${location.pathname === '/monte-carlo' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/monte-carlo' ? 'page' : undefined}
         >
-          <MaterialIcon name="casino" className="nav-icon" /> {t('nav.monteCarlo')}
+          <MaterialIcon name="casino" className="nav-icon" /> {NAVBAR_LABELS.monteCarlo}
         </Link>
       </div>
       <div className="nav-actions">

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { MaterialIcon } from './MaterialIcon';
+import { NAVBAR_LABELS } from '../constants/navbarLabels';
 import './NotFoundPage.css';
 
 export function NotFoundPage() {
@@ -18,7 +19,8 @@ export function NotFoundPage() {
             <MaterialIcon name="home" /> {t('notFound.backHome')}
           </Link>
           <Link to="/fire-calculator" className="btn-calculator">
-            <MaterialIcon name="local_fire_department" /> {t('nav.fireCalculator')}
+            {/* Navbar label — English only by design (#233). */}
+            <MaterialIcon name="local_fire_department" /> {NAVBAR_LABELS.fireCalculator}
           </Link>
         </div>
         <div className="helpful-links">

--- a/src/constants/navbarLabels.ts
+++ b/src/constants/navbarLabels.ts
@@ -1,0 +1,31 @@
+/**
+ * Navbar labels — English ONLY. Do NOT localize.
+ *
+ * Per issue mbianchidev/fire-tools#233, the app navbar must always render in
+ * English regardless of the user's selected UI language. These strings are the
+ * single source of truth for the top-level navigation and any navbar-styled
+ * links that appear elsewhere (e.g. on the 404 page).
+ *
+ * Rules for contributors:
+ *  - NEVER pass these strings through `react-i18next` (`t(...)`) or any other
+ *    translation pipeline.
+ *  - NEVER add equivalent `nav.*` keys to `src/i18n/locales/*.json`.
+ *  - If a new top-level navbar entry is added, add it here in English and
+ *    consume the constant directly in JSX.
+ *
+ * A regression test in `tests/shared/navbarLabels.test.ts` enforces these
+ * rules at build time.
+ */
+export const NAVBAR_LABELS = {
+  ariaLabel: 'Main navigation',
+  toggle: 'Toggle navigation menu',
+  home: 'Home',
+  assetAllocation: 'Asset Allocation',
+  portfolioBreakdown: 'Portfolio Breakdown',
+  cashflow: 'Cashflow',
+  netWorth: 'Net Worth',
+  fireCalculator: 'FIRE Calculator',
+  monteCarlo: 'Monte Carlo',
+} as const;
+
+export type NavbarLabelKey = keyof typeof NAVBAR_LABELS;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -8,17 +8,6 @@
     "cookiePolicy": "Cookie-Richtlinie",
     "github": "GitHub"
   },
-  "nav": {
-    "label": "Hauptnavigation",
-    "toggle": "Navigationsmenü ein-/ausblenden",
-    "home": "Startseite",
-    "assetAllocation": "Asset-Allokation",
-    "portfolioBreakdown": "Portfolio-Aufschlüsselung",
-    "cashflow": "Cashflow",
-    "netWorth": "Nettovermögen",
-    "fireCalculator": "FIRE-Rechner",
-    "monteCarlo": "Monte Carlo"
-  },
   "common": {
     "save": "Speichern",
     "cancel": "Abbrechen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -8,17 +8,6 @@
     "cookiePolicy": "Cookie Policy",
     "github": "GitHub"
   },
-  "nav": {
-    "label": "Main navigation",
-    "toggle": "Toggle navigation menu",
-    "home": "Home",
-    "assetAllocation": "Asset Allocation",
-    "portfolioBreakdown": "Portfolio Breakdown",
-    "cashflow": "Cashflow",
-    "netWorth": "Net Worth",
-    "fireCalculator": "FIRE Calculator",
-    "monteCarlo": "Monte Carlo"
-  },
   "common": {
     "save": "Save",
     "cancel": "Cancel",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -8,17 +8,6 @@
     "cookiePolicy": "Política de cookies",
     "github": "GitHub"
   },
-  "nav": {
-    "label": "Navegación principal",
-    "toggle": "Mostrar u ocultar el menú",
-    "home": "Inicio",
-    "assetAllocation": "Asignación de activos",
-    "portfolioBreakdown": "Composición de la cartera",
-    "cashflow": "Flujo de caja",
-    "netWorth": "Patrimonio neto",
-    "fireCalculator": "Calculadora FIRE",
-    "monteCarlo": "Monte Carlo"
-  },
   "common": {
     "save": "Guardar",
     "cancel": "Cancelar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -8,17 +8,6 @@
     "cookiePolicy": "Politique relative aux cookies",
     "github": "GitHub"
   },
-  "nav": {
-    "label": "Navigation principale",
-    "toggle": "Afficher ou masquer le menu",
-    "home": "Accueil",
-    "assetAllocation": "Allocation d'actifs",
-    "portfolioBreakdown": "Répartition du portefeuille",
-    "cashflow": "Flux de trésorerie",
-    "netWorth": "Patrimoine net",
-    "fireCalculator": "Calculateur FIRE",
-    "monteCarlo": "Monte-Carlo"
-  },
   "common": {
     "save": "Enregistrer",
     "cancel": "Annuler",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -8,17 +8,6 @@
     "cookiePolicy": "Informativa sui cookie",
     "github": "GitHub"
   },
-  "nav": {
-    "label": "Navigazione principale",
-    "toggle": "Apri/chiudi il menu di navigazione",
-    "home": "Home",
-    "assetAllocation": "Allocazione del portafoglio",
-    "portfolioBreakdown": "Composizione del portafoglio",
-    "cashflow": "Flussi di cassa",
-    "netWorth": "Patrimonio netto",
-    "fireCalculator": "Calcolatore FIRE",
-    "monteCarlo": "Monte Carlo"
-  },
   "common": {
     "save": "Salva",
     "cancel": "Annulla",

--- a/tests/shared/navbarLabels.test.ts
+++ b/tests/shared/navbarLabels.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for issue mbianchidev/fire-tools#233.
+ *
+ * The app navbar must always render in English, regardless of the user's
+ * selected UI language. This is enforced by:
+ *  1. Centralising the labels in `src/constants/navbarLabels.ts`.
+ *  2. Forbidding any `t('nav.…')` (i18n) lookups in source.
+ *  3. Forbidding any `nav.*` keys in the locale JSON files.
+ *
+ * If this file fails, do NOT "fix" it by re-introducing translations — the
+ * navbar is intentionally non-localisable. Update the constants instead.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { NAVBAR_LABELS } from '../../src/constants/navbarLabels';
+import en from '../../src/i18n/locales/en.json';
+import itLocale from '../../src/i18n/locales/it.json';
+import fr from '../../src/i18n/locales/fr.json';
+import de from '../../src/i18n/locales/de.json';
+import es from '../../src/i18n/locales/es.json';
+
+const SELF_FILE = fileURLToPath(import.meta.url);
+const SRC_DIR = resolve(dirname(SELF_FILE), '../../src');
+
+const collectSourceFiles = (dir: string, acc: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) collectSourceFiles(full, acc);
+    else if (/\.(ts|tsx)$/.test(entry)) acc.push(full);
+  }
+  return acc;
+};
+
+const T_NAV_REGEX = /\bt\(\s*['"`]nav\./;
+
+describe('navbar is English-only (#233)', () => {
+  it('exposes the expected English labels via NAVBAR_LABELS', () => {
+    expect(NAVBAR_LABELS).toEqual({
+      ariaLabel: 'Main navigation',
+      toggle: 'Toggle navigation menu',
+      home: 'Home',
+      assetAllocation: 'Asset Allocation',
+      portfolioBreakdown: 'Portfolio Breakdown',
+      cashflow: 'Cashflow',
+      netWorth: 'Net Worth',
+      fireCalculator: 'FIRE Calculator',
+      monteCarlo: 'Monte Carlo',
+    });
+  });
+
+  it('no source file routes navbar strings through i18n (t("nav.…"))', () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles(SRC_DIR)) {
+      if (file === SELF_FILE) continue;
+      const content = readFileSync(file, 'utf-8');
+      if (T_NAV_REGEX.test(content)) offenders.push(file);
+    }
+    expect(
+      offenders,
+      `Files routing navbar labels through t('nav.…') — use NAVBAR_LABELS instead:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('no locale file defines a top-level `nav` block', () => {
+    const locales: Record<string, Record<string, unknown>> = {
+      en: en as Record<string, unknown>,
+      it: itLocale as Record<string, unknown>,
+      fr: fr as Record<string, unknown>,
+      de: de as Record<string, unknown>,
+      es: es as Record<string, unknown>,
+    };
+    for (const [name, data] of Object.entries(locales)) {
+      expect(
+        Object.prototype.hasOwnProperty.call(data, 'nav'),
+        `Locale "${name}" must not define a "nav" block — navbar labels live in src/constants/navbarLabels.ts`,
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #233.

## What

Make the app navbar always render in English regardless of the user's selected UI language, and add code-level guardrails so future contributors can't accidentally localize it again.

## Changes

- **New `src/constants/navbarLabels.ts`** — single source of truth for navbar strings (`NAVBAR_LABELS`), English-only, with an explanatory header comment referencing this issue and forbidding routing them through `react-i18next`.
- **`src/App.tsx`** — the `Navigation` component now consumes `NAVBAR_LABELS` instead of `t('nav.*')`. Removed the `useTranslation()` call from `Navigation` (the import stays — it's still used by other components in the file for page chrome / footer strings).
- **`src/components/NotFoundPage.tsx`** — the 404 page's "FIRE Calculator" CTA also previously read `t('nav.fireCalculator')`; switched to the same constant so it stays in sync.
- **`src/i18n/locales/{en,it,fr,de,es}.json`** — removed the entire `nav` block from all five locale files so the keys simply don't exist anymore. The existing `tests/shared/i18n.test.ts` key-parity invariant still holds because all five lost the same block.
- **`tests/shared/navbarLabels.test.ts`** — new regression test that asserts (a) `NAVBAR_LABELS` matches the expected English values, (b) no source file under `src/` calls `t('nav.…')`, and (c) no locale file has a top-level `nav` key.

## Scope notes

- The issue specifically calls out *navbar items (menu labels, links)*. The `ProfileMenu` / `NotificationBell` dropdowns rendered next to the navbar contain sub-UI (notifications list, settings shortcut, etc.) and were left localized. Happy to broaden enforcement in a follow-up if that's preferred.
- Other `t('app.*')` calls in `App.tsx` (skip link, page title, tagline, footer disclaimer / privacy policy) are non-navbar page chrome and were intentionally left localized.

## Validation

- `npm run build` — clean.
- `npm test` — 1051/1051 tests pass, including the new regression suite and the existing locale key-parity test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>