### PR TITLE
fix: run pre-hook scripts before electron:dev:full

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "electron:rebuild": "node scripts/ensure-native-modules.mjs",
     "preelectron:dev": "node scripts/stop-dev.mjs && node scripts/ensure-electron.mjs && node scripts/ensure-native-modules.mjs",
     "electron:dev": "node scripts/electron-dev.mjs",
+    "preelectron:dev:full": "node scripts/stop-dev.mjs && node scripts/ensure-electron.mjs && node scripts/ensure-native-modules.mjs",
     "electron:dev:full": "node scripts/dev-electron-stack.mjs",
     "electron:build": "npm run build:electron",
     "electron:dist": "npm run build:electron && electron-builder --config electron-builder.yml"


### PR DESCRIPTION
npm only matches `pre<script>` hooks against the exact script name, so `preelectron:dev` was never running for the `:full` variant. As a result, `npm run electron:dev:full` skipped the electron binary download and native module rebuild.

Add an explicit `preelectron:dev:full` script mirroring `preelectron:dev` so both variants behave the same.

Verified via `npm pkg get scripts.preelectron:dev:full`.