### PR TITLE
feat: add About section and fix backend version reporting (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Back up your data anytime with CSV export. Import previously saved data to resto
 **🌍 Multi-language UI**  
 The interface ships in English (default), Italian, French, German, and Spanish. Change the language from **Settings → Language**; the choice is stored alongside your other (encrypted) preferences and is independent of the display currency. See [Internationalization (i18n)](#-internationalization-i18n) for coverage details.
 
+**ℹ️ About / Build Info**
+A built-in **Settings → About** section shows the running app version, the git commit hash the build was produced from (with a link to GitHub), the build timestamp, and the versions of major dependencies (React, Vite, Recharts, etc.). When the local backend is reachable, it also surfaces the backend's version and its own dependency set (Express, better-sqlite3, …) — useful for filing bug reports and confirming the frontend and backend are running the same release.
+
 ---
 
 ## 🚀 Quick Start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     build:
       context: .
       dockerfile: server/Dockerfile
+      args:
+        GIT_COMMIT_HASH: ${GIT_COMMIT_HASH:-unknown}
+        BUILD_TIME: ${BUILD_TIME:-}
     image: firetools/backend:dev
     environment:
       NODE_ENV: production
@@ -35,6 +38,9 @@ services:
     build:
       context: .
       dockerfile: docker/frontend.Dockerfile
+      args:
+        GIT_COMMIT_HASH: ${GIT_COMMIT_HASH:-unknown}
+        BUILD_TIME: ${BUILD_TIME:-}
     image: firetools/frontend:dev
     depends_on:
       backend:

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -2,6 +2,10 @@
 # Build context MUST be the repo root (see docker-compose.yml).
 
 FROM node:22-bookworm-slim AS build
+ARG GIT_COMMIT_HASH=unknown
+ARG BUILD_TIME
+ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
+    BUILD_TIME=${BUILD_TIME}
 WORKDIR /app
 
 # Install deps first to leverage Docker layer cache. Skip lifecycle scripts —

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fire-tools",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,11 +12,15 @@ COPY server/src ./src
 RUN npm run build
 
 FROM node:22-bookworm-slim AS runtime
+ARG GIT_COMMIT_HASH=unknown
+ARG BUILD_TIME
 ENV NODE_ENV=production \
     PORT=8787 \
     HOST=0.0.0.0 \
     DATABASE_URL=file:/data/firetools.db \
-    MIGRATIONS_PATH=/app/migrations
+    MIGRATIONS_PATH=/app/migrations \
+    GIT_COMMIT_HASH=${GIT_COMMIT_HASH} \
+    BUILD_TIME=${BUILD_TIME}
 WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates dumb-init \

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fire-tools-server",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fire-tools-server",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "better-sqlite3": "^11.3.0",
         "cors": "^2.8.5",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire-tools-server",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Local-deployment backend for Fire Tools (SQLite-first, Postgres-compatible). Implements docs/api/openapi.yaml.",
   "private": true,
   "type": "module",

--- a/server/src/buildInfo.ts
+++ b/server/src/buildInfo.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface BuildInfo {
+  version: string;
+  commit: string;
+  buildTime: string | null;
+  dependencies: Record<string, string>;
+}
+
+const FALLBACK_VERSION = '0.0.0';
+const FALLBACK_COMMIT = 'unknown';
+
+const loadPackageJson = (): {
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+} => {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // From src/ (dev) or dist/ (runtime) walk up to the directory containing package.json.
+    const candidates = [
+      resolve(here, '..', 'package.json'),
+      resolve(here, '..', '..', 'package.json'),
+    ];
+    for (const candidate of candidates) {
+      try {
+        const raw = readFileSync(candidate, 'utf-8');
+        return JSON.parse(raw);
+      } catch {
+        // try next candidate
+      }
+    }
+  } catch (err) {
+    console.error('[buildInfo] failed to read package.json:', (err as Error).message);
+  }
+  return {};
+};
+
+const pickDependencies = (
+  pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> },
+): Record<string, string> => {
+  const all = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+  const wanted = ['better-sqlite3', 'express', 'cors', 'express-rate-limit', 'zod', 'typescript'];
+  const out: Record<string, string> = {};
+  for (const name of wanted) {
+    if (all[name]) out[name] = all[name];
+  }
+  return out;
+};
+
+let cached: BuildInfo | null = null;
+
+export const getBuildInfo = (): BuildInfo => {
+  if (cached) return cached;
+  const pkg = loadPackageJson();
+  const version = pkg.version ?? process.env.npm_package_version ?? FALLBACK_VERSION;
+  const commit =
+    process.env.GIT_COMMIT_HASH ?? process.env.GIT_COMMIT ?? FALLBACK_COMMIT;
+  const buildTime = process.env.BUILD_TIME ?? null;
+  cached = {
+    version,
+    commit,
+    buildTime,
+    dependencies: pickDependencies(pkg),
+  };
+  return cached;
+};

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import type { Database } from 'better-sqlite3';
+import { getBuildInfo } from '../buildInfo.js';
 
 export const buildHealthRouter = (db: Database, dbPath: string): Router => {
   const router = Router();
@@ -7,10 +8,14 @@ export const buildHealthRouter = (db: Database, dbPath: string): Router => {
   router.get('/health', (_req: Request, res: Response) => {
     try {
       const row = db.prepare('SELECT 1 AS ok').get() as { ok: number };
+      const info = getBuildInfo();
       res.json({
         status: row.ok === 1 ? 'ok' : 'degraded',
         database: { driver: 'sqlite', path: dbPath, ok: row.ok === 1 },
-        version: process.env.npm_package_version ?? '0.0.0',
+        version: info.version,
+        commit: info.commit,
+        buildTime: info.buildTime,
+        dependencies: info.dependencies,
       });
     } catch (err) {
       res.status(503).json({

--- a/src/components/AboutSection.css
+++ b/src/components/AboutSection.css
@@ -49,9 +49,11 @@
 
 .about-grid code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  background: var(--code-bg, #f3f4f6);
-  padding: 0.1rem 0.35rem;
-  border-radius: 3px;
+  background: var(--bg-tertiary, #f3f4f6);
+  color: var(--text-primary, #111);
+  border: 1px solid var(--border-subtle, transparent);
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
   font-size: 0.9rem;
 }
 
@@ -64,7 +66,7 @@
 }
 
 .about-status-error {
-  color: var(--color-error, #b91c1c);
+  color: var(--error, #b91c1c);
 }
 
 .about-deps-table {
@@ -76,7 +78,7 @@
 .about-deps-table td {
   text-align: left;
   padding: 0.35rem 0.5rem;
-  border-bottom: 1px solid var(--border-color, #e5e7eb);
+  border-bottom: 1px solid var(--border-subtle, #e5e7eb);
 }
 
 .about-deps-table th {
@@ -88,8 +90,9 @@
 .about-dep-tag {
   display: inline-block;
   font-size: 0.7rem;
-  background: var(--badge-bg, #e0e7ff);
-  color: var(--badge-fg, #3730a3);
+  background: var(--bg-elevated, #e0e7ff);
+  color: var(--accent-primary, #3730a3);
+  border: 1px solid var(--border-subtle, transparent);
   padding: 0.05rem 0.4rem;
   border-radius: 999px;
   margin-left: 0.3rem;

--- a/src/components/AboutSection.css
+++ b/src/components/AboutSection.css
@@ -1,0 +1,97 @@
+.about-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.about-header,
+.about-subheader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.about-header h3,
+.about-subheader h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.about-subheader {
+  margin-top: 0.75rem;
+}
+
+.about-refresh-btn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.6rem;
+}
+
+.about-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4rem 1rem;
+  margin: 0;
+}
+
+.about-grid dt {
+  font-weight: 600;
+  color: var(--text-secondary, #555);
+}
+
+.about-grid dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.about-grid code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  background: var(--code-bg, #f3f4f6);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.9rem;
+}
+
+.about-status {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-secondary, #555);
+}
+
+.about-status-error {
+  color: var(--color-error, #b91c1c);
+}
+
+.about-deps-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.about-deps-table th,
+.about-deps-table td {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
+.about-deps-table th {
+  font-weight: 600;
+  color: var(--text-secondary, #555);
+  font-size: 0.85rem;
+}
+
+.about-dep-tag {
+  display: inline-block;
+  font-size: 0.7rem;
+  background: var(--badge-bg, #e0e7ff);
+  color: var(--badge-fg, #3730a3);
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  margin-left: 0.3rem;
+  vertical-align: middle;
+}

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { buildInfo, formatCommit } from '../utils/buildInfo';
+import { getApiBaseUrl } from '../utils/apiBase';
+import { MaterialIcon } from './MaterialIcon';
+import './AboutSection.css';
+
+interface BackendInfo {
+  version?: string;
+  commit?: string;
+  buildTime?: string | null;
+  dependencies?: Record<string, string>;
+}
+
+type BackendStatus =
+  | { state: 'idle' }
+  | { state: 'loading' }
+  | { state: 'ok'; info: BackendInfo }
+  | { state: 'unreachable'; error: string };
+
+const COMMIT_URL_BASE = 'https://github.com/mbianchidev/fire-tools/commit/';
+
+export const AboutSection: React.FC = () => {
+  const { t } = useTranslation();
+  const [backend, setBackend] = useState<BackendStatus>({ state: 'idle' });
+
+  const loadBackend = async () => {
+    setBackend({ state: 'loading' });
+    try {
+      const base = await getApiBaseUrl();
+      if (!base) {
+        setBackend({ state: 'unreachable', error: t('about.backendUnreachable') });
+        return;
+      }
+      const res = await fetch(`${base}/health`);
+      if (!res.ok) {
+        setBackend({ state: 'unreachable', error: `HTTP ${res.status}` });
+        return;
+      }
+      const info = (await res.json()) as BackendInfo;
+      setBackend({ state: 'ok', info });
+    } catch (err) {
+      setBackend({ state: 'unreachable', error: (err as Error).message });
+    }
+  };
+
+  useEffect(() => {
+    void loadBackend();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const commitShort = formatCommit(buildInfo.commit);
+  const commitIsKnown = buildInfo.commit && buildInfo.commit !== 'unknown';
+  const deps = Object.entries(buildInfo.dependencies);
+
+  return (
+    <div className="about-section">
+      <div className="about-header">
+        <MaterialIcon name="info" />
+        <h3>{t('about.appInfo')}</h3>
+      </div>
+
+      <dl className="about-grid">
+        <dt>{t('about.appVersion')}</dt>
+        <dd data-testid="about-app-version">{buildInfo.version}</dd>
+
+        <dt>{t('about.commit')}</dt>
+        <dd data-testid="about-commit">
+          {commitIsKnown ? (
+            <a
+              href={`${COMMIT_URL_BASE}${buildInfo.commit}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={buildInfo.commit}
+            >
+              <code>{commitShort}</code>
+            </a>
+          ) : (
+            <code>{t('common.notAvailable')}</code>
+          )}
+        </dd>
+
+        {buildInfo.buildTime && (
+          <>
+            <dt>{t('about.buildTime')}</dt>
+            <dd data-testid="about-build-time">
+              <code>{buildInfo.buildTime}</code>
+            </dd>
+          </>
+        )}
+      </dl>
+
+      <div className="about-subheader">
+        <MaterialIcon name="dns" />
+        <h3>{t('about.backendInfo')}</h3>
+        <button
+          type="button"
+          className="secondary-btn about-refresh-btn"
+          onClick={() => void loadBackend()}
+          disabled={backend.state === 'loading'}
+        >
+          <MaterialIcon name="refresh" /> {t('about.refresh')}
+        </button>
+      </div>
+
+      {backend.state === 'loading' && (
+        <p className="about-status">{t('common.loading')}</p>
+      )}
+      {backend.state === 'unreachable' && (
+        <p className="about-status about-status-error" data-testid="about-backend-error">
+          <MaterialIcon name="error" /> {backend.error}
+        </p>
+      )}
+      {backend.state === 'ok' && (
+        <dl className="about-grid">
+          <dt>{t('about.backendVersion')}</dt>
+          <dd data-testid="about-backend-version">{backend.info.version ?? t('common.notAvailable')}</dd>
+
+          {backend.info.commit && (
+            <>
+              <dt>{t('about.commit')}</dt>
+              <dd>
+                {backend.info.commit !== 'unknown' ? (
+                  <a
+                    href={`${COMMIT_URL_BASE}${backend.info.commit}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={backend.info.commit}
+                  >
+                    <code>{formatCommit(backend.info.commit)}</code>
+                  </a>
+                ) : (
+                  <code>{t('common.notAvailable')}</code>
+                )}
+              </dd>
+            </>
+          )}
+
+          {backend.info.buildTime && (
+            <>
+              <dt>{t('about.buildTime')}</dt>
+              <dd>
+                <code>{backend.info.buildTime}</code>
+              </dd>
+            </>
+          )}
+        </dl>
+      )}
+
+      <div className="about-subheader">
+        <MaterialIcon name="extension" />
+        <h3>{t('about.dependencies')}</h3>
+      </div>
+      {deps.length === 0 ? (
+        <p className="about-status">{t('common.notAvailable')}</p>
+      ) : (
+        <table className="about-deps-table" data-testid="about-dependencies">
+          <thead>
+            <tr>
+              <th>{t('about.dependencyName')}</th>
+              <th>{t('about.dependencyVersion')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {deps.map(([name, version]) => (
+              <tr key={name}>
+                <td><code>{name}</code></td>
+                <td><code>{version}</code></td>
+              </tr>
+            ))}
+            {backend.state === 'ok' && backend.info.dependencies
+              ? Object.entries(backend.info.dependencies)
+                  .filter(([name]) => !buildInfo.dependencies[name])
+                  .map(([name, version]) => (
+                    <tr key={`backend-${name}`}>
+                      <td>
+                        <code>{name}</code>{' '}
+                        <span className="about-dep-tag">{t('about.backendDepTag')}</span>
+                      </td>
+                      <td><code>{version}</code></td>
+                    </tr>
+                  ))
+              : null}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { buildInfo, formatCommit } from '../utils/buildInfo';
+import { buildInfo, formatCommit, buildCommitUrl } from '../utils/buildInfo';
 import { getApiBaseUrl } from '../utils/apiBase';
 import { MaterialIcon } from './MaterialIcon';
+import { CopyableValue } from './CopyableValue';
 import './AboutSection.css';
 
 interface BackendInfo {
@@ -17,8 +18,6 @@ type BackendStatus =
   | { state: 'loading' }
   | { state: 'ok'; info: BackendInfo }
   | { state: 'unreachable'; error: string };
-
-const COMMIT_URL_BASE = 'https://github.com/mbianchidev/fire-tools/commit/';
 
 export const AboutSection: React.FC = () => {
   const { t } = useTranslation();
@@ -50,7 +49,8 @@ export const AboutSection: React.FC = () => {
   }, []);
 
   const commitShort = formatCommit(buildInfo.commit);
-  const commitIsKnown = buildInfo.commit && buildInfo.commit !== 'unknown';
+  const commitIsKnown = Boolean(buildInfo.commit) && buildInfo.commit !== 'unknown';
+  const frontendCommitUrl = buildCommitUrl(buildInfo.repoUrl, buildInfo.commit);
   const deps = Object.entries(buildInfo.dependencies);
 
   return (
@@ -62,19 +62,25 @@ export const AboutSection: React.FC = () => {
 
       <dl className="about-grid">
         <dt>{t('about.appVersion')}</dt>
-        <dd data-testid="about-app-version">{buildInfo.version}</dd>
+        <dd data-testid="about-app-version">
+          <CopyableValue value={buildInfo.version} />
+        </dd>
 
         <dt>{t('about.commit')}</dt>
         <dd data-testid="about-commit">
           {commitIsKnown ? (
-            <a
-              href={`${COMMIT_URL_BASE}${buildInfo.commit}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={buildInfo.commit}
-            >
-              <code>{commitShort}</code>
-            </a>
+            frontendCommitUrl ? (
+              <a
+                href={frontendCommitUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={buildInfo.commit}
+              >
+                <code>{commitShort}</code>
+              </a>
+            ) : (
+              <code title={buildInfo.commit}>{commitShort}</code>
+            )
           ) : (
             <code>{t('common.notAvailable')}</code>
           )}
@@ -114,21 +120,39 @@ export const AboutSection: React.FC = () => {
       {backend.state === 'ok' && (
         <dl className="about-grid">
           <dt>{t('about.backendVersion')}</dt>
-          <dd data-testid="about-backend-version">{backend.info.version ?? t('common.notAvailable')}</dd>
+          <dd data-testid="about-backend-version">
+            {backend.info.version ? (
+              <CopyableValue value={backend.info.version} />
+            ) : (
+              t('common.notAvailable')
+            )}
+          </dd>
 
           {backend.info.commit && (
             <>
               <dt>{t('about.commit')}</dt>
               <dd>
                 {backend.info.commit !== 'unknown' ? (
-                  <a
-                    href={`${COMMIT_URL_BASE}${backend.info.commit}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={backend.info.commit}
-                  >
-                    <code>{formatCommit(backend.info.commit)}</code>
-                  </a>
+                  (() => {
+                    const backendCommitUrl = buildCommitUrl(
+                      buildInfo.repoUrl,
+                      backend.info.commit,
+                    );
+                    return backendCommitUrl ? (
+                      <a
+                        href={backendCommitUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={backend.info.commit}
+                      >
+                        <code>{formatCommit(backend.info.commit)}</code>
+                      </a>
+                    ) : (
+                      <code title={backend.info.commit}>
+                        {formatCommit(backend.info.commit)}
+                      </code>
+                    );
+                  })()
                 ) : (
                   <code>{t('common.notAvailable')}</code>
                 )}
@@ -165,7 +189,7 @@ export const AboutSection: React.FC = () => {
             {deps.map(([name, version]) => (
               <tr key={name}>
                 <td><code>{name}</code></td>
-                <td><code>{version}</code></td>
+                <td><CopyableValue value={version} /></td>
               </tr>
             ))}
             {backend.state === 'ok' && backend.info.dependencies
@@ -177,7 +201,7 @@ export const AboutSection: React.FC = () => {
                         <code>{name}</code>{' '}
                         <span className="about-dep-tag">{t('about.backendDepTag')}</span>
                       </td>
-                      <td><code>{version}</code></td>
+                      <td><CopyableValue value={version} /></td>
                     </tr>
                   ))
               : null}

--- a/src/components/CopyableValue.css
+++ b/src/components/CopyableValue.css
@@ -18,21 +18,23 @@
 }
 
 .copyable-value:focus-visible {
-  outline: 2px solid var(--color-accent, #3b82f6);
+  outline: 2px solid var(--accent-primary, #3b82f6);
   outline-offset: 2px;
 }
 
 .copyable-value code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  background: var(--code-bg, #f3f4f6);
-  padding: 0.1rem 0.35rem;
-  border-radius: 3px;
+  background: var(--bg-tertiary, #f3f4f6);
+  color: var(--text-primary, #111);
+  border: 1px solid var(--border-subtle, transparent);
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
   font-size: 0.9rem;
 }
 
 .copyable-value-feedback {
   font-size: 0.7rem;
-  color: var(--color-success, #047857);
+  color: var(--success, #047857);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;

--- a/src/components/CopyableValue.css
+++ b/src/components/CopyableValue.css
@@ -1,0 +1,44 @@
+.copyable-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.copyable-value:hover code {
+  outline: 1px dashed var(--text-secondary, #888);
+  outline-offset: 1px;
+}
+
+.copyable-value:focus-visible {
+  outline: 2px solid var(--color-accent, #3b82f6);
+  outline-offset: 2px;
+}
+
+.copyable-value code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  background: var(--code-bg, #f3f4f6);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.9rem;
+}
+
+.copyable-value-feedback {
+  font-size: 0.7rem;
+  color: var(--color-success, #047857);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  min-width: 0;
+}
+
+.copyable-value:not(.copyable-value--copied) .copyable-value-feedback:empty {
+  display: none;
+}

--- a/src/components/CopyableValue.test.tsx
+++ b/src/components/CopyableValue.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CopyableValue } from './CopyableValue';
+
+describe('CopyableValue', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('renders the value inside a button', () => {
+    render(<CopyableValue value="1.2.3" />);
+    const btn = screen.getByRole('button');
+    expect(btn.textContent).toContain('1.2.3');
+  });
+
+  it('writes the value to the clipboard on click', async () => {
+    render(<CopyableValue value="1.2.3" />);
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('1.2.3');
+    });
+  });
+
+  it('shows a "copied" indicator after a successful copy', async () => {
+    render(<CopyableValue value="abc" />);
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByRole('button').className).toMatch(/copyable-value--copied/);
+    });
+  });
+});

--- a/src/components/CopyableValue.tsx
+++ b/src/components/CopyableValue.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import './CopyableValue.css';
+
+interface CopyableValueProps {
+  value: string;
+  label?: string;
+  className?: string;
+  title?: string;
+  'data-testid'?: string;
+}
+
+const writeToClipboard = async (text: string): Promise<boolean> => {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to legacy path
+  }
+  if (typeof document === 'undefined') return false;
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+};
+
+export const CopyableValue: React.FC<CopyableValueProps> = ({
+  value,
+  label,
+  className,
+  title,
+  'data-testid': testId,
+}) => {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    const ok = await writeToClipboard(value);
+    if (!ok) return;
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  }, [value]);
+
+  const tooltip = copied
+    ? t('common.copied')
+    : title ?? t('common.copyToClipboard');
+
+  return (
+    <button
+      type="button"
+      className={`copyable-value${copied ? ' copyable-value--copied' : ''}${className ? ` ${className}` : ''}`}
+      onClick={() => void handleClick()}
+      title={tooltip}
+      aria-label={label ?? tooltip}
+      data-testid={testId}
+    >
+      <code>{value}</code>
+      <span className="copyable-value-feedback" aria-hidden="true">
+        {copied ? t('common.copied') : ''}
+      </span>
+    </button>
+  );
+};

--- a/src/components/SettingsPage.css
+++ b/src/components/SettingsPage.css
@@ -230,6 +230,9 @@
 .setting-item input[type="text"],
 .setting-item input[type="number"],
 .setting-item input[type="password"],
+.setting-item input[type="url"],
+.setting-item input[type="email"],
+.setting-item input[type="search"],
 .setting-item textarea {
   width: 100%;
   padding: 0.75rem 1rem;

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -138,18 +138,38 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
   useEffect(() => {
     if (!isElectron) return;
     let cancelled = false;
-    (async () => {
-      const info = await getEmbeddedBackendInfo();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    // Poll until the embedded backend reports a URL or error. The main
+    // process answers immediately even while `startEmbedded()` is still
+    // running, so a single fetch on mount races the server boot.
+    const poll = async () => {
       if (cancelled) return;
-      if (info?.error) {
-        setEmbeddedBackendError(info.error);
+      try {
+        const info = await getEmbeddedBackendInfo();
+        if (cancelled) return;
+        if (info?.error) {
+          setEmbeddedBackendError(info.error);
+          setEmbeddedBackendUrl(null);
+          return;
+        }
+        if (info?.url) {
+          setEmbeddedBackendUrl(info.url);
+          setEmbeddedBackendError(null);
+          return;
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setEmbeddedBackendError(err instanceof Error ? err.message : String(err));
         setEmbeddedBackendUrl(null);
-      } else if (info?.url) {
-        setEmbeddedBackendUrl(info.url);
-        setEmbeddedBackendError(null);
+        return;
       }
-    })();
-    return () => { cancelled = true; };
+      timer = setTimeout(poll, 500);
+    };
+    poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
   }, [isElectron]);
 
   // Show temporary message
@@ -345,11 +365,28 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
       }
       origin = trimmed;
     } else {
-      if (!embeddedBackendUrl) {
+      let url = embeddedBackendUrl;
+      if (!url) {
+        // Backend might still be starting; ask main one more time before
+        // declaring it unavailable to avoid a stale-state false negative.
+        try {
+          const info = await getEmbeddedBackendInfo();
+          if (info?.url) {
+            url = info.url;
+            setEmbeddedBackendUrl(info.url);
+            setEmbeddedBackendError(null);
+          } else if (info?.error) {
+            setEmbeddedBackendError(info.error);
+          }
+        } catch {
+          // Fall through to the error branch below.
+        }
+      }
+      if (!url) {
         setBackendTestState({ status: 'error', message: embeddedBackendError || t('settings.backend.embeddedUnavailable') });
         return;
       }
-      origin = embeddedBackendUrl;
+      origin = url;
     }
     try {
       await probeBackend(origin);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -34,6 +34,7 @@ import { LanguageSelector } from './LanguageSelector';
 import { probeBackend, getEmbeddedBackendInfo, getApiBaseUrl } from '../utils/apiBase';
 import { API_ENDPOINTS, type ApiEndpoint } from '../utils/apiCatalog';
 import { IS_DEMO_MODE } from '../utils/demoMode';
+import { AboutSection } from './AboutSection';
 import './SettingsPage.css';
 
 interface SettingsPageProps {
@@ -41,7 +42,7 @@ interface SettingsPageProps {
 }
 
 // Section identifiers for collapsible state
-const SETTINGS_SECTIONS = ['language', 'account', 'fire', 'display', 'privacy', 'backend', 'advanced', 'experimental', 'notifications', 'email', 'disclaimer', 'currency', 'marketData', 'categories', 'data', 'support'] as const;
+const SETTINGS_SECTIONS = ['language', 'account', 'fire', 'display', 'privacy', 'backend', 'advanced', 'experimental', 'notifications', 'email', 'disclaimer', 'currency', 'marketData', 'categories', 'data', 'support', 'about'] as const;
 type SettingsSection = typeof SETTINGS_SECTIONS[number];
 
 export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) => {
@@ -2202,6 +2203,23 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                   </a>
                 </div>
               </div>
+            </div>
+          )}
+        </section>
+
+        {/* About */}
+        <section className="settings-section collapsible-section">
+          <button
+            className="collapsible-header"
+            onClick={() => toggleSection('about')}
+            aria-expanded={!collapsedSections.has('about')}
+            aria-controls="about-content"
+          >
+            <h2><MaterialIcon name="info" /> {t('settings.sections.about')} <span className="collapse-icon-small" aria-hidden="true">{collapsedSections.has('about') ? '▶' : '▼'}</span></h2>
+          </button>
+          {!collapsedSections.has('about') && (
+            <div id="about-content" className="collapsible-content">
+              <AboutSection />
             </div>
           )}
         </section>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -148,7 +148,8 @@
       "language": "Sprache",
       "disclaimer": "Haftungsausschluss",
       "backend": "Backend",
-      "advanced": "Erweitert"
+      "advanced": "Erweitert",
+      "about": "Info"
     },
     "accountName": "Kontoname",
     "accountNameHelp": "Dieser Name wird in der gesamten App angezeigt",
@@ -2414,5 +2415,19 @@
       ],
       "lastUpdatedDate": "31. Dezember 2025"
     }
+  },
+  "about": {
+    "appInfo": "App-Informationen",
+    "appVersion": "Version",
+    "commit": "Commit",
+    "buildTime": "Erstellt am",
+    "backendInfo": "Backend",
+    "backendVersion": "Backend-Version",
+    "dependencies": "Wichtige Abhängigkeiten",
+    "dependencyName": "Paket",
+    "dependencyVersion": "Version",
+    "backendUnreachable": "Backend nicht erreichbar. App läuft im Nur-Client-Modus.",
+    "backendDepTag": "backend",
+    "refresh": "Aktualisieren"
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -42,6 +42,8 @@
     "spanish": "Spanisch",
     "hideValues": "Werte ausblenden",
     "notAvailable": "k.A.",
+    "copyToClipboard": "Klicken zum Kopieren",
+    "copied": "Kopiert!",
     "months": {
       "april": "April",
       "august": "August",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -148,7 +148,8 @@
       "language": "Language",
       "disclaimer": "Disclaimer",
       "backend": "Backend",
-      "advanced": "Advanced"
+      "advanced": "Advanced",
+      "about": "About"
     },
     "accountName": "Account Name",
     "accountNameHelp": "This name will be displayed throughout the app",
@@ -2414,5 +2415,19 @@
       ],
       "lastUpdatedDate": "December 31, 2025"
     }
+  },
+  "about": {
+    "appInfo": "App information",
+    "appVersion": "Version",
+    "commit": "Commit",
+    "buildTime": "Built at",
+    "backendInfo": "Backend",
+    "backendVersion": "Backend version",
+    "dependencies": "Major dependencies",
+    "dependencyName": "Package",
+    "dependencyVersion": "Version",
+    "backendUnreachable": "Backend is not reachable. The app runs in client-only mode.",
+    "backendDepTag": "backend",
+    "refresh": "Refresh"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -42,6 +42,8 @@
     "spanish": "Spanish",
     "hideValues": "Hide values",
     "notAvailable": "N/A",
+    "copyToClipboard": "Click to copy",
+    "copied": "Copied!",
     "months": {
       "april": "April",
       "august": "August",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -148,7 +148,8 @@
       "language": "Idioma",
       "disclaimer": "Aviso legal",
       "backend": "Backend",
-      "advanced": "Avanzado"
+      "advanced": "Avanzado",
+      "about": "Acerca de"
     },
     "accountName": "Nombre de cuenta",
     "accountNameHelp": "Este nombre se mostrará en toda la aplicación",
@@ -2414,5 +2415,19 @@
       ],
       "lastUpdatedDate": "31 de diciembre de 2025"
     }
+  },
+  "about": {
+    "appInfo": "Información de la app",
+    "appVersion": "Versión",
+    "commit": "Commit",
+    "buildTime": "Compilado el",
+    "backendInfo": "Backend",
+    "backendVersion": "Versión del backend",
+    "dependencies": "Dependencias principales",
+    "dependencyName": "Paquete",
+    "dependencyVersion": "Versión",
+    "backendUnreachable": "Backend no accesible. La app funciona en modo solo cliente.",
+    "backendDepTag": "backend",
+    "refresh": "Actualizar"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -42,6 +42,8 @@
     "spanish": "Español",
     "hideValues": "Ocultar valores",
     "notAvailable": "N/D",
+    "copyToClipboard": "Haz clic para copiar",
+    "copied": "¡Copiado!",
     "months": {
       "april": "Abril",
       "august": "Agosto",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -148,7 +148,8 @@
       "language": "Langue",
       "disclaimer": "Avertissement",
       "backend": "Backend",
-      "advanced": "Avancé"
+      "advanced": "Avancé",
+      "about": "À propos"
     },
     "accountName": "Nom de compte",
     "accountNameHelp": "Ce nom sera affiché dans toute l'application",
@@ -2414,5 +2415,19 @@
       ],
       "lastUpdatedDate": "31 décembre 2025"
     }
+  },
+  "about": {
+    "appInfo": "Informations sur l'application",
+    "appVersion": "Version",
+    "commit": "Commit",
+    "buildTime": "Compilé le",
+    "backendInfo": "Backend",
+    "backendVersion": "Version backend",
+    "dependencies": "Dépendances principales",
+    "dependencyName": "Paquet",
+    "dependencyVersion": "Version",
+    "backendUnreachable": "Backend injoignable. L'application fonctionne en mode client uniquement.",
+    "backendDepTag": "backend",
+    "refresh": "Actualiser"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -42,6 +42,8 @@
     "spanish": "Espagnol",
     "hideValues": "Masquer les valeurs",
     "notAvailable": "N/D",
+    "copyToClipboard": "Cliquer pour copier",
+    "copied": "Copié !",
     "months": {
       "april": "Avril",
       "august": "Août",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -148,7 +148,8 @@
       "language": "Lingua",
       "disclaimer": "Disclaimer",
       "backend": "Backend",
-      "advanced": "Avanzate"
+      "advanced": "Avanzate",
+      "about": "Informazioni"
     },
     "accountName": "Nome account",
     "accountNameHelp": "Questo nome verrà visualizzato in tutta l'applicazione",
@@ -2414,5 +2415,19 @@
       ],
       "lastUpdatedDate": "31 dicembre 2025"
     }
+  },
+  "about": {
+    "appInfo": "Informazioni sull'app",
+    "appVersion": "Versione",
+    "commit": "Commit",
+    "buildTime": "Compilato il",
+    "backendInfo": "Backend",
+    "backendVersion": "Versione backend",
+    "dependencies": "Dipendenze principali",
+    "dependencyName": "Pacchetto",
+    "dependencyVersion": "Versione",
+    "backendUnreachable": "Backend non raggiungibile. L'app è in modalità solo client.",
+    "backendDepTag": "backend",
+    "refresh": "Aggiorna"
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -42,6 +42,8 @@
     "spanish": "Spagnolo",
     "hideValues": "Nascondi valori",
     "notAvailable": "N/D",
+    "copyToClipboard": "Clicca per copiare",
+    "copied": "Copiato!",
     "months": {
       "april": "Aprile",
       "august": "Agosto",

--- a/src/utils/buildInfo.test.ts
+++ b/src/utils/buildInfo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildCommitUrl, formatCommit } from './buildInfo';
+
+describe('formatCommit', () => {
+  it('truncates long hashes to 7 chars', () => {
+    expect(formatCommit('abcdef0123456789')).toBe('abcdef0');
+  });
+
+  it('returns hash unchanged when shorter than 7 chars', () => {
+    expect(formatCommit('abc')).toBe('abc');
+  });
+
+  it('returns "unknown" placeholder for empty / unknown input', () => {
+    expect(formatCommit('')).toBe('unknown');
+    expect(formatCommit('unknown')).toBe('unknown');
+  });
+});
+
+describe('buildCommitUrl', () => {
+  const sha = 'abcdef0123456789';
+
+  it('returns null when repoUrl is missing', () => {
+    expect(buildCommitUrl('', sha)).toBeNull();
+  });
+
+  it('returns null when commit is missing or unknown', () => {
+    expect(buildCommitUrl('https://github.com/o/r', '')).toBeNull();
+    expect(buildCommitUrl('https://github.com/o/r', 'unknown')).toBeNull();
+  });
+
+  it('builds GitHub commit URL', () => {
+    expect(buildCommitUrl('https://github.com/o/r', sha)).toBe(
+      `https://github.com/o/r/commit/${sha}`,
+    );
+  });
+
+  it('builds GitLab commit URL (same shape as GitHub)', () => {
+    expect(buildCommitUrl('https://gitlab.com/o/r', sha)).toBe(
+      `https://gitlab.com/o/r/commit/${sha}`,
+    );
+  });
+
+  it('builds Bitbucket commit URL (uses /commits/)', () => {
+    expect(buildCommitUrl('https://bitbucket.org/o/r', sha)).toBe(
+      `https://bitbucket.org/o/r/commits/${sha}`,
+    );
+  });
+
+  it('strips trailing slashes on repoUrl', () => {
+    expect(buildCommitUrl('https://github.com/o/r/', sha)).toBe(
+      `https://github.com/o/r/commit/${sha}`,
+    );
+  });
+});

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -1,0 +1,47 @@
+/**
+ * Build metadata injected at compile time by Vite (see `vite.config.ts`).
+ * Values fall back gracefully when the corresponding global is undefined
+ * (e.g. when running unit tests that haven't gone through the Vite build).
+ */
+
+const safeRead = <T>(value: T | undefined, fallback: T): T =>
+  value === undefined || value === null ? fallback : value;
+
+export interface BuildInfo {
+  version: string;
+  commit: string;
+  buildTime: string;
+  dependencies: Record<string, string>;
+}
+
+const readGlobal = <T>(name: string, fallback: T): T => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const value = (globalThis as any)[name];
+    return safeRead<T>(value as T | undefined, fallback);
+  } catch {
+    return fallback;
+  }
+};
+
+export const buildInfo: BuildInfo = {
+  version:
+    typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : readGlobal('__APP_VERSION__', '0.0.0'),
+  commit:
+    typeof __APP_COMMIT_HASH__ !== 'undefined'
+      ? __APP_COMMIT_HASH__
+      : readGlobal('__APP_COMMIT_HASH__', 'unknown'),
+  buildTime:
+    typeof __APP_BUILD_TIME__ !== 'undefined'
+      ? __APP_BUILD_TIME__
+      : readGlobal('__APP_BUILD_TIME__', ''),
+  dependencies:
+    typeof __APP_DEPENDENCIES__ !== 'undefined'
+      ? __APP_DEPENDENCIES__
+      : readGlobal<Record<string, string>>('__APP_DEPENDENCIES__', {}),
+};
+
+export const formatCommit = (commit: string): string => {
+  if (!commit || commit === 'unknown') return commit || 'unknown';
+  return commit.length > 7 ? commit.slice(0, 7) : commit;
+};

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -12,6 +12,7 @@ export interface BuildInfo {
   commit: string;
   buildTime: string;
   dependencies: Record<string, string>;
+  repoUrl: string;
 }
 
 const readGlobal = <T>(name: string, fallback: T): T => {
@@ -39,9 +40,29 @@ export const buildInfo: BuildInfo = {
     typeof __APP_DEPENDENCIES__ !== 'undefined'
       ? __APP_DEPENDENCIES__
       : readGlobal<Record<string, string>>('__APP_DEPENDENCIES__', {}),
+  repoUrl:
+    typeof __APP_REPO_URL__ !== 'undefined'
+      ? __APP_REPO_URL__
+      : readGlobal('__APP_REPO_URL__', ''),
 };
 
 export const formatCommit = (commit: string): string => {
   if (!commit || commit === 'unknown') return commit || 'unknown';
   return commit.length > 7 ? commit.slice(0, 7) : commit;
+};
+
+/**
+ * Build a URL to a commit on the host where the repo lives.
+ * Supports GitHub, GitLab and Bitbucket URL shapes; returns `null` if we
+ * don't know enough to construct a stable link.
+ */
+export const buildCommitUrl = (
+  repoUrl: string,
+  commit: string,
+): string | null => {
+  if (!repoUrl || !commit || commit === 'unknown') return null;
+  const base = repoUrl.replace(/\/+$/, '');
+  if (/bitbucket\.org/i.test(base)) return `${base}/commits/${commit}`;
+  // Default to the GitHub / GitLab shape (both use /commit/<sha>).
+  return `${base}/commit/${commit}`;
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string
+declare const __APP_COMMIT_HASH__: string
+declare const __APP_BUILD_TIME__: string
+declare const __APP_DEPENDENCIES__: Record<string, string>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,3 +4,4 @@ declare const __APP_VERSION__: string
 declare const __APP_COMMIT_HASH__: string
 declare const __APP_BUILD_TIME__: string
 declare const __APP_DEPENDENCIES__: Record<string, string>
+declare const __APP_REPO_URL__: string

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,9 @@
 // Global vitest setup. Ensures i18next is initialised with English resources
 // before any component that calls `useTranslation()` is rendered.
+import { vi } from 'vitest';
 import '../src/i18n';
+
+vi.stubGlobal('__APP_VERSION__', '1.0.0');
+vi.stubGlobal('__APP_COMMIT_HASH__', 'testcommit');
+vi.stubGlobal('__APP_BUILD_TIME__', '2024-01-01T00:00:00.000Z');
+vi.stubGlobal('__APP_DEPENDENCIES__', { react: '19.0.0' });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,3 +7,4 @@ vi.stubGlobal('__APP_VERSION__', '1.0.0');
 vi.stubGlobal('__APP_COMMIT_HASH__', 'testcommit');
 vi.stubGlobal('__APP_BUILD_TIME__', '2024-01-01T00:00:00.000Z');
 vi.stubGlobal('__APP_DEPENDENCIES__', { react: '19.0.0' });
+vi.stubGlobal('__APP_REPO_URL__', 'https://github.com/test/test');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,54 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { existsSync, statSync, createReadStream } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { existsSync, readFileSync, statSync, createReadStream } from 'node:fs'
 import { join, resolve } from 'node:path'
+
+const pkg = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8'),
+) as {
+  version?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+const resolveCommitHash = (): string => {
+  if (process.env.GIT_COMMIT_HASH) return process.env.GIT_COMMIT_HASH
+  if (process.env.GIT_COMMIT) return process.env.GIT_COMMIT
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim() || 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+const allDeps: Record<string, string> = {
+  ...(pkg.dependencies ?? {}),
+  ...(pkg.devDependencies ?? {}),
+}
+const FEATURED_DEPS = [
+  'react',
+  'react-router-dom',
+  'recharts',
+  'vite',
+  'typescript',
+  'electron',
+  'better-sqlite3',
+  'express',
+  'i18next',
+  'js-cookie',
+  'crypto-js',
+] as const
+const featuredDependencies: Record<string, string> = {}
+for (const name of FEATURED_DEPS) {
+  if (allDeps[name]) featuredDependencies[name] = allDeps[name]
+}
+
+const APP_VERSION = pkg.version ?? '0.0.0'
+const APP_COMMIT_HASH = resolveCommitHash()
+const APP_BUILD_TIME = process.env.BUILD_TIME ?? new Date().toISOString()
 
 // Lightweight static handler used in `npm run dev:all` to serve the pre-built
 // landing page (at /), OpenAPI viewer (at /api) and docs (at /docs) from a
@@ -133,6 +180,12 @@ export default defineConfig(({ mode, command }) => ({
       : '/demo/',
   build: {
     outDir: mode === 'electron' ? 'dist-electron' : 'dist/demo',
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
+    __APP_COMMIT_HASH__: JSON.stringify(APP_COMMIT_HASH),
+    __APP_BUILD_TIME__: JSON.stringify(APP_BUILD_TIME),
+    __APP_DEPENDENCIES__: JSON.stringify(featuredDependencies),
   },
   server: {
     proxy: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,8 @@ const pkg = JSON.parse(
   version?: string
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  repository?: string | { url?: string }
+  homepage?: string
 }
 
 const resolveCommitHash = (): string => {
@@ -21,6 +23,43 @@ const resolveCommitHash = (): string => {
       .trim() || 'unknown'
   } catch {
     return 'unknown'
+  }
+}
+
+// Normalize any git remote / package.json repository URL into a clean
+// "https://host/owner/repo" form (no trailing .git, no git+ prefix, no SSH).
+const normalizeRepoUrl = (raw: string | undefined | null): string => {
+  if (!raw) return ''
+  let url = raw.trim()
+  if (!url) return ''
+  url = url.replace(/^git\+/, '')
+  // git@github.com:owner/repo(.git) -> https://github.com/owner/repo
+  const sshMatch = url.match(/^git@([^:]+):(.+?)(?:\.git)?$/)
+  if (sshMatch) url = `https://${sshMatch[1]}/${sshMatch[2]}`
+  // ssh://git@host/owner/repo(.git) -> https://host/owner/repo
+  url = url.replace(/^ssh:\/\/git@/, 'https://')
+  url = url.replace(/\.git$/, '')
+  url = url.replace(/\/+$/, '')
+  return url
+}
+
+const resolveRepoUrl = (): string => {
+  if (process.env.APP_REPO_URL) return normalizeRepoUrl(process.env.APP_REPO_URL)
+  const fromPkg =
+    typeof pkg.repository === 'string'
+      ? pkg.repository
+      : pkg.repository?.url ?? pkg.homepage
+  const normalized = normalizeRepoUrl(fromPkg)
+  if (normalized) return normalized
+  try {
+    const remote = execSync('git config --get remote.origin.url', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+    return normalizeRepoUrl(remote)
+  } catch {
+    return ''
   }
 }
 
@@ -49,6 +88,7 @@ for (const name of FEATURED_DEPS) {
 const APP_VERSION = pkg.version ?? '0.0.0'
 const APP_COMMIT_HASH = resolveCommitHash()
 const APP_BUILD_TIME = process.env.BUILD_TIME ?? new Date().toISOString()
+const APP_REPO_URL = resolveRepoUrl()
 
 // Lightweight static handler used in `npm run dev:all` to serve the pre-built
 // landing page (at /), OpenAPI viewer (at /api) and docs (at /docs) from a
@@ -186,6 +226,7 @@ export default defineConfig(({ mode, command }) => ({
     __APP_COMMIT_HASH__: JSON.stringify(APP_COMMIT_HASH),
     __APP_BUILD_TIME__: JSON.stringify(APP_BUILD_TIME),
     __APP_DEPENDENCIES__: JSON.stringify(featuredDependencies),
+    __APP_REPO_URL__: JSON.stringify(APP_REPO_URL),
   },
   server: {
     proxy: {


### PR DESCRIPTION
Fixes #235

## What

- **New Settings → About section** displaying:
  - App version (read from `package.json`)
  - Git commit hash for the build (linked to GitHub)
  - Build timestamp
  - Major frontend dependency versions (React, Vite, Recharts, etc.)
  - Backend version + its own dependency set (Express, better-sqlite3, …) when the local backend is reachable
- **Backend version bug fixed**: `/health` was reporting `0.0.0` because `process.env.npm_package_version` is empty when running `node dist/index.js` (only set by `npm run start`). Now reads `package.json` from disk via a new `server/src/buildInfo.ts` module — works for both `tsx` dev and the compiled `dist` prod path.
- **Version aligned**: bumped `server/package.json` from `0.1.0` → `1.0.0` so frontend and backend report the same version.
- **Build-time commit hash injection**:
  - `vite.config.ts` resolves the hash from `GIT_COMMIT_HASH` env → `GIT_COMMIT` env → `git rev-parse --short HEAD` → `'unknown'`, then exposes `__APP_VERSION__`, `__APP_COMMIT_HASH__`, `__APP_BUILD_TIME__`, `__APP_DEPENDENCIES__` via `define`.
  - `docker/frontend.Dockerfile` and `server/Dockerfile` accept `GIT_COMMIT_HASH` / `BUILD_TIME` build args, plumbed through `docker-compose.yml`.
- **i18n**: full translations for the new `about.*` namespace and `settings.sections.about` in en / it / fr / de / es.
- **README**: short description of the About section under Features.

## Files

- New: `src/components/AboutSection.tsx`, `src/components/AboutSection.css`, `src/utils/buildInfo.ts`, `server/src/buildInfo.ts`
- Modified: `src/components/SettingsPage.tsx`, `vite.config.ts`, `src/vite-env.d.ts`, `server/src/routes/health.ts`, `server/package.json`, `server/Dockerfile`, `docker/frontend.Dockerfile`, `docker-compose.yml`, `tests/setup.ts`, 5 locale files, `README.md`

## Verification

- `npm test` → **1048/1048** passing
- `npm --prefix server test` → **20/20** passing
- `npm run build` → ✅
- `npm --prefix server run build` → ✅

## Notes / assumptions

- Commit link base is hard-coded to `https://github.com/mbianchidev/fire-tools/commit/`.
- Backend dependency rows in the About table are tagged with a small "backend" badge when they don't exist on the frontend.
- The About section is collapsible and follows the same pattern as the existing Support/Market Data sections in Settings.