### PR TITLE
test(server): comprehensive backend API test coverage (#238)

### DIFF
--- a/server/test/app.test.ts
+++ b/server/test/app.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../src/migrate.js';
+import { buildApp } from '../src/app.js';
+import { testEnv, makeApp } from './helpers.js';
+
+const buildRestricted = () => {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  const env = testEnv();
+  env.corsAllowAll = false;
+  env.corsOrigins = ['http://localhost:5173'];
+  runMigrations(db, env.migrationsPath);
+  return buildApp({ db, env, dbPath: ':memory:', disableRateLimit: true });
+};
+
+describe('CORS handling', () => {
+  it('allows configured origin', async () => {
+    const app = buildRestricted();
+    const res = await request(app)
+      .get('/api/v1/health')
+      .set('Origin', 'http://localhost:5173');
+    expect(res.status).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:5173');
+  });
+
+  it('denies disallowed origin with 403 cors_denied', async () => {
+    const app = buildRestricted();
+    const res = await request(app)
+      .get('/api/v1/health')
+      .set('Origin', 'http://evil.com');
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('cors_denied');
+  });
+
+  it('allows requests without an Origin header', async () => {
+    const app = buildRestricted();
+    const res = await request(app).get('/api/v1/health');
+    expect(res.status).toBe(200);
+  });
+
+  it('corsAllowAll bypasses allowlist', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .get('/api/v1/health')
+      .set('Origin', 'http://anywhere.example');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('Route mounting', () => {
+  it('all routers mounted under /api/v1', async () => {
+    const { app } = makeApp();
+    const paths = [
+      '/api/v1/health',
+      '/api/v1/users/me',
+      '/api/v1/settings',
+      '/api/v1/notifications',
+      '/api/v1/calculator/projections',
+      '/api/v1/asset-allocation/config',
+      '/api/v1/expense-tracker/config',
+      '/api/v1/net-worth/config',
+      '/api/v1/questionnaire',
+      '/api/v1/portfolio-breakdown',
+      '/api/v1/banks',
+      '/api/v1/ui-preferences',
+    ];
+    for (const p of paths) {
+      const res = await request(app).get(p);
+      // Some routes (e.g. calculator/projections) require query params and return 400.
+      expect([200, 400, 404, 501]).toContain(res.status);
+      if (res.status !== 404) {
+        expect(res.headers['content-type']).toMatch(/json/);
+      }
+    }
+  });
+
+  it('unknown /api/v1 route returns 501 not_implemented', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/does-not-exist');
+    expect(res.status).toBe(501);
+    expect(res.body.error.code).toBe('not_implemented');
+  });
+
+  it('unknown route outside /api/v1 returns 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/totally-unknown');
+    expect(res.status).toBe(404);
+  });
+
+  it('x-powered-by header is disabled', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/health');
+    expect(res.headers['x-powered-by']).toBeUndefined();
+  });
+});

