### PR TITLE
chore: bump version to 2.1.1 + fix backend commit/build time in About

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fire-tools",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fire-tools",
-      "version": "2.0.1",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "stop": "node scripts/stop-dev.mjs",
     "build": "rm -rf dist && tsc && vite build",
     "postbuild": "node scripts/build-landing.mjs && node scripts/build-docs.mjs",
-    "build:electron": "tsc && vite build --mode electron && npm install --prefix server && npm --prefix server run build",
+    "build:electron": "tsc && vite build --mode electron && npm install --prefix server && npm --prefix server run build && node scripts/gen-build-meta.mjs",
     "build:landing": "node scripts/build-landing.mjs",
     "build:docs": "node scripts/build-docs.mjs",
     "docs:screenshots": "node scripts/take-screenshots.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire-tools",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "FIRE tools including calculator with Monte Carlo simulations and asset allocation manager",
   "type": "module",
   "engines": {

--- a/scripts/gen-build-meta.mjs
+++ b/scripts/gen-build-meta.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Bake build metadata (commit + build time) into `server/dist/build-meta.json`.
+ *
+ * The packaged Electron app ships the compiled backend inside an asar with no
+ * `.git` directory and no build-time env vars, so the embedded server cannot
+ * resolve its commit live. We write the values here at build time; the server's
+ * buildInfo resolver reads this file as the packaged fallback.
+ *
+ * Resolution: env (GIT_COMMIT_HASH / GIT_COMMIT, BUILD_TIME) first, then live git.
+ */
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const outDir = resolve(repoRoot, 'server', 'dist');
+const outFile = resolve(outDir, 'build-meta.json');
+
+const nonEmpty = (value) => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? trimmed : undefined;
+};
+
+const resolveCommit = () => {
+  const fromEnv = nonEmpty(process.env.GIT_COMMIT_HASH) ?? nonEmpty(process.env.GIT_COMMIT);
+  if (fromEnv) return fromEnv;
+  try {
+    return (
+      execSync('git rev-parse --short HEAD', {
+        cwd: repoRoot,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 1000,
+      })
+        .toString()
+        .trim() || 'unknown'
+    );
+  } catch {
+    return 'unknown';
+  }
+};
+
+const meta = {
+  commit: resolveCommit(),
+  buildTime: nonEmpty(process.env.BUILD_TIME) ?? new Date().toISOString(),
+};
+
+try {
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(outFile, `${JSON.stringify(meta, null, 2)}\n`, 'utf-8');
+  console.log(`[gen-build-meta] wrote ${outFile} (commit=${meta.commit}, buildTime=${meta.buildTime})`);
+} catch (err) {
+  console.error(`[gen-build-meta] failed to write ${outFile}:`, err);
+  process.exit(1);
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fire-tools-server",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fire-tools-server",
-      "version": "2.0.1",
+      "version": "2.1.1",
       "dependencies": {
         "better-sqlite3": "npm:better-sqlite3-multiple-ciphers@^12.10.0",
         "cors": "^2.8.5",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire-tools-server",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Local-deployment backend for Fire Tools (SQLite-first, Postgres-compatible). Implements docs/api/openapi.yaml.",
   "private": true,
   "type": "module",

--- a/server/src/buildInfo.ts
+++ b/server/src/buildInfo.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { logger } from './logger.js';
@@ -13,22 +14,29 @@ export interface BuildInfo {
 const FALLBACK_VERSION = '0.0.0';
 const FALLBACK_COMMIT = 'unknown';
 
-const loadPackageJson = (): {
+/** Treat empty / whitespace-only env values as absent so they don't block fallbacks. */
+const nonEmpty = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+interface PackageJson {
   version?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
-} => {
+}
+
+const loadPackageJson = (moduleDir: string): PackageJson => {
   try {
-    const here = dirname(fileURLToPath(import.meta.url));
     // From src/ (dev) or dist/ (runtime) walk up to the directory containing package.json.
     const candidates = [
-      resolve(here, '..', 'package.json'),
-      resolve(here, '..', '..', 'package.json'),
+      resolve(moduleDir, '..', 'package.json'),
+      resolve(moduleDir, '..', '..', 'package.json'),
     ];
     for (const candidate of candidates) {
       try {
         const raw = readFileSync(candidate, 'utf-8');
-        return JSON.parse(raw);
+        return JSON.parse(raw) as PackageJson;
       } catch {
         // try next candidate
       }
@@ -39,9 +47,7 @@ const loadPackageJson = (): {
   return {};
 };
 
-const pickDependencies = (
-  pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> },
-): Record<string, string> => {
+const pickDependencies = (pkg: PackageJson): Record<string, string> => {
   const all = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
   const wanted = ['better-sqlite3', 'express', 'cors', 'express-rate-limit', 'zod', 'typescript'];
   const out: Record<string, string> = {};
@@ -51,20 +57,98 @@ const pickDependencies = (
   return out;
 };
 
-let cached: BuildInfo | null = null;
+interface BuildMeta {
+  commit?: string;
+  buildTime?: string;
+}
 
-export const getBuildInfo = (): BuildInfo => {
-  if (cached) return cached;
-  const pkg = loadPackageJson();
-  const version = pkg.version ?? process.env.npm_package_version ?? FALLBACK_VERSION;
+/** Read the build metadata baked next to the compiled bundle (packaged Electron app). */
+const readBakedMeta = (moduleDir: string): BuildMeta => {
+  try {
+    const raw = readFileSync(resolve(moduleDir, 'build-meta.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as BuildMeta;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+/** Resolve the short commit hash of the checkout the process is running from. */
+const liveGitCommit = (cwd: string): string | undefined => {
+  try {
+    const out = execSync('git rev-parse --short HEAD', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1000,
+    })
+      .toString()
+      .trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Best-effort build time from the compiled module's mtime (compiled runs without baked meta). */
+const moduleMtime = (moduleFile: string): string | undefined => {
+  try {
+    return statSync(moduleFile).mtime.toISOString();
+  } catch {
+    return undefined;
+  }
+};
+
+export interface ComputeOptions {
+  env?: NodeJS.ProcessEnv;
+  /** Directory the compiled module lives in (build-meta.json / package.json resolve from here). */
+  moduleDir?: string;
+  /** File whose mtime is used as the build-time fallback. */
+  moduleFile?: string;
+  /** Working directory used for the live `git` lookup. */
+  gitCwd?: string;
+}
+
+/**
+ * Compute build metadata with graceful fallbacks. Uncached and dependency-injectable
+ * so the resolution order can be unit-tested deterministically.
+ *
+ * commit:    env -> live git (current checkout) -> baked meta (packaged) -> 'unknown'
+ * buildTime: env -> baked meta -> module mtime -> now (never null once resolvable)
+ */
+export const computeBuildInfo = (opts: ComputeOptions = {}): BuildInfo => {
+  const moduleFile = opts.moduleFile ?? fileURLToPath(import.meta.url);
+  const moduleDir = opts.moduleDir ?? dirname(moduleFile);
+  const env = opts.env ?? process.env;
+  const gitCwd = opts.gitCwd ?? moduleDir;
+
+  const pkg = loadPackageJson(moduleDir);
+  const meta = readBakedMeta(moduleDir);
+
   const commit =
-    process.env.GIT_COMMIT_HASH ?? process.env.GIT_COMMIT ?? FALLBACK_COMMIT;
-  const buildTime = process.env.BUILD_TIME ?? null;
-  cached = {
-    version,
+    nonEmpty(env.GIT_COMMIT_HASH) ??
+    nonEmpty(env.GIT_COMMIT) ??
+    liveGitCommit(gitCwd) ??
+    nonEmpty(meta.commit) ??
+    FALLBACK_COMMIT;
+
+  const buildTime =
+    nonEmpty(env.BUILD_TIME) ??
+    nonEmpty(meta.buildTime) ??
+    moduleMtime(moduleFile) ??
+    new Date().toISOString();
+
+  return {
+    version: pkg.version ?? nonEmpty(env.npm_package_version) ?? FALLBACK_VERSION,
     commit,
     buildTime,
     dependencies: pickDependencies(pkg),
   };
+};
+
+let cached: BuildInfo | null = null;
+
+export const getBuildInfo = (): BuildInfo => {
+  if (cached) return cached;
+  cached = computeBuildInfo();
   return cached;
 };

--- a/server/test/buildInfo.test.ts
+++ b/server/test/buildInfo.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { computeBuildInfo } from '../src/buildInfo.js';
+
+/** A directory that is guaranteed not to be a git checkout, so live git lookup fails. */
+const makeNonRepoDir = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'fire-buildinfo-'));
+
+describe('computeBuildInfo', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeNonRepoDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('prefers explicit env vars for commit and buildTime', () => {
+    const info = computeBuildInfo({
+      env: { GIT_COMMIT_HASH: 'abc1234', BUILD_TIME: '2024-05-01T00:00:00.000Z' },
+      moduleDir: dir,
+      gitCwd: dir,
+    });
+    expect(info.commit).toBe('abc1234');
+    expect(info.buildTime).toBe('2024-05-01T00:00:00.000Z');
+  });
+
+  it('ignores empty env values and falls through to later sources', () => {
+    fs.writeFileSync(
+      path.join(dir, 'build-meta.json'),
+      JSON.stringify({ commit: 'baked99', buildTime: '2023-01-02T03:04:05.000Z' }),
+    );
+    const info = computeBuildInfo({
+      env: { GIT_COMMIT_HASH: '   ', BUILD_TIME: '' },
+      moduleDir: dir,
+      gitCwd: dir,
+    });
+    expect(info.commit).toBe('baked99');
+    expect(info.buildTime).toBe('2023-01-02T03:04:05.000Z');
+  });
+
+  it('falls back to baked build-meta.json when env and live git are unavailable', () => {
+    fs.writeFileSync(
+      path.join(dir, 'build-meta.json'),
+      JSON.stringify({ commit: 'packaged1', buildTime: '2022-06-07T08:09:10.000Z' }),
+    );
+    const info = computeBuildInfo({ env: {}, moduleDir: dir, gitCwd: dir });
+    expect(info.commit).toBe('packaged1');
+    expect(info.buildTime).toBe('2022-06-07T08:09:10.000Z');
+  });
+
+  it('resolves the live commit from the running checkout in development', () => {
+    // Point the git lookup at the real checkout (the server package cwd).
+    const info = computeBuildInfo({ env: {}, moduleDir: dir, gitCwd: process.cwd() });
+    expect(info.commit).not.toBe('unknown');
+    expect(info.commit).toMatch(/^[0-9a-f]{7,40}$/);
+  });
+
+  it('never returns a null buildTime and degrades commit to "unknown" with no sources', () => {
+    const missingFile = path.join(dir, 'does-not-exist.js');
+    const info = computeBuildInfo({
+      env: {},
+      moduleDir: dir,
+      moduleFile: missingFile,
+      gitCwd: dir,
+    });
+    expect(info.commit).toBe('unknown');
+    expect(info.buildTime).not.toBeNull();
+    expect(() => new Date(info.buildTime as string).toISOString()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

- Bump app + server version `2.0.1` → `2.1.1` (package.json + lockfiles).
- Fix backend reporting `commit: "unknown"` and `buildTime: null` when testing the backend connection in **Settings → About**.

## Why

The embedded backend only read `GIT_COMMIT_HASH` / `BUILD_TIME` env vars (set in Docker), so in dev and in the packaged Electron app it had no commit/build time.

## How

`server/src/buildInfo.ts` now resolves with graceful fallbacks:

- **commit:** env → live `git rev-parse --short HEAD` (development) → baked `build-meta.json` (packaged) → `unknown`
- **buildTime:** env → baked meta → compiled module mtime → now (never `null`)

A new `scripts/gen-build-meta.mjs` bakes `server/dist/build-meta.json` during `build:electron`, so the asar-embedded server reports the commit it was built from. Docker keeps using env vars.

Empty env values are treated as absent; the live git lookup has a 1s timeout and is cached after the first `/health` call.

## Tests

- New `server/test/buildInfo.test.ts` covers env precedence, empty-env fallthrough, baked-meta fallback, live-git resolution, and the never-null buildTime / `unknown` degradation.
- Full server suite green (305 passed); frontend + server typecheck clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>