### PR TITLE
fix: chart age tooltip showing untranslated i18n key

### DIFF
--- a/src/components/IncomeExpensesChart.tsx
+++ b/src/components/IncomeExpensesChart.tsx
@@ -166,7 +166,7 @@ export const IncomeExpensesChart: React.FC<IncomeExpensesChartProps> = ({
           />
           <Tooltip 
             formatter={(value) => isPrivacyMode ? PRIVACY_PLACEHOLDER : formatCurrency(Number(value))} 
-            labelFormatter={(label) => t('charts.ageTooltip', { age: label })}
+            labelFormatter={(label) => t('charts.ageTooltipLabel', { age: label })}
             contentStyle={{ background: '#1A1D26', border: '1px solid #2DD4BF', borderRadius: '8px', color: '#F8FAFC' }}
             labelStyle={{ color: '#F8FAFC' }}
             itemStyle={{ color: '#F8FAFC' }}

--- a/src/components/NetWorthChart.tsx
+++ b/src/components/NetWorthChart.tsx
@@ -164,7 +164,7 @@ export const NetWorthChart: React.FC<NetWorthChartProps> = ({
           />
           <Tooltip 
             formatter={(value) => isPrivacyMode ? PRIVACY_PLACEHOLDER : formatCurrency(Number(value))} 
-            labelFormatter={(label) => t('charts.ageTooltip', { age: label })}
+            labelFormatter={(label) => t('charts.ageTooltipLabel', { age: label })}
             contentStyle={{ background: '#1A1D26', border: '1px solid #2DD4BF', borderRadius: '8px', color: '#F8FAFC' }}
             labelStyle={{ color: '#F8FAFC' }}
             itemStyle={{ color: '#F8FAFC' }}


### PR DESCRIPTION
## Problem
The Income vs Expenses and Net Worth charts displayed the literal string `charts.ageTooltip` in the tooltip header instead of the translated 'Age N' text.

## Root cause
Both chart components called `t('charts.ageTooltip', { age: label })`, but all five locale files (`en/de/es/fr/it.json`) define the key as `charts.ageTooltipLabel`. i18next renders missing keys as their literal path.

## Fix
Updated the two call sites to use the existing locale key `charts.ageTooltipLabel`. No locale changes needed.

## Verification
- `npm test` → 1069 passing
- Locale files already contain the correct translated template for all 5 languages.