--- a/server/test/assetAllocation.test.ts
+++ b/server/test/assetAllocation.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const validAsset = {
+  externalId: 'a-1',
+  name: 'Acme ETF',
+  ticker: 'ACM',
+  assetClass: 'STOCKS',
+  subAssetType: 'ETF',
+  currentValue: 1000,
+  targetMode: 'PERCENTAGE',
+};
+
+describe('asset-allocation config', () => {
+  it('GET returns defaults', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/asset-allocation/config');
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('EUR');
+    expect(res.body.allowNegativeCash).toBe(false);
+    expect(res.body.targetAllocationTolerance).toBe(2);
+  });
+
+  it('PUT updates config', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/asset-allocation/config').send({
+      currency: 'USD',
+      allowNegativeCash: true,
+      targetAllocationTolerance: 5,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('USD');
+    expect(res.body.allowNegativeCash).toBe(true);
+    expect(res.body.targetAllocationTolerance).toBe(5);
+  });
+
+  it('PUT rejects missing field', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .put('/api/v1/asset-allocation/config')
+      .send({ currency: 'EUR', allowNegativeCash: false });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('asset-allocation assets', () => {
+  it('GET returns empty', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/asset-allocation/assets');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('POST creates an asset', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/asset-allocation/assets').send(validAsset);
+    expect(res.status).toBe(201);
+    expect(res.body.externalId).toBe('a-1');
+    expect(res.body.assetClass).toBe('STOCKS');
+    expect(res.body.currentValue).toBe(1000);
+  });
+
+  it('POST 409 on dup', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(validAsset);
+    const res = await request(app).post('/api/v1/asset-allocation/assets').send(validAsset);
+    expect(res.status).toBe(409);
+  });
+
+  it('POST rejects missing field', async () => {
+    const { app } = makeApp();
+    const { name: _x, ...partial } = validAsset;
+    const res = await request(app).post('/api/v1/asset-allocation/assets').send(partial);
+    expect(res.status).toBe(400);
+  });
+
+  it('POST rejects invalid assetClass', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/asset-allocation/assets')
+      .send({ ...validAsset, assetClass: 'BOGUS' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST rejects invalid subAssetType', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/asset-allocation/assets')
+      .send({ ...validAsset, subAssetType: 'NOPE' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST rejects invalid targetMode', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/asset-allocation/assets')
+      .send({ ...validAsset, targetMode: 'WEIRD' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST rejects invalid originalCurrency', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/asset-allocation/assets')
+      .send({ ...validAsset, originalCurrency: 'XYZ', originalValue: 100 });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET filters by assetClass', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(validAsset);
+    await request(app)
+      .post('/api/v1/asset-allocation/assets')
+      .send({ ...validAsset, externalId: 'a-2', assetClass: 'CASH', subAssetType: 'SAVINGS_ACCOUNT' });
+    const stocks = await request(app).get('/api/v1/asset-allocation/assets?assetClass=STOCKS');
+    expect(stocks.body.length).toBe(1);
+    const cash = await request(app).get('/api/v1/asset-allocation/assets?assetClass=CASH');
+    expect(cash.body.length).toBe(1);
+  });
+
+  it('GET rejects invalid assetClass param', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/asset-allocation/assets?assetClass=NOPE');
+    expect(res.status).toBe(400);
+  });
+
+  it('GET by externalId', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(validAsset);
+    const res = await request(app).get('/api/v1/asset-allocation/assets/a-1');
+    expect(res.status).toBe(200);
+    expect(res.body.externalId).toBe('a-1');
+  });
+
+  it('GET 404 for missing externalId', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/asset-allocation/assets/missing');
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT replaces (upserts) asset', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(validAsset);
+    const res = await request(app)
+      .put('/api/v1/asset-allocation/assets/a-1')
+      .send({ ...validAsset, name: 'Renamed', currentValue: 2000 });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Renamed');
+    expect(res.body.currentValue).toBe(2000);
+  });
+
+  it('PUT creates if missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/asset-allocation/assets/new-1').send(validAsset);
+    expect(res.status).toBe(200);
+    expect(res.body.externalId).toBe('new-1');
+  });
+
+  it('POST includes mortgageData', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/asset-allocation/assets')
+      .send({
+        ...validAsset,
+        externalId: 'house-1',
+        assetClass: 'REAL_ESTATE',
+        subAssetType: 'PROPERTY',
+        isPrimaryResidence: true,
+        mortgageData: {
+          principalAmount: 200000,
+          currentBalance: 150000,
+          interestRate: 3.5,
+          termYears: 30,
+          remainingYears: 25,
+          monthlyPayment: 1000,
+          startDate: '2020-01-01',
+          propertyValue: 300000,
+          lender: 'Bank',
+        },
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.isPrimaryResidence).toBe(true);
+    expect(res.body.mortgageData.lender).toBe('Bank');
+  });
+
+  it('DELETE removes asset', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(validAsset);
+    const del = await request(app).delete('/api/v1/asset-allocation/assets/a-1');
+    expect(del.status).toBe(204);
+    const get = await request(app).get('/api/v1/asset-allocation/assets/a-1');
+    expect(get.status).toBe(404);
+  });
+
+  it('DELETE 404 for missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete('/api/v1/asset-allocation/assets/none');
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/test/banks.test.ts
+++ b/server/test/banks.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const seedBanks = (db: import('better-sqlite3').Database) => {
+  const stmt = db.prepare(
+    `INSERT INTO banks (code, name, country_code, supports_open_banking, bic, institution_type, logo_url)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  stmt.run('ITALPHA', 'Alpha IT', 'IT', 1, 'ALPHAITMM', 'BANK', null);
+  stmt.run('ITBETA', 'Beta IT', 'IT', 0, null, 'BANK', null);
+  stmt.run('FRGAMMA', 'Gamma FR', 'FR', 1, null, 'NEOBANK', null);
+};
+
+describe('GET /api/v1/banks', () => {
+  it('returns empty array when no banks', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/banks');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns seeded banks sorted by name', async () => {
+    const { app, db } = makeApp();
+    seedBanks(db);
+    const res = await request(app).get('/api/v1/banks');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(3);
+    expect(res.body[0].name).toBe('Alpha IT');
+    expect(res.body[0].code).toBe('ITALPHA');
+    expect(res.body[0].supportsOpenBanking).toBe(true);
+  });
+
+  it('filters by countryCode', async () => {
+    const { app, db } = makeApp();
+    seedBanks(db);
+    const res = await request(app).get('/api/v1/banks?countryCode=IT');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+    expect(res.body.every((b: { countryCode: string }) => b.countryCode === 'IT')).toBe(true);
+  });
+
+  it('filters by supportsOpenBanking=true', async () => {
+    const { app, db } = makeApp();
+    seedBanks(db);
+    const res = await request(app).get('/api/v1/banks?supportsOpenBanking=true');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+    expect(res.body.every((b: { supportsOpenBanking: boolean }) => b.supportsOpenBanking)).toBe(true);
+  });
+
+  it('filters by supportsOpenBanking=false', async () => {
+    const { app, db } = makeApp();
+    seedBanks(db);
+    const res = await request(app).get('/api/v1/banks?supportsOpenBanking=false');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].code).toBe('ITBETA');
+  });
+
+  it('combines filters', async () => {
+    const { app, db } = makeApp();
+    seedBanks(db);
+    const res = await request(app).get('/api/v1/banks?countryCode=FR&supportsOpenBanking=true');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].code).toBe('FRGAMMA');
+  });
+
+  it('ignores invalid supportsOpenBanking value', async () => {
+    const { app, db } = makeApp();
+    seedBanks(db);
+    const res = await request(app).get('/api/v1/banks?supportsOpenBanking=maybe');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(3);
+  });
+});
+
+describe('GET /api/v1/banks/:code', () => {
+  it('returns single bank', async () => {
+    const { app, db } = makeApp();
+    seedBanks(db);
+    const res = await request(app).get('/api/v1/banks/ITALPHA');
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe('ITALPHA');
+    expect(res.body.bic).toBe('ALPHAITMM');
+  });
+
+  it('returns 404 for unknown code', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/banks/NOPE');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+});

--- a/server/test/calculator.test.ts
+++ b/server/test/calculator.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const fullInputs = {
+  initialSavings: 50000,
+  stocksPercent: 60,
+  bondsPercent: 30,
+  cashPercent: 10,
+  currentAnnualExpenses: 30000,
+  fireAnnualExpenses: 25000,
+  annualLaborIncome: 70000,
+  laborIncomeGrowthRate: 0.02,
+  savingsRate: 0.3,
+  desiredWithdrawalRate: 0.04,
+  yearsOfExpenses: 25,
+  expectedStockReturn: 0.07,
+  expectedBondReturn: 0.03,
+  expectedCashReturn: 0.01,
+  yearOfBirth: 1990,
+  retirementAge: 65,
+  statePensionIncome: 0,
+  privatePensionIncome: 0,
+  otherIncome: 0,
+  stopWorkingAtFIRE: true,
+  maxAge: 95,
+  useAssetAllocationValue: false,
+  useExpenseTrackerExpenses: false,
+  useExpenseTrackerIncome: false,
+};
+
+describe('GET /api/v1/calculator/inputs', () => {
+  it('auto-creates defaults on first call', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/calculator/inputs');
+    expect(res.status).toBe(200);
+    expect(typeof res.body.initialSavings).toBe('number');
+    expect(typeof res.body.stopWorkingAtFIRE).toBe('boolean');
+    expect(typeof res.body.useAssetAllocationValue).toBe('boolean');
+  });
+});
+
+describe('PUT /api/v1/calculator/inputs', () => {
+  it('replaces all fields', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/calculator/inputs').send(fullInputs);
+    expect(res.status).toBe(200);
+    expect(res.body.initialSavings).toBe(50000);
+    expect(res.body.stocksPercent).toBe(60);
+    expect(res.body.stopWorkingAtFIRE).toBe(true);
+  });
+
+  it('persists after PUT', async () => {
+    const { app } = makeApp();
+    await request(app).put('/api/v1/calculator/inputs').send(fullInputs);
+    const res = await request(app).get('/api/v1/calculator/inputs');
+    expect(res.body.initialSavings).toBe(50000);
+    expect(res.body.retirementAge).toBe(65);
+  });
+
+  it('rejects empty body', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/calculator/inputs').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('rejects missing single field', async () => {
+    const { app } = makeApp();
+    const { maxAge: _x, ...partial } = fullInputs;
+    const res = await request(app).put('/api/v1/calculator/inputs').send(partial);
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toContain('maxAge');
+  });
+});
+
+describe('calculator multi-user isolation', () => {
+  it('keeps inputs separate per x-user-id', async () => {
+    const { app, db } = makeApp();
+    db.prepare(
+      "INSERT INTO users (id, email, created_at) VALUES (2, 'two@x', '2024-01-01T00:00:00Z')",
+    ).run();
+    await request(app)
+      .put('/api/v1/calculator/inputs')
+      .set('x-user-id', '1')
+      .send({ ...fullInputs, initialSavings: 111 });
+    await request(app)
+      .put('/api/v1/calculator/inputs')
+      .set('x-user-id', '2')
+      .send({ ...fullInputs, initialSavings: 222 });
+    const u1 = await request(app).get('/api/v1/calculator/inputs').set('x-user-id', '1');
+    const u2 = await request(app).get('/api/v1/calculator/inputs').set('x-user-id', '2');
+    expect(u1.body.initialSavings).toBe(111);
+    expect(u2.body.initialSavings).toBe(222);
+  });
+});

--- a/server/test/expenseTracker.test.ts
+++ b/server/test/expenseTracker.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const base = '/api/v1/expense-tracker';
+
+const exp = (overrides: Record<string, unknown> = {}) => ({
+  externalId: 'e-1',
+  date: '2024-06-15',
+  amount: 12.5,
+  description: 'Lunch',
+  category: 'food',
+  expenseType: 'NEED',
+  ...overrides,
+});
+
+const inc = (overrides: Record<string, unknown> = {}) => ({
+  externalId: 'i-1',
+  date: '2024-06-01',
+  amount: 3000,
+  description: 'Paycheck',
+  source: 'SALARY',
+  ...overrides,
+});
+
+describe('expense-tracker config', () => {
+  it('GET returns defaults (EUR + current year/month)', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/config`);
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('EUR');
+    expect(typeof res.body.currentYear).toBe('number');
+    expect(typeof res.body.currentMonth).toBe('number');
+  });
+
+  it('PUT updates config', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/config`).send({
+      currency: 'USD', currentYear: 2025, currentMonth: 3,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ currency: 'USD', currentYear: 2025, currentMonth: 3 });
+  });
+
+  it('PUT missing field → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/config`).send({ currency: 'EUR' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('PUT invalid currency → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/config`).send({
+      currency: 'XXX', currentYear: 2024, currentMonth: 1,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('expense-tracker months', () => {
+  it('GET auto-creates and returns empty month', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/months/2024/6`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ year: 2024, month: 6, isClosed: false });
+    expect(res.body.expenses).toEqual([]);
+    expect(res.body.incomes).toEqual([]);
+  });
+
+  it('GET invalid year → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/months/1800/6`);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+
+  it('GET invalid month → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/months/2024/13`);
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT replaces month contents', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/months/2024/7`).send({
+      expenses: [exp({ externalId: 'e-a', amount: 10 }), exp({ externalId: 'e-b', amount: 20 })],
+      incomes: [inc({ externalId: 'i-a' })],
+      budgets: [{ category: 'food', monthlyBudget: 500 }],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.expenses).toHaveLength(2);
+    expect(res.body.incomes).toHaveLength(1);
+    expect(res.body.budgets).toHaveLength(1);
+  });
+
+  it('PUT invalid expenseType → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/months/2024/7`).send({
+      expenses: [exp({ expenseType: 'INVALID' })],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH isClosed toggles closed flag', async () => {
+    const { app } = makeApp();
+    await request(app).get(`${base}/months/2024/8`);
+    const res = await request(app).patch(`${base}/months/2024/8`).send({ isClosed: true });
+    expect(res.status).toBe(200);
+    expect(res.body.isClosed).toBe(true);
+  });
+});
+
+describe('expense-tracker expenses', () => {
+  it('POST creates expense', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/expenses`).send(exp());
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ externalId: 'e-1', amount: 12.5, category: 'food', expenseType: 'NEED', type: 'expense' });
+  });
+
+  it('POST duplicate externalId → 409', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp());
+    const res = await request(app).post(`${base}/expenses`).send(exp());
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('conflict');
+  });
+
+  it('POST missing field → 400', async () => {
+    const { app } = makeApp();
+    const { date, ...rest } = exp();
+    void date;
+    const res = await request(app).post(`${base}/expenses`).send(rest);
+    expect(res.status).toBe(400);
+  });
+
+  it('POST invalid expenseType → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/expenses`).send(exp({ expenseType: 'NOPE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST invalid currency → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/expenses`).send(exp({ currency: 'ZZZ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('GET lists expenses', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-a' }));
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-b' }));
+    const res = await request(app).get(`${base}/expenses`);
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it('GET filters by category', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-a', category: 'food' }));
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-b', category: 'transport' }));
+    const res = await request(app).get(`${base}/expenses?category=food`);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].category).toBe('food');
+  });
+
+  it('GET filters by date range', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-jan', date: '2024-01-15' }));
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-jun', date: '2024-06-15' }));
+    const res = await request(app).get(`${base}/expenses?startDate=2024-05-01&endDate=2024-12-31`);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].externalId).toBe('e-jun');
+  });
+
+  it('GET filters by searchTerm', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-a', description: 'Lunch at cafe' }));
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-b', description: 'Gas station' }));
+    const res = await request(app).get(`${base}/expenses?searchTerm=cafe`);
+    expect(res.body.items).toHaveLength(1);
+  });
+
+  it('GET filters by isRecurring', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-a', isRecurring: true }));
+    await request(app).post(`${base}/expenses`).send(exp({ externalId: 'e-b', isRecurring: false }));
+    const res = await request(app).get(`${base}/expenses?isRecurring=true`);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].externalId).toBe('e-a');
+  });
+
+  it('GET invalid expenseType filter → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/expenses?expenseType=NOPE`);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+
+  it('PUT upserts expense', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp());
+    const res = await request(app).put(`${base}/expenses/e-1`).send(exp({ amount: 99 }));
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(99);
+  });
+
+  it('DELETE removes expense', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/expenses`).send(exp());
+    const del = await request(app).delete(`${base}/expenses/e-1`);
+    expect(del.status).toBe(204);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/expenses/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('expense-tracker incomes', () => {
+  it('POST creates income', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/incomes`).send(inc());
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ externalId: 'i-1', source: 'SALARY', type: 'income' });
+  });
+
+  it('POST duplicate → 409', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/incomes`).send(inc());
+    const res = await request(app).post(`${base}/incomes`).send(inc());
+    expect(res.status).toBe(409);
+  });
+
+  it('POST invalid source → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/incomes`).send(inc({ source: 'NOPE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST missing field → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/incomes`).send({ externalId: 'x', date: '2024-01-01', amount: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET filters by source', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/incomes`).send(inc({ externalId: 'i-a', source: 'SALARY' }));
+    await request(app).post(`${base}/incomes`).send(inc({ externalId: 'i-b', source: 'BONUS' }));
+    const res = await request(app).get(`${base}/incomes?source=SALARY`);
+    expect(res.body.items).toHaveLength(1);
+  });
+
+  it('GET invalid source filter → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/incomes?source=NOPE`);
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT upserts income', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/incomes`).send(inc());
+    const res = await request(app).put(`${base}/incomes/i-1`).send(inc({ amount: 9999 }));
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(9999);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/incomes/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('expense-tracker budgets', () => {
+  it('PUT replaces full list', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/budgets`).send([
+      { category: 'food', monthlyBudget: 500 },
+      { category: 'transport', monthlyBudget: 100, monthKey: '2024-06' },
+    ]);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('GET monthKey=global returns global budgets', async () => {
+    const { app } = makeApp();
+    await request(app).put(`${base}/budgets`).send([{ category: 'food', monthlyBudget: 500 }]);
+    const res = await request(app).get(`${base}/budgets?monthKey=global`);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('GET invalid monthKey → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/budgets?monthKey=2024`);
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT invalid monthKey in body → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/budgets`).send([
+      { category: 'x', monthlyBudget: 1, monthKey: 'bad' },
+    ]);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('expense-tracker custom categories', () => {
+  const cat = (o: Record<string, unknown> = {}) => ({
+    externalId: 'c-1', name: 'My Cat', icon: '🍕', color: '#f00',
+    defaultExpenseType: 'WANT', ...o,
+  });
+
+  it('POST creates category', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/custom-categories`).send(cat());
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ externalId: 'c-1', name: 'My Cat', defaultExpenseType: 'WANT' });
+  });
+
+  it('POST missing field → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/custom-categories`).send({ externalId: 'c-1', name: 'x' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST invalid defaultExpenseType → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/custom-categories`).send(cat({ defaultExpenseType: 'X' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST duplicate → 409', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/custom-categories`).send(cat());
+    const res = await request(app).post(`${base}/custom-categories`).send(cat());
+    expect(res.status).toBe(409);
+  });
+
+  it('PUT updates category', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/custom-categories`).send(cat());
+    const res = await request(app).put(`${base}/custom-categories/c-1`)
+      .send({ name: 'Updated', icon: '🚗', color: '#000', defaultExpenseType: 'NEED' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Updated');
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/custom-categories/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('expense-tracker category overrides', () => {
+  it('PUT replaces list', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/category-overrides`).send([
+      { categoryId: 'food', name: 'Groceries', icon: '🛒', color: '#0f0' },
+    ]);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].categoryId).toBe('food');
+  });
+
+  it('PUT missing categoryId → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/category-overrides`).send([{ name: 'x' }]);
+    expect(res.status).toBe(400);
+  });
+
+  it('GET returns saved overrides', async () => {
+    const { app } = makeApp();
+    await request(app).put(`${base}/category-overrides`).send([{ categoryId: 'food' }]);
+    const res = await request(app).get(`${base}/category-overrides`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});

--- a/server/test/health.test.ts
+++ b/server/test/health.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+describe('GET /api/v1/health', () => {
+  it('returns ok shape with db driver and path', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.database.driver).toBe('sqlite');
+    expect(res.body.database.path).toBe(':memory:');
+    expect(res.body.database.ok).toBe(true);
+    expect(typeof res.body.version).toBe('string');
+  });
+
+  it('returns 503 when database is closed', async () => {
+    const { app, db } = makeApp();
+    db.close();
+    const res = await request(app).get('/api/v1/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('down');
+    expect(res.body.error.code).toBe('database_unavailable');
+  });
+});

--- a/server/test/http.test.ts
+++ b/server/test/http.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+// Tests for cross-cutting validators in src/http.ts exercised via real routes.
+
+describe('resolveUserId edge cases', () => {
+  it('rejects x-user-id="0" with 400 invalid_user', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/settings').set('x-user-id', '0');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_user');
+  });
+
+  it('rejects negative x-user-id with 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/settings').set('x-user-id', '-5');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_user');
+  });
+
+  it('rejects non-integer x-user-id with 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/settings').set('x-user-id', 'abc');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_user');
+  });
+
+  it('rejects fractional x-user-id with 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/settings').set('x-user-id', '1.5');
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts valid x-user-id', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/settings').set('x-user-id', '1');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('parseYearMonth edge cases', () => {
+  it('year below range → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/months/1800/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+
+  it('year above range → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/months/3000/6');
+    expect(res.status).toBe(400);
+  });
+
+  it('non-numeric year → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/months/abc/6');
+    expect(res.status).toBe(400);
+  });
+
+  it('month=0 → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/months/2024/0');
+    expect(res.status).toBe(400);
+  });
+
+  it('month=13 → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/months/2024/13');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('parsePagination edge cases', () => {
+  it('limit=0 → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/expenses?limit=0');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+
+  it('limit > 500 → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/expenses?limit=501');
+    expect(res.status).toBe(400);
+  });
+
+  it('non-integer limit → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/expenses?limit=abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('invalid cursor (non-base64) → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/expenses?cursor=!!!notbase64!!!');
+    expect(res.status).toBe(400);
+  });
+
+  it('valid cursor accepted', async () => {
+    const { app } = makeApp();
+    const cursor = Buffer.from('0', 'utf8').toString('base64url');
+    const res = await request(app).get(`/api/v1/expense-tracker/expenses?cursor=${cursor}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('limit at max boundary (500) accepted', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/expenses?limit=500');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('error envelope shape', () => {
+  it('400 errors include code + message', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/months/abc/6');
+    expect(res.body.error).toHaveProperty('code');
+    expect(res.body.error).toHaveProperty('message');
+  });
+
+  it('Content-Type is application/json on errors', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/expense-tracker/months/abc/6');
+    expect(res.headers['content-type']).toMatch(/json/);
+  });
+});
+
+describe('JSON body parsing', () => {
+  it('handles malformed JSON without crashing', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/expense-tracker/expenses')
+      .set('Content-Type', 'application/json')
+      .send('{ not json ');
+    // The fallback error handler returns 500 for body-parser SyntaxError;
+    // either 400 or 500 is acceptable — we just need a structured envelope.
+    expect([400, 500]).toContain(res.status);
+    expect(res.body.error).toHaveProperty('code');
+  });
+});

--- a/server/test/monteCarlo.test.ts
+++ b/server/test/monteCarlo.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const fullRun = {
+  numSimulations: 10000,
+  stockVolatility: 0.15,
+  bondVolatility: 0.05,
+  blackSwanProbability: 0.02,
+  blackSwanImpact: 0.4,
+  successCount: 9500,
+  failureCount: 500,
+  successRate: 0.95,
+  medianYearsToFIRE: 22,
+  fixedParameters: { initialSavings: 10000 },
+};
+
+describe('POST /api/v1/calculator/monte-carlo/runs', () => {
+  it('creates a run', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/calculator/monte-carlo/runs').send(fullRun);
+    expect(res.status).toBe(201);
+    expect(res.body.successRate).toBe(0.95);
+    expect(res.body.numSimulations).toBe(10000);
+    expect(typeof res.body.id).toBe('number');
+    expect(res.body.fixedParameters).toEqual({ initialSavings: 10000 });
+  });
+
+  it('accepts null medianYearsToFIRE', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/calculator/monte-carlo/runs')
+      .send({ ...fullRun, medianYearsToFIRE: null });
+    expect(res.status).toBe(201);
+    expect(res.body.medianYearsToFIRE).toBeNull();
+  });
+
+  it('accepts optional logs array', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/calculator/monte-carlo/runs')
+      .send({ ...fullRun, logs: [{ level: 'info', msg: 'ok' }] });
+    expect(res.status).toBe(201);
+    expect(res.body.logs).toEqual([{ level: 'info', msg: 'ok' }]);
+  });
+
+  it('rejects missing required field', async () => {
+    const { app } = makeApp();
+    const { numSimulations: _omit, ...partial } = fullRun;
+    const res = await request(app).post('/api/v1/calculator/monte-carlo/runs').send(partial);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+    expect(res.body.error.message).toContain('numSimulations');
+  });
+});
+
+describe('GET /api/v1/calculator/monte-carlo/runs', () => {
+  it('returns empty paginated list', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/calculator/monte-carlo/runs');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it('paginates with limit and cursor', async () => {
+    const { app } = makeApp();
+    for (let i = 0; i < 3; i++) {
+      await request(app).post('/api/v1/calculator/monte-carlo/runs').send(fullRun);
+    }
+    const first = await request(app).get('/api/v1/calculator/monte-carlo/runs?limit=2');
+    expect(first.status).toBe(200);
+    expect(first.body.items.length).toBe(2);
+    expect(first.body.nextCursor).not.toBeNull();
+    const second = await request(app).get(
+      `/api/v1/calculator/monte-carlo/runs?limit=2&cursor=${first.body.nextCursor}`,
+    );
+    expect(second.body.items.length).toBe(1);
+    expect(second.body.nextCursor).toBeNull();
+  });
+
+  it('rejects limit over 500', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/calculator/monte-carlo/runs?limit=501');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+});
+
+describe('GET /api/v1/calculator/monte-carlo/runs/:id', () => {
+  it('returns the run', async () => {
+    const { app } = makeApp();
+    const create = await request(app).post('/api/v1/calculator/monte-carlo/runs').send(fullRun);
+    const res = await request(app).get(`/api/v1/calculator/monte-carlo/runs/${create.body.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(create.body.id);
+    expect(res.body.successRate).toBe(0.95);
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/calculator/monte-carlo/runs/99999');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+
+  it('rejects non-positive id', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/calculator/monte-carlo/runs/0');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+});
+
+describe('DELETE /api/v1/calculator/monte-carlo/runs/:id', () => {
+  it('deletes a run', async () => {
+    const { app } = makeApp();
+    const create = await request(app).post('/api/v1/calculator/monte-carlo/runs').send(fullRun);
+    const del = await request(app).delete(`/api/v1/calculator/monte-carlo/runs/${create.body.id}`);
+    expect(del.status).toBe(204);
+    const after = await request(app).get(`/api/v1/calculator/monte-carlo/runs/${create.body.id}`);
+    expect(after.status).toBe(404);
+  });
+
+  it('returns 404 when missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete('/api/v1/calculator/monte-carlo/runs/99999');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+});

--- a/server/test/netWorth.test.ts
+++ b/server/test/netWorth.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const base = '/api/v1/net-worth';
+
+const holding = (o: Record<string, unknown> = {}) => ({
+  externalId: 'h-1', ticker: 'VOO', name: 'Vanguard 500',
+  shares: 10, pricePerShare: 400, currency: 'USD', assetClass: 'ETF',
+  ...o,
+});
+const cash = (o: Record<string, unknown> = {}) => ({
+  externalId: 'c-1', accountName: 'Main', accountType: 'CHECKING',
+  balance: 1000, currency: 'EUR', ...o,
+});
+const pension = (o: Record<string, unknown> = {}) => ({
+  externalId: 'p-1', name: 'Plan A', currentValue: 50000,
+  currency: 'EUR', pensionType: 'PRIVATE', ...o,
+});
+const debt = (o: Record<string, unknown> = {}) => ({
+  externalId: 'd-1', name: 'Loan', debtType: 'PERSONAL_LOAN',
+  currentBalance: 5000, currency: 'EUR', ...o,
+});
+const tax = (o: Record<string, unknown> = {}) => ({
+  externalId: 't-1', name: 'Income Tax 2024', taxType: 'INCOME_TAX',
+  amount: 1200, currency: 'EUR', isPaid: false, ...o,
+});
+const op = (o: Record<string, unknown> = {}) => ({
+  externalId: 'o-1', date: '2024-06-01', type: 'PURCHASE',
+  description: 'Bought ETF', amount: 500, currency: 'EUR', ...o,
+});
+
+describe('net-worth config', () => {
+  it('GET returns defaults', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/config`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      defaultCurrency: 'EUR',
+      showPensionInNetWorth: true,
+      includeUnrealizedGains: true,
+      syncWithAssetAllocation: false,
+    });
+  });
+
+  it('PUT updates config', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/config`).send({
+      defaultCurrency: 'USD', currentYear: 2025, currentMonth: 3,
+      showPensionInNetWorth: false, includeUnrealizedGains: false,
+      syncWithAssetAllocation: true,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.defaultCurrency).toBe('USD');
+    expect(res.body.syncWithAssetAllocation).toBe(true);
+  });
+
+  it('PUT missing field → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/config`).send({ defaultCurrency: 'EUR' });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT invalid currency → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/config`).send({
+      defaultCurrency: 'XXX', currentYear: 2024, currentMonth: 1,
+      showPensionInNetWorth: true, includeUnrealizedGains: true,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('net-worth snapshot & months', () => {
+  it('GET snapshot returns shell with config', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/snapshot`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('years');
+    expect(res.body).toHaveProperty('defaultCurrency');
+    expect(res.body.settings).toBeDefined();
+  });
+
+  it('GET month auto-creates empty month', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/months/2024/6`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ year: 2024, month: 6, isFrozen: false });
+    expect(res.body.assets).toEqual([]);
+  });
+
+  it('PUT month replaces contents', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put(`${base}/months/2024/7`).send({
+      assets: [holding()],
+      cashEntries: [cash()],
+      pensions: [pension()],
+      debts: [debt()],
+      taxes: [tax()],
+      operations: [op()],
+      isFrozen: false,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.assets).toHaveLength(1);
+    expect(res.body.cashEntries).toHaveLength(1);
+    expect(res.body.pensions).toHaveLength(1);
+    expect(res.body.debts).toHaveLength(1);
+    expect(res.body.taxes).toHaveLength(1);
+    expect(res.body.operations).toHaveLength(1);
+  });
+
+  it('PATCH month sets isFrozen', async () => {
+    const { app } = makeApp();
+    await request(app).get(`${base}/months/2024/8`);
+    const res = await request(app).patch(`${base}/months/2024/8`).send({ isFrozen: true });
+    expect(res.status).toBe(200);
+    expect(res.body.isFrozen).toBe(true);
+    expect(res.body.frozenDate).toBeTruthy();
+  });
+
+  it('PATCH monthNote updates note', async () => {
+    const { app } = makeApp();
+    await request(app).get(`${base}/months/2024/9`);
+    const res = await request(app).patch(`${base}/months/2024/9`).send({ monthNote: 'hi' });
+    expect(res.body.monthNote).toBe('hi');
+  });
+});
+
+describe('net-worth holdings', () => {
+  it('POST creates holding', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/holdings`).send(holding());
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ externalId: 'h-1', ticker: 'VOO', assetClass: 'ETF' });
+  });
+
+  it('POST invalid assetClass → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/holdings`).send(holding({ assetClass: 'NOPE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST invalid currency → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/holdings`).send(holding({ currency: 'XXX' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('POST missing field → 400', async () => {
+    const { app } = makeApp();
+    const { shares, ...rest } = holding();
+    void shares;
+    const res = await request(app).post(`${base}/months/2024/6/holdings`).send(rest);
+    expect(res.status).toBe(400);
+  });
+
+  it('GET lists holdings', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/holdings`).send(holding({ externalId: 'h-a' }));
+    await request(app).post(`${base}/months/2024/6/holdings`).send(holding({ externalId: 'h-b' }));
+    const res = await request(app).get(`${base}/months/2024/6/holdings`);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('PUT upserts holding', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/holdings`).send(holding());
+    const res = await request(app).put(`${base}/months/2024/6/holdings/h-1`)
+      .send(holding({ shares: 99 }));
+    expect(res.status).toBe(200);
+    expect(res.body.shares).toBe(99);
+  });
+
+  it('DELETE removes holding', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/holdings`).send(holding());
+    const res = await request(app).delete(`${base}/months/2024/6/holdings/h-1`);
+    expect(res.status).toBe(204);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/months/2024/6/holdings/missing`);
+    expect(res.status).toBe(404);
+  });
+
+  it('POST holding with vehicleDepreciation block', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/holdings`).send(holding({
+      assetClass: 'VEHICLE',
+      vehicleDepreciation: {
+        method: 'STRAIGHT_LINE', purchasePrice: 20000,
+        purchaseDate: '2020-01-01', salvageValue: 2000, usefulLifeYears: 10,
+      },
+    }));
+    expect(res.status).toBe(201);
+    expect(res.body.vehicleDepreciation).toBeDefined();
+  });
+
+  it('POST holding with invalid vehicleDepreciation.method → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/holdings`).send(holding({
+      assetClass: 'VEHICLE',
+      vehicleDepreciation: {
+        method: 'WRONG', purchasePrice: 1, purchaseDate: '2020-01-01',
+        salvageValue: 1, usefulLifeYears: 1,
+      },
+    }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('net-worth cash entries', () => {
+  it('POST creates cash entry', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/cash`).send(cash());
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ externalId: 'c-1', balance: 1000 });
+  });
+
+  it('POST invalid accountType → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/cash`).send(cash({ accountType: 'BAD' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT upserts cash entry', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/cash`).send(cash());
+    const res = await request(app).put(`${base}/months/2024/6/cash/c-1`).send(cash({ balance: 9000 }));
+    expect(res.status).toBe(200);
+    expect(res.body.balance).toBe(9000);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/months/2024/6/cash/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('net-worth pension entries', () => {
+  it('POST creates pension', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/pensions`).send(pension());
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ externalId: 'p-1', pensionType: 'PRIVATE' });
+  });
+
+  it('POST invalid pensionType → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/pensions`).send(pension({ pensionType: 'NOPE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT upserts pension', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/pensions`).send(pension());
+    const res = await request(app).put(`${base}/months/2024/6/pensions/p-1`)
+      .send(pension({ currentValue: 80000 }));
+    expect(res.body.currentValue).toBe(80000);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/months/2024/6/pensions/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('net-worth debt entries', () => {
+  it('POST creates debt', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/debts`).send(debt());
+    expect(res.status).toBe(201);
+  });
+
+  it('POST invalid debtType → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/debts`).send(debt({ debtType: 'NOPE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT upserts debt', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/debts`).send(debt());
+    const res = await request(app).put(`${base}/months/2024/6/debts/d-1`).send(debt({ currentBalance: 4500 }));
+    expect(res.body.currentBalance).toBe(4500);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/months/2024/6/debts/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('net-worth tax entries', () => {
+  it('POST creates tax', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/taxes`).send(tax());
+    expect(res.status).toBe(201);
+    expect(res.body.isPaid).toBe(false);
+  });
+
+  it('POST invalid taxType → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/taxes`).send(tax({ taxType: 'NOPE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT upserts tax', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/taxes`).send(tax());
+    const res = await request(app).put(`${base}/months/2024/6/taxes/t-1`).send(tax({ isPaid: true }));
+    expect(res.body.isPaid).toBe(true);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/months/2024/6/taxes/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('net-worth operations (paginated)', () => {
+  it('POST creates operation', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/operations`).send(op());
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ externalId: 'o-1', type: 'PURCHASE' });
+  });
+
+  it('POST invalid type → 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post(`${base}/months/2024/6/operations`).send(op({ type: 'NOPE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('GET returns paginated items', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/operations`).send(op({ externalId: 'o-a' }));
+    await request(app).post(`${base}/months/2024/6/operations`).send(op({ externalId: 'o-b' }));
+    const res = await request(app).get(`${base}/months/2024/6/operations`);
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body).toHaveProperty('nextCursor');
+  });
+
+  it('PUT upserts operation', async () => {
+    const { app } = makeApp();
+    await request(app).post(`${base}/months/2024/6/operations`).send(op());
+    const res = await request(app).put(`${base}/months/2024/6/operations/o-1`).send(op({ amount: 999 }));
+    expect(res.body.amount).toBe(999);
+  });
+
+  it('DELETE missing → 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete(`${base}/months/2024/6/operations/missing`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('net-worth user scoping', () => {
+  it('GET holdings empty after fresh init for user 1', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get(`${base}/months/2024/6/holdings`).set('x-user-id', '1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});

--- a/server/test/notifications.test.ts
+++ b/server/test/notifications.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const validNotif = {
+  type: 'SYSTEM',
+  title: 'Hello',
+  message: 'World',
+};
+
+describe('POST /api/v1/notifications', () => {
+  it('creates a notification with defaults', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/notifications').send(validNotif);
+    expect(res.status).toBe(201);
+    expect(res.body.type).toBe('SYSTEM');
+    expect(res.body.priority).toBe('MEDIUM');
+    expect(res.body.read).toBe(false);
+    expect(res.body.externalId).toMatch(/^notif-/);
+    expect(res.body.id).toBeGreaterThan(0);
+  });
+
+  it('uses provided externalId and priority', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/notifications')
+      .send({ ...validNotif, externalId: 'ext-1', priority: 'HIGH' });
+    expect(res.status).toBe(201);
+    expect(res.body.externalId).toBe('ext-1');
+    expect(res.body.priority).toBe('HIGH');
+  });
+
+  it('returns 409 on duplicate externalId', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'dup' });
+    const res = await request(app)
+      .post('/api/v1/notifications')
+      .send({ ...validNotif, externalId: 'dup' });
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('conflict');
+  });
+
+  it('rejects missing fields', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/notifications').send({ type: 'SYSTEM' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('rejects invalid type', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/notifications')
+      .send({ ...validNotif, type: 'BOGUS' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toContain('Invalid type');
+  });
+
+  it('rejects invalid priority', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/notifications')
+      .send({ ...validNotif, priority: 'URGENT' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toContain('Invalid priority');
+  });
+});
+
+describe('GET /api/v1/notifications', () => {
+  it('returns empty', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/notifications');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it('lists ordered by timestamp desc', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, title: 'A' });
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, title: 'B' });
+    const res = await request(app).get('/api/v1/notifications');
+    expect(res.body.items.length).toBe(2);
+  });
+
+  it('filters by unreadOnly', async () => {
+    const { app } = makeApp();
+    const c1 = await request(app)
+      .post('/api/v1/notifications')
+      .send({ ...validNotif, externalId: 'a' });
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'b' });
+    await request(app).patch(`/api/v1/notifications/${c1.body.externalId}`).send({ read: true });
+    const res = await request(app).get('/api/v1/notifications?unreadOnly=true');
+    expect(res.body.items.length).toBe(1);
+    expect(res.body.items[0].externalId).toBe('b');
+  });
+
+  it('paginates', async () => {
+    const { app } = makeApp();
+    for (let i = 0; i < 3; i++) {
+      await request(app)
+        .post('/api/v1/notifications')
+        .send({ ...validNotif, externalId: `p${i}` });
+    }
+    const first = await request(app).get('/api/v1/notifications?limit=2');
+    expect(first.body.items.length).toBe(2);
+    expect(first.body.nextCursor).not.toBeNull();
+    const second = await request(app).get(
+      `/api/v1/notifications?limit=2&cursor=${first.body.nextCursor}`,
+    );
+    expect(second.body.items.length).toBe(1);
+    expect(second.body.nextCursor).toBeNull();
+  });
+});
+
+describe('GET/PATCH/DELETE /api/v1/notifications/:externalId', () => {
+  it('gets a notification by externalId', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'g1' });
+    const res = await request(app).get('/api/v1/notifications/g1');
+    expect(res.status).toBe(200);
+    expect(res.body.externalId).toBe('g1');
+  });
+
+  it('returns 404 for unknown', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/notifications/missing');
+    expect(res.status).toBe(404);
+  });
+
+  it('marks read via patch', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'p1' });
+    const res = await request(app).patch('/api/v1/notifications/p1').send({ read: true });
+    expect(res.status).toBe(200);
+    expect(res.body.read).toBe(true);
+  });
+
+  it('rejects non-boolean read', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'p2' });
+    const res = await request(app).patch('/api/v1/notifications/p2').send({ read: 'yes' });
+    expect(res.status).toBe(400);
+  });
+
+  it('deletes a notification', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'd1' });
+    const del = await request(app).delete('/api/v1/notifications/d1');
+    expect(del.status).toBe(204);
+    const get = await request(app).get('/api/v1/notifications/d1');
+    expect(get.status).toBe(404);
+  });
+});
+
+describe('POST /api/v1/notifications/mark-all-read', () => {
+  it('marks all unread as read', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'm1' });
+    await request(app).post('/api/v1/notifications').send({ ...validNotif, externalId: 'm2' });
+    const res = await request(app).post('/api/v1/notifications/mark-all-read');
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBe(2);
+    const list = await request(app).get('/api/v1/notifications?unreadOnly=true');
+    expect(list.body.items.length).toBe(0);
+  });
+});

--- a/server/test/pdfImports.test.ts
+++ b/server/test/pdfImports.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const validDraft = {
+  id: 'd-1',
+  kind: 'expense',
+  date: '2024-03-15T00:00:00Z',
+  amount: 12.5,
+  description: 'Coffee',
+  docType: 'receipt',
+  sourceFile: 'receipt.pdf',
+  include: true,
+  confidence: 0.9,
+  suggestedCategory: 'FOOD',
+  suggestedExpenseType: 'WANT',
+  currency: 'EUR',
+};
+
+const validImport = {
+  sourceFile: 'receipt.pdf',
+  docType: 'receipt',
+  drafts: [validDraft],
+};
+
+describe('POST /api/v1/pdf-imports', () => {
+  it('creates import with pending status', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe('pending');
+    expect(res.body.drafts.length).toBe(1);
+    expect(res.body.drafts[0].id).toBe('d-1');
+  });
+
+  it('rejects missing required field', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/pdf-imports').send({ sourceFile: 'a.pdf' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid docType', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/pdf-imports')
+      .send({ ...validImport, docType: 'bogus' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects drafts not array', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/pdf-imports')
+      .send({ ...validImport, drafts: 'not an array' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects draft missing field', async () => {
+    const { app } = makeApp();
+    const { id: _omit, ...bad } = validDraft;
+    const res = await request(app)
+      .post('/api/v1/pdf-imports')
+      .send({ ...validImport, drafts: [bad] });
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toContain('drafts[0]');
+  });
+
+  it('rejects draft invalid kind', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/pdf-imports')
+      .send({ ...validImport, drafts: [{ ...validDraft, kind: 'weird' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects draft invalid docType', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/pdf-imports')
+      .send({ ...validImport, drafts: [{ ...validDraft, docType: 'auto' }] });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/v1/pdf-imports', () => {
+  it('lists imports paginated', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/pdf-imports').send(validImport);
+    await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const res = await request(app).get('/api/v1/pdf-imports');
+    expect(res.status).toBe(200);
+    expect(res.body.items.length).toBe(2);
+  });
+
+  it('filters by status', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const list = await request(app).get('/api/v1/pdf-imports?status=pending');
+    expect(list.body.items.length).toBe(1);
+    const empty = await request(app).get('/api/v1/pdf-imports?status=committed');
+    expect(empty.body.items.length).toBe(0);
+  });
+
+  it('rejects invalid status filter', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/pdf-imports?status=weird');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET/PATCH/DELETE /api/v1/pdf-imports/:id', () => {
+  it('GET by id', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const res = await request(app).get(`/api/v1/pdf-imports/${created.body.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(created.body.id);
+  });
+
+  it('GET 404 missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/pdf-imports/9999');
+    expect(res.status).toBe(404);
+  });
+
+  it('PATCH updates status', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const res = await request(app)
+      .patch(`/api/v1/pdf-imports/${created.body.id}`)
+      .send({ status: 'reviewed' });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('reviewed');
+  });
+
+  it('PATCH rejects invalid status', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const res = await request(app)
+      .patch(`/api/v1/pdf-imports/${created.body.id}`)
+      .send({ status: 'wat' });
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH updates drafts', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const res = await request(app)
+      .patch(`/api/v1/pdf-imports/${created.body.id}`)
+      .send({ drafts: [{ ...validDraft, id: 'd-99', description: 'New' }] });
+    expect(res.status).toBe(200);
+    expect(res.body.drafts[0].id).toBe('d-99');
+  });
+
+  it('DELETE removes import', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const del = await request(app).delete(`/api/v1/pdf-imports/${created.body.id}`);
+    expect(del.status).toBe(204);
+    const get = await request(app).get(`/api/v1/pdf-imports/${created.body.id}`);
+    expect(get.status).toBe(404);
+  });
+});
+
+describe('POST /api/v1/pdf-imports/:id/commit', () => {
+  it('commits drafts to expense entries', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    const res = await request(app).post(`/api/v1/pdf-imports/${created.body.id}/commit`);
+    expect(res.status).toBe(200);
+    expect(res.body.importedExpenses).toBe(1);
+    expect(res.body.importedIncomes).toBe(0);
+    const reread = await request(app).get(`/api/v1/pdf-imports/${created.body.id}`);
+    expect(reread.body.status).toBe('committed');
+    expect(reread.body.committedAt).not.toBeNull();
+  });
+
+  it('commits income drafts to income entries', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send({
+      ...validImport,
+      drafts: [
+        {
+          ...validDraft,
+          kind: 'income',
+          id: 'i-1',
+          suggestedIncomeSource: 'SALARY',
+        },
+      ],
+    });
+    const res = await request(app).post(`/api/v1/pdf-imports/${created.body.id}/commit`);
+    expect(res.body.importedIncomes).toBe(1);
+    expect(res.body.importedExpenses).toBe(0);
+  });
+
+  it('skips drafts with include=false', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send({
+      ...validImport,
+      drafts: [{ ...validDraft, include: false }],
+    });
+    const res = await request(app).post(`/api/v1/pdf-imports/${created.body.id}/commit`);
+    expect(res.body.importedExpenses).toBe(0);
+  });
+
+  it('returns 409 if already committed', async () => {
+    const { app } = makeApp();
+    const created = await request(app).post('/api/v1/pdf-imports').send(validImport);
+    await request(app).post(`/api/v1/pdf-imports/${created.body.id}/commit`);
+    const res = await request(app).post(`/api/v1/pdf-imports/${created.body.id}/commit`);
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 404 for missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/pdf-imports/9999/commit');
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/test/portfolioBreakdown.test.ts
+++ b/server/test/portfolioBreakdown.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const stockAsset = {
+  externalId: 'sa-1',
+  name: 'Vanguard SP500',
+  ticker: 'VOO',
+  assetClass: 'STOCKS',
+  subAssetType: 'ETF',
+  currentValue: 1000,
+  targetMode: 'PERCENTAGE',
+  originalCurrency: 'USD',
+};
+
+const cashAsset = {
+  externalId: 'sa-2',
+  name: 'EUR cash',
+  ticker: '',
+  assetClass: 'CASH',
+  subAssetType: 'SAVINGS_ACCOUNT',
+  currentValue: 500,
+  targetMode: 'OFF',
+  originalCurrency: 'EUR',
+};
+
+describe('PUT/GET /api/v1/portfolio-breakdown/metadata/:ticker', () => {
+  it('upserts and reads metadata', async () => {
+    const { app } = makeApp();
+    const put = await request(app).put('/api/v1/portfolio-breakdown/metadata/VOO').send({
+      longName: 'Vanguard 500',
+      currency: 'USD',
+      exchange: 'NYSE',
+      sector: 'Diversified',
+      country: 'United States',
+      fundFamily: 'Vanguard',
+      sectorWeightings: [
+        { sector: 'Tech', weight: 0.3 },
+        { sector: 'Health', weight: 0.7 },
+      ],
+      regionWeightings: [{ region: 'North America', weight: 1.0 }],
+    });
+    expect(put.status).toBe(200);
+    expect(put.body.ticker).toBe('VOO');
+    expect(put.body.sectorWeightings.length).toBe(2);
+
+    const get = await request(app).get('/api/v1/portfolio-breakdown/metadata/VOO');
+    expect(get.status).toBe(200);
+    expect(get.body.longName).toBe('Vanguard 500');
+    expect(get.body.regionWeightings[0].region).toBe('North America');
+  });
+
+  it('GET returns 404 when missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/portfolio-breakdown/metadata/MISSING');
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT updates same ticker (upsert)', async () => {
+    const { app } = makeApp();
+    await request(app).put('/api/v1/portfolio-breakdown/metadata/AAA').send({ longName: 'v1' });
+    const res = await request(app).put('/api/v1/portfolio-breakdown/metadata/AAA').send({ longName: 'v2' });
+    expect(res.body.longName).toBe('v2');
+  });
+});
+
+describe('GET /api/v1/portfolio-breakdown', () => {
+  it('requires dimension', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/portfolio-breakdown');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+
+  it('rejects unknown dimension', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/portfolio-breakdown?dimension=galaxy');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns currency breakdown', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(stockAsset);
+    await request(app).post('/api/v1/asset-allocation/assets').send(cashAsset);
+    const res = await request(app).get('/api/v1/portfolio-breakdown?dimension=currency');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    const [out] = res.body;
+    expect(out.dimension).toBe('currency');
+    expect(out.totalValue).toBe(1500);
+    const labels = out.entries.map((e: { label: string }) => e.label).sort();
+    expect(labels).toEqual(['EUR', 'USD']);
+  });
+
+  it('accepts multiple dimensions', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(stockAsset);
+    const res = await request(app).get(
+      '/api/v1/portfolio-breakdown?dimension=currency&dimension=holding',
+    );
+    expect(res.body.length).toBe(2);
+    expect(res.body[0].dimension).toBe('currency');
+    expect(res.body[1].dimension).toBe('holding');
+  });
+
+  it('counts assets without metadata as unknownValue for sector', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(stockAsset);
+    const res = await request(app).get('/api/v1/portfolio-breakdown?dimension=sector');
+    expect(res.body[0].unknownValue).toBe(1000);
+  });
+
+  it('applies sector weightings from metadata', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/asset-allocation/assets').send(stockAsset);
+    await request(app).put('/api/v1/portfolio-breakdown/metadata/VOO').send({
+      sectorWeightings: [
+        { sector: 'Tech', weight: 0.6 },
+        { sector: 'Health', weight: 0.4 },
+      ],
+    });
+    const res = await request(app).get('/api/v1/portfolio-breakdown?dimension=sector');
+    const entries = res.body[0].entries;
+    const tech = entries.find((e: { label: string }) => e.label === 'Tech');
+    const health = entries.find((e: { label: string }) => e.label === 'Health');
+    expect(tech.value).toBeCloseTo(600);
+    expect(health.value).toBeCloseTo(400);
+    expect(res.body[0].unknownValue).toBe(0);
+  });
+});

--- a/server/test/questionnaire.test.ts
+++ b/server/test/questionnaire.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const fullPayload = {
+  persona: 'REGULAR_FIRE',
+  personaExplanation: 'A balanced FIRE seeker',
+  safeWithdrawalRate: 4,
+  suggestedSavingsRate: 50,
+  assetAllocation: { stocks: 70, bonds: 25, cash: 5 },
+  suitableAssets: ['ETF', 'BONDS'],
+  riskTolerance: 'moderate',
+  responses: [{ q: 'age', a: 30 }],
+};
+
+describe('POST /api/v1/questionnaire/results', () => {
+  it('stores a result', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/v1/questionnaire/results').send(fullPayload);
+    expect(res.status).toBe(201);
+    expect(res.body.persona).toBe('REGULAR_FIRE');
+    expect(res.body.assetAllocation.stocks).toBe(70);
+    expect(typeof res.body.id).toBe('number');
+  });
+
+  it('accepts optional crypto and realEstate allocations', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/questionnaire/results')
+      .send({
+        ...fullPayload,
+        assetAllocation: { stocks: 60, bonds: 20, cash: 5, crypto: 10, realEstate: 5 },
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.assetAllocation.crypto).toBe(10);
+    expect(res.body.assetAllocation.realEstate).toBe(5);
+  });
+
+  it('rejects invalid persona', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/questionnaire/results')
+      .send({ ...fullPayload, persona: 'WEIRD_FIRE' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('rejects invalid riskTolerance', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/questionnaire/results')
+      .send({ ...fullPayload, riskTolerance: 'YOLO' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('rejects missing required field', async () => {
+    const { app } = makeApp();
+    const { persona: _omit, ...partial } = fullPayload;
+    const res = await request(app).post('/api/v1/questionnaire/results').send(partial);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('rejects non-numeric allocation values', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post('/api/v1/questionnaire/results')
+      .send({ ...fullPayload, assetAllocation: { stocks: 'a lot', bonds: 25, cash: 5 } });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+});
+
+describe('GET /api/v1/questionnaire/results', () => {
+  it('returns empty array initially', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/questionnaire/results');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('returns array of results', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/questionnaire/results').send(fullPayload);
+    await request(app).post('/api/v1/questionnaire/results').send({ ...fullPayload, persona: 'LEAN_FIRE' });
+    const res = await request(app).get('/api/v1/questionnaire/results');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+  });
+});
+
+describe('GET /api/v1/questionnaire/results/latest', () => {
+  it('returns 404 when no results', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/questionnaire/results/latest');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+
+  it('returns most recent result', async () => {
+    const { app } = makeApp();
+    await request(app).post('/api/v1/questionnaire/results').send(fullPayload);
+    await request(app).post('/api/v1/questionnaire/results').send({ ...fullPayload, persona: 'FAT_FIRE' });
+    const res = await request(app).get('/api/v1/questionnaire/results/latest');
+    expect(res.status).toBe(200);
+    expect(res.body.persona).toBe('FAT_FIRE');
+  });
+});

--- a/server/test/settings.test.ts
+++ b/server/test/settings.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+const validSettings = {
+  accountName: 'Alice',
+  decimalSeparator: '.',
+  decimalPlaces: 2,
+  currencySettings: {
+    defaultCurrency: 'EUR',
+    fallbackRates: { USD: 1.1 },
+    useApiRates: true,
+    lastApiUpdate: null,
+  },
+  privacyMode: false,
+  dateFormat: 'YYYY-MM-DD',
+  fireAssetClassInclusion: { STOCKS: true },
+  includePrimaryResidenceInFIRE: false,
+  searchThreshold: 0.4,
+  experimentalFeatures: { foo: true },
+};
+
+const validNotifPref = {
+  enableInAppNotifications: true,
+  newMonthReminders: true,
+  newQuarterReminders: false,
+  taxReminders: true,
+  dcaReminders: false,
+  portfolioAlerts: true,
+  fireMilestones: true,
+  enableEmailNotifications: false,
+  emailAddress: 'a@b.com',
+  emailFrequency: 'DAILY',
+  taxReminderMonths: [3, 6, 9, 12],
+  taxReminderDaysBefore: 7,
+};
+
+describe('GET /api/v1/settings', () => {
+  it('auto-creates and returns default settings', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/settings');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('accountName');
+    expect(res.body).toHaveProperty('decimalSeparator');
+    expect(res.body).toHaveProperty('currencySettings');
+    expect(res.body.currencySettings).toHaveProperty('defaultCurrency');
+    expect(typeof res.body.privacyMode).toBe('boolean');
+    expect(typeof res.body.includePrimaryResidenceInFIRE).toBe('boolean');
+  });
+});
+
+describe('PUT /api/v1/settings', () => {
+  it('replaces all settings fields', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/settings').send(validSettings);
+    expect(res.status).toBe(200);
+    expect(res.body.accountName).toBe('Alice');
+    expect(res.body.decimalSeparator).toBe('.');
+    expect(res.body.privacyMode).toBe(false);
+    expect(res.body.currencySettings.defaultCurrency).toBe('EUR');
+    expect(res.body.fireAssetClassInclusion).toEqual({ STOCKS: true });
+  });
+
+  it('rejects missing required field', async () => {
+    const { app } = makeApp();
+    const { decimalSeparator: _x, ...partial } = validSettings;
+    const res = await request(app).put('/api/v1/settings').send(partial);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+    expect(res.body.error.message).toContain('decimalSeparator');
+  });
+});
+
+describe('PATCH /api/v1/settings', () => {
+  it('applies partial updates', async () => {
+    const { app } = makeApp();
+    const res = await request(app).patch('/api/v1/settings').send({ accountName: 'Bob' });
+    expect(res.status).toBe(200);
+    expect(res.body.accountName).toBe('Bob');
+  });
+
+  it('ignores invalid decimalSeparator silently', async () => {
+    const { app } = makeApp();
+    const res = await request(app).patch('/api/v1/settings').send({ decimalSeparator: 'X' });
+    expect(res.status).toBe(200);
+    expect(res.body.decimalSeparator).not.toBe('X');
+  });
+
+  it('clears llmCategorization when set to null', async () => {
+    const { app } = makeApp();
+    await request(app)
+      .patch('/api/v1/settings')
+      .send({
+        llmCategorization: { baseUrl: 'http://x', apiKey: 'k', model: 'm' },
+      });
+    const before = await request(app).get('/api/v1/settings');
+    expect(before.body.llmCategorization).toBeDefined();
+    await request(app).patch('/api/v1/settings').send({ llmCategorization: null });
+    const after = await request(app).get('/api/v1/settings');
+    expect(after.body.llmCategorization).toBeUndefined();
+  });
+});
+
+describe('GET /api/v1/settings/notifications', () => {
+  it('returns defaults', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/settings/notifications');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('enableInAppNotifications');
+    expect(res.body).toHaveProperty('taxReminderMonths');
+    expect(Array.isArray(res.body.taxReminderMonths)).toBe(true);
+  });
+});
+
+describe('PUT /api/v1/settings/notifications', () => {
+  it('replaces all fields', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/settings/notifications').send(validNotifPref);
+    expect(res.status).toBe(200);
+    expect(res.body.emailAddress).toBe('a@b.com');
+    expect(res.body.taxReminderMonths).toEqual([3, 6, 9, 12]);
+  });
+
+  it('rejects missing required field', async () => {
+    const { app } = makeApp();
+    const { emailAddress: _x, ...partial } = validNotifPref;
+    const res = await request(app).put('/api/v1/settings/notifications').send(partial);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+});
+
+describe('settings multi-user isolation', () => {
+  it('keeps settings separate per x-user-id', async () => {
+    const { app, db } = makeApp();
+    db.prepare(
+      "INSERT INTO users (id, email, created_at) VALUES (2, 'two@x', '2024-01-01T00:00:00Z')",
+    ).run();
+    await request(app)
+      .patch('/api/v1/settings')
+      .set('x-user-id', '1')
+      .send({ accountName: 'OneName' });
+    await request(app)
+      .patch('/api/v1/settings')
+      .set('x-user-id', '2')
+      .send({ accountName: 'TwoName' });
+    const u1 = await request(app).get('/api/v1/settings').set('x-user-id', '1');
+    const u2 = await request(app).get('/api/v1/settings').set('x-user-id', '2');
+    expect(u1.body.accountName).toBe('OneName');
+    expect(u2.body.accountName).toBe('TwoName');
+  });
+});

--- a/server/test/uiPreferences.test.ts
+++ b/server/test/uiPreferences.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+describe('GET /api/v1/ui-preferences', () => {
+  it('returns empty preferences object', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/ui-preferences');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ preferences: {} });
+  });
+});
+
+describe('PUT /api/v1/ui-preferences/:key', () => {
+  it('creates a preference', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/ui-preferences/theme').send({ value: 'dark' });
+    expect(res.status).toBe(200);
+    expect(res.body.key).toBe('theme');
+    expect(res.body.value).toBe('dark');
+    expect(typeof res.body.updatedAt).toBe('string');
+  });
+
+  it('upserts existing preference', async () => {
+    const { app } = makeApp();
+    await request(app).put('/api/v1/ui-preferences/theme').send({ value: 'dark' });
+    const res = await request(app).put('/api/v1/ui-preferences/theme').send({ value: 'light' });
+    expect(res.status).toBe(200);
+    expect(res.body.value).toBe('light');
+  });
+
+  it('rejects key starting with digit', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/ui-preferences/1invalid').send({ value: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+
+  it('rejects key with invalid chars', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/ui-preferences/bad%20key').send({ value: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+
+  it('rejects non-string value', async () => {
+    const { app } = makeApp();
+    const res = await request(app).put('/api/v1/ui-preferences/theme').send({ value: 42 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('rejects value over 8KB', async () => {
+    const { app } = makeApp();
+    const huge = 'a'.repeat(8 * 1024 + 1);
+    const res = await request(app).put('/api/v1/ui-preferences/theme').send({ value: huge });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_body');
+  });
+
+  it('accepts value at exactly 8KB', async () => {
+    const { app } = makeApp();
+    const exact = 'a'.repeat(8 * 1024);
+    const res = await request(app).put('/api/v1/ui-preferences/edge').send({ value: exact });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /api/v1/ui-preferences/:key', () => {
+  it('returns 404 when missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/ui-preferences/nonexistent');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+
+  it('rejects invalid key in GET', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/ui-preferences/1nope');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_param');
+  });
+});
+
+describe('DELETE /api/v1/ui-preferences/:key', () => {
+  it('returns 204 on success', async () => {
+    const { app } = makeApp();
+    await request(app).put('/api/v1/ui-preferences/theme').send({ value: 'dark' });
+    const res = await request(app).delete('/api/v1/ui-preferences/theme');
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 404 when missing', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete('/api/v1/ui-preferences/nonexistent');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+});
+
+describe('multi-user ui-preferences isolation', () => {
+  it('separates by x-user-id', async () => {
+    const { app, db } = makeApp();
+    db.prepare("INSERT INTO users (id, email, created_at) VALUES (2, 'u2@x', '2024-01-01T00:00:00Z')").run();
+    await request(app).put('/api/v1/ui-preferences/k').send({ value: '1' });
+    await request(app).put('/api/v1/ui-preferences/k').set('x-user-id', '2').send({ value: '2' });
+    const r1 = await request(app).get('/api/v1/ui-preferences/k');
+    const r2 = await request(app).get('/api/v1/ui-preferences/k').set('x-user-id', '2');
+    expect(r1.body.value).toBe('1');
+    expect(r2.body.value).toBe('2');
+  });
+});

--- a/server/test/users.test.ts
+++ b/server/test/users.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { makeApp } from './helpers.js';
+
+describe('GET /api/v1/users/me', () => {
+  it('returns bootstrap user', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/v1/users/me');
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(1);
+    expect(res.body.email).toBe('local@firetools.local');
+    expect(typeof res.body.createdAt).toBe('string');
+    expect(res.body).toHaveProperty('displayName');
+  });
+
+  it('returns 404 when bootstrap user is missing', async () => {
+    const { app, db } = makeApp();
+    db.prepare('DELETE FROM users WHERE id = 1').run();
+    const res = await request(app).get('/api/v1/users/me');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+});


### PR DESCRIPTION
Closes #238.

## Summary
Adds per-router test suites covering all 15 Express routers under `server/src/routes/`. Test count grew **from 20 to 263** (16 new files, 2,456 LOC).

## Coverage per router
| Router | File | Tests |
| --- | --- | --- |
| health | `health.test.ts` | 2 |
| users | `users.test.ts` | 2 |
| settings | `settings.test.ts` | 10 |
| calculator | `calculator.test.ts` | 6 |
| uiPreferences | `uiPreferences.test.ts` | 13 |
| banks | `banks.test.ts` | 9 |
| questionnaire | `questionnaire.test.ts` | 10 |
| monteCarlo | `monteCarlo.test.ts` | 12 |
| notifications | `notifications.test.ts` | 16 |
| assetAllocation | `assetAllocation.test.ts` | 20 |
| portfolioBreakdown | `portfolioBreakdown.test.ts` | 9 |
| pdfImports | `pdfImports.test.ts` | 21 |
| expenseTracker | `expenseTracker.test.ts` | 45 |
| netWorth | `netWorth.test.ts` | 41 |
| http (cross-cutting) | `http.test.ts` | 19 |
| app + mounting | `app.test.ts` | 8 |

## What each suite checks
- Happy path CRUD for every entity
- Body & query validation → `invalid_body` / `invalid_param` envelopes
- Enum/whitelist enforcement (currencies, expense types, account types, etc.)
- Duplicate / unique constraint → `409 conflict`
- Missing-resource → `404 not_found`
- Pagination (`limit`, `cursor`, `offset`) and `nextCursor` shape
- `x-user-id` header handling
- Error envelope structure
- CORS allow / deny

## Verification
```
Test Files  18 passed (18)
     Tests  263 passed (263)
```

No production code changed — tests only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>