### PR TITLE
feat: add SWR/LTWR/PWR withdrawal rate options (#193)

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -12,6 +12,7 @@ walkthrough and a screenshot so you can see exactly what to expect.
 - [Homepage & navigation](./homepage.md)
 - [FIRE calculator](./fire-calculator.md)
 - [Monte Carlo simulation](./monte-carlo.md)
+- [Withdrawal rate options (SWR / LTWR / PWR)](./withdrawal-rate.md)
 - [Asset allocation manager](./asset-allocation.md)
 - [Expense tracker](./expense-tracker.md)
 - [Net-worth tracker](./net-worth-tracker.md)

--- a/docs/user/withdrawal-rate.md
+++ b/docs/user/withdrawal-rate.md
@@ -1,0 +1,59 @@
+# Withdrawal rate options (SWR / LTWR / PWR)
+
+The Withdrawal Rate Simulator stress-tests how long your portfolio lasts at a
+given withdrawal rate, and lets you reason about **three** related withdrawal
+concepts. You enter **one** rate and choose which one it is — the app derives
+the other two.
+
+## The three rates
+
+- **Safe Withdrawal Rate (SWR)** — the maximum inflation-adjusted rate that
+  avoids depleting your portfolio over a *fixed* horizon (the classic 4% rule
+  assumes a 30-year retirement). Highest of the three.
+- **Long-Term Withdrawal Rate (LTWR)** — a sustainable middle ground over a
+  long (50-year) horizon, where SWR and PWR converge.
+- **Perpetual Withdrawal Rate (PWR)** — the rate that preserves your principal
+  indefinitely. The most conservative; typically below 4%.
+
+For typical inputs the ordering always holds: **PWR ≤ LTWR ≤ SWR**.
+
+## How to use it
+
+1. Pick which rate you are entering with the **"I'm entering this rate as"**
+   selector (SWR, LTWR or PWR).
+2. Drag the slider to set that rate. The selected option is highlighted in the
+   results, the other two are labelled *Derived*.
+3. Adjust the **retirement horizon** — it is the horizon used for SWR. LTWR
+   uses a fixed 50-year long-term horizon.
+
+## How the conversion works (assumptions)
+
+The conversion uses a **deterministic amortization model**, separate from the
+stochastic Monte Carlo success-rate chart below it. A single latent variable —
+the **implied real (after-inflation) return** `r` — links the three rates:
+
+- Annuity factor: `A(r, N) = r / (1 − (1 + r)^(−N))` — the level real
+  withdrawal (as a share of the initial portfolio) that depletes it to zero
+  over `N` years. Its limit as `r → 0` is `1/N`.
+- **PWR = r** — withdrawing only the real return preserves the real principal
+  forever (equals the limit of `A(r, N)` as `N → ∞`, for `r > 0`).
+- **SWR = A(r, N_swr)** with `N_swr` your retirement horizon (default 30y).
+- **LTWR = A(r, N_ltwr)** with `N_ltwr = 50y` (fixed long-term horizon).
+
+From the rate you enter and its type, the app backs out `r` (directly for PWR,
+by inverting `A` for SWR/LTWR) and recomputes the other two. Because every rate
+is a deterministic function of `r`, conversions round-trip exactly.
+
+### Edge case — non-positive real return
+
+If the entered rate is below `1/N` (for example an SWR under ~3.33% on a
+30-year horizon), the implied real return is **non-positive**. No positive rate
+can then preserve principal forever, so the perpetual rate is shown as **0%**
+and a note explains why.
+
+## Reading the success-rate chart
+
+Below the three rates, the bar chart shows the Monte Carlo **success rate** at
+each candidate withdrawal rate over your horizon. Green bars (≥90%) are robust;
+amber and red flag fragility to bad sequences of returns. The dashed line marks
+your currently selected rate.

--- a/src/App.css
+++ b/src/App.css
@@ -1138,6 +1138,40 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   box-shadow: 0 12px 40px var(--error-glow);
 }
 
+/* Withdrawal-rate type selector (issue #193) */
+.wr-type-option {
+  padding: 0.5rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, #2a2d36);
+  background: var(--surface-2, #1a1d26);
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.wr-type-option:hover:not(:disabled) {
+  border-color: var(--accent, #2dd4bf);
+  color: var(--text, #f8fafc);
+}
+
+.wr-type-option-active {
+  border-color: var(--accent, #2dd4bf);
+  background: rgba(45, 212, 191, 0.12);
+  color: var(--text, #f8fafc);
+}
+
+.wr-type-option:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.result-card.wr-pill-good {
+  border-color: var(--accent, #2dd4bf);
+  box-shadow: 0 0 0 1px var(--accent, #2dd4bf) inset;
+}
+
 .result-label {
   font-size: 0.9rem;
   opacity: 0.9;

--- a/src/components/WithdrawalRatePage.tsx
+++ b/src/components/WithdrawalRatePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   BarChart,
   Bar,
@@ -24,6 +25,13 @@ import {
   WithdrawalRateInputs,
   WithdrawalRateResult,
 } from '../utils/withdrawalRateSimulator';
+import {
+  convertWithdrawalRates,
+  WithdrawalRateType,
+  WITHDRAWAL_RATE_TYPES,
+  DEFAULT_LTWR_HORIZON_YEARS,
+} from '../utils/withdrawalRateConversion';
+import { logger } from '../utils/logger';
 import { formatDisplayCurrency, formatDisplayPercent } from '../utils/numberFormatter';
 import { MaterialIcon } from './MaterialIcon';
 import { SliderInput } from './SliderInput';
@@ -71,6 +79,7 @@ function successRateColor(rate: number): string {
 
 export const WithdrawalRatePage: React.FC = () => {
   const location = useLocation();
+  const { t } = useTranslation();
 
   // Load inputs once per navigation, same pattern as MonteCarloPage.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -109,6 +118,7 @@ export const WithdrawalRatePage: React.FC = () => {
   const [withdrawalRate, setWithdrawalRate] = useState<number>(
     inputs.desiredWithdrawalRate || 4,
   );
+  const [inputRateType, setInputRateType] = useState<WithdrawalRateType>('swr');
   const [retirementYears, setRetirementYears] = useState<number>(DEFAULT_RETIREMENT_YEARS);
   const [numSimulations, setNumSimulations] = useState<number>(DEFAULT_NUM_SIMULATIONS);
 
@@ -186,6 +196,30 @@ export const WithdrawalRatePage: React.FC = () => {
 
   const currentAnnualWithdrawal = inputs.initialSavings * (withdrawalRate / 100);
 
+  // Derive the SWR/LTWR/PWR triple from the single entered rate + its type.
+  const rateTriple = useMemo(() => {
+    if (!(withdrawalRate > 0)) return null;
+    try {
+      return convertWithdrawalRates(withdrawalRate, inputRateType, {
+        swrHorizonYears: retirementYears,
+        ltwrHorizonYears: DEFAULT_LTWR_HORIZON_YEARS,
+      });
+    } catch (err) {
+      logger.error('withdrawal-rate', 'conversion-failed', 'withdrawal rate conversion failed', {
+        pii: { error: (err as Error)?.message },
+      });
+      return null;
+    }
+  }, [withdrawalRate, inputRateType, retirementYears]);
+
+  const rateCards: { type: WithdrawalRateType; value: number; horizon: number }[] = rateTriple
+    ? [
+        { type: 'swr', value: rateTriple.swr, horizon: retirementYears },
+        { type: 'ltwr', value: rateTriple.ltwr, horizon: DEFAULT_LTWR_HORIZON_YEARS },
+        { type: 'pwr', value: rateTriple.pwr, horizon: 0 },
+      ]
+    : [];
+
   return (
     <div className="app-container">
       <main className="main-content" id="main-content">
@@ -217,8 +251,36 @@ export const WithdrawalRatePage: React.FC = () => {
 
           <div className="mc-inputs">
             <div className="form-group" style={{ gridColumn: '1 / -1' }}>
+              <label htmlFor="wr-input-type">{t('withdrawalRate.inputType.label')}</label>
+              <div
+                id="wr-input-type"
+                role="radiogroup"
+                aria-label={t('withdrawalRate.inputType.label')}
+                className="wr-type-selector"
+                style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}
+              >
+                {WITHDRAWAL_RATE_TYPES.map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    role="radio"
+                    aria-checked={inputRateType === type}
+                    className={`wr-type-option${inputRateType === type ? ' wr-type-option-active' : ''}`}
+                    onClick={() => setInputRateType(type)}
+                    disabled={!canSimulate}
+                  >
+                    {t(`withdrawalRate.types.${type}`)}
+                  </button>
+                ))}
+              </div>
+              <p className="section-description" style={{ margin: '0.4rem 0 0' }}>
+                {t('withdrawalRate.inputType.help')}
+              </p>
+            </div>
+
+            <div className="form-group" style={{ gridColumn: '1 / -1' }}>
               <label htmlFor="wr-rate">
-                Withdrawal rate: <strong>{withdrawalRate.toFixed(1)}%</strong>{' '}
+                {t(`withdrawalRate.short.${inputRateType}`)}: <strong>{withdrawalRate.toFixed(1)}%</strong>{' '}
                 <span style={{ color: '#94A3B8', fontWeight: 'normal' }}>
                   (≈{' '}
                   <PrivacyBlur isPrivacyMode={isPrivacyMode}>
@@ -315,6 +377,71 @@ export const WithdrawalRatePage: React.FC = () => {
             </div>
           )}
         </section>
+
+        {rateTriple && (
+          <section
+            className="monte-carlo-section"
+            aria-labelledby="wr-options-heading"
+            style={{ marginTop: '1.5rem' }}
+          >
+            <h3 id="wr-options-heading" style={{ marginTop: 0 }}>
+              <MaterialIcon name="balance" /> {t('withdrawalRate.results.heading')}
+            </h3>
+            <p className="section-description">{t('withdrawalRate.results.description')}</p>
+
+            <div className="results-grid" role="list">
+              {rateCards.map((card) => {
+                const isEntered = card.type === inputRateType;
+                const horizonYears = card.type === 'ltwr' ? DEFAULT_LTWR_HORIZON_YEARS : retirementYears;
+                return (
+                  <div
+                    key={card.type}
+                    className={`result-card${isEntered ? ' wr-pill-good' : ''}`}
+                    role="listitem"
+                  >
+                    <div className="result-label">
+                      {t(`withdrawalRate.types.${card.type}`)}{' '}
+                      <span style={{ color: isEntered ? undefined : '#94A3B8', fontWeight: 600 }}>
+                        ·{' '}
+                        {isEntered
+                          ? t('withdrawalRate.results.youEntered')
+                          : t('withdrawalRate.results.derived')}
+                      </span>
+                    </div>
+                    <div className="result-value">{formatDisplayPercent(card.value)}</div>
+                    <div className="result-subtitle">
+                      {card.type === 'pwr'
+                        ? t('withdrawalRate.explanations.pwr')
+                        : t(`withdrawalRate.explanations.${card.type}`, { years: horizonYears })}
+                    </div>
+                  </div>
+                );
+              })}
+
+              <div className="result-card" role="listitem">
+                <div className="result-label">{t('withdrawalRate.results.impliedRealReturn')}</div>
+                <div className="result-value">{formatDisplayPercent(rateTriple.impliedRealReturn)}</div>
+                <div className="result-subtitle">{t('withdrawalRate.ltwrHorizonNote', { years: DEFAULT_LTWR_HORIZON_YEARS })}</div>
+              </div>
+            </div>
+
+            {!rateTriple.principalPreserved && (
+              <div
+                className="validation-error-banner"
+                role="status"
+                aria-live="polite"
+                style={{ marginTop: '1rem' }}
+              >
+                <strong>
+                  <MaterialIcon name="info" />{' '}
+                  {t('withdrawalRate.principalWarning', {
+                    rate: formatDisplayPercent(rateTriple.impliedRealReturn),
+                  })}
+                </strong>
+              </div>
+            )}
+          </section>
+        )}
 
         {sweep.length > 0 && (
           <section

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2552,5 +2552,35 @@
     "backendUnreachable": "Backend nicht erreichbar. App läuft im Nur-Client-Modus.",
     "backendDepTag": "backend",
     "refresh": "Aktualisieren"
+  },
+  "withdrawalRate": {
+    "inputType": {
+      "label": "Ich gebe diese Rate ein als",
+      "help": "Wählen Sie aus, welches Entnahmeraten-Konzept Ihre Eingabe darstellt. Die anderen beiden werden daraus abgeleitet."
+    },
+    "types": {
+      "swr": "Sichere Entnahmerate (SWR)",
+      "ltwr": "Langfristige Entnahmerate (LTWR)",
+      "pwr": "Ewige Entnahmerate (PWR)"
+    },
+    "short": {
+      "swr": "SWR",
+      "ltwr": "LTWR",
+      "pwr": "PWR"
+    },
+    "explanations": {
+      "swr": "Maximale inflationsbereinigte Rate, die das Portfolio über Ihren Zeitraum von {{years}} Jahren nicht erschöpft.",
+      "ltwr": "Nachhaltiger Mittelweg über einen langen Zeitraum von {{years}} Jahren, in dem SWR und PWR konvergieren.",
+      "pwr": "Rate, die Ihr Kapital unbegrenzt erhält — typischerweise die konservativste."
+    },
+    "results": {
+      "heading": "Entnahmeraten-Optionen",
+      "description": "Sie geben eine Rate ein; die anderen beiden werden über die implizite Realrendite mit einem deterministischen Amortisationsmodell abgeleitet.",
+      "impliedRealReturn": "Implizite Realrendite",
+      "youEntered": "Eingegeben",
+      "derived": "Abgeleitet"
+    },
+    "principalWarning": "Ihre Eingabe impliziert eine nicht-positive Realrendite ({{rate}}), daher kann keine positive Rate das Kapital dauerhaft erhalten. Die ewige Rate wird als 0% angezeigt.",
+    "ltwrHorizonNote": "LTWR verwendet einen festen langfristigen Zeitraum von {{years}} Jahren."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2552,5 +2552,35 @@
     "backendUnreachable": "Backend is not reachable. The app runs in client-only mode.",
     "backendDepTag": "backend",
     "refresh": "Refresh"
+  },
+  "withdrawalRate": {
+    "inputType": {
+      "label": "I'm entering this rate as",
+      "help": "Pick which withdrawal-rate concept your input represents. The other two are derived from it."
+    },
+    "types": {
+      "swr": "Safe Withdrawal Rate (SWR)",
+      "ltwr": "Long-Term Withdrawal Rate (LTWR)",
+      "pwr": "Perpetual Withdrawal Rate (PWR)"
+    },
+    "short": {
+      "swr": "SWR",
+      "ltwr": "LTWR",
+      "pwr": "PWR"
+    },
+    "explanations": {
+      "swr": "Maximum inflation-adjusted rate that avoids depleting the portfolio over your {{years}}-year horizon.",
+      "ltwr": "Sustainable middle ground over a long {{years}}-year horizon, where SWR and PWR converge.",
+      "pwr": "Rate that preserves your principal indefinitely — typically the most conservative."
+    },
+    "results": {
+      "heading": "Withdrawal rate options",
+      "description": "You enter one rate; the other two are derived from the implied real return using a deterministic amortization model.",
+      "impliedRealReturn": "Implied real return",
+      "youEntered": "You entered",
+      "derived": "Derived"
+    },
+    "principalWarning": "Your input implies a non-positive real return ({{rate}}), so no positive rate can preserve principal forever. Perpetual rate is shown as 0%.",
+    "ltwrHorizonNote": "LTWR uses a fixed {{years}}-year long-term horizon."
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2552,5 +2552,35 @@
     "backendUnreachable": "Backend no accesible. La app funciona en modo solo cliente.",
     "backendDepTag": "backend",
     "refresh": "Actualizar"
+  },
+  "withdrawalRate": {
+    "inputType": {
+      "label": "Introduzco esta tasa como",
+      "help": "Elija qué concepto de tasa de retiro representa su entrada. Las otras dos se derivan de ella."
+    },
+    "types": {
+      "swr": "Tasa de Retiro Segura (SWR)",
+      "ltwr": "Tasa de Retiro a Largo Plazo (LTWR)",
+      "pwr": "Tasa de Retiro Perpetua (PWR)"
+    },
+    "short": {
+      "swr": "SWR",
+      "ltwr": "LTWR",
+      "pwr": "PWR"
+    },
+    "explanations": {
+      "swr": "Tasa máxima ajustada por inflación que evita agotar la cartera durante su horizonte de {{years}} años.",
+      "ltwr": "Punto intermedio sostenible en un horizonte largo de {{years}} años, donde SWR y PWR convergen.",
+      "pwr": "Tasa que preserva su capital indefinidamente — normalmente la más conservadora."
+    },
+    "results": {
+      "heading": "Opciones de tasa de retiro",
+      "description": "Usted introduce una tasa; las otras dos se derivan del rendimiento real implícito mediante un modelo de amortización determinista.",
+      "impliedRealReturn": "Rendimiento real implícito",
+      "youEntered": "Introducida",
+      "derived": "Derivada"
+    },
+    "principalWarning": "Su entrada implica un rendimiento real no positivo ({{rate}}), por lo que ninguna tasa positiva puede preservar el capital para siempre. La tasa perpetua se muestra como 0%.",
+    "ltwrHorizonNote": "LTWR usa un horizonte a largo plazo fijo de {{years}} años."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2552,5 +2552,35 @@
     "backendUnreachable": "Backend injoignable. L'application fonctionne en mode client uniquement.",
     "backendDepTag": "backend",
     "refresh": "Actualiser"
+  },
+  "withdrawalRate": {
+    "inputType": {
+      "label": "Je saisis ce taux comme",
+      "help": "Choisissez le concept de taux de retrait que représente votre saisie. Les deux autres en sont déduits."
+    },
+    "types": {
+      "swr": "Taux de Retrait Sûr (SWR)",
+      "ltwr": "Taux de Retrait à Long Terme (LTWR)",
+      "pwr": "Taux de Retrait Perpétuel (PWR)"
+    },
+    "short": {
+      "swr": "SWR",
+      "ltwr": "LTWR",
+      "pwr": "PWR"
+    },
+    "explanations": {
+      "swr": "Taux maximal ajusté de l'inflation qui évite d'épuiser le portefeuille sur votre horizon de {{years}} ans.",
+      "ltwr": "Juste milieu durable sur un long horizon de {{years}} ans, où le SWR et le PWR convergent.",
+      "pwr": "Taux qui préserve votre capital indéfiniment — généralement le plus prudent."
+    },
+    "results": {
+      "heading": "Options de taux de retrait",
+      "description": "Vous saisissez un taux ; les deux autres sont déduits du rendement réel implicite à l'aide d'un modèle d'amortissement déterministe.",
+      "impliedRealReturn": "Rendement réel implicite",
+      "youEntered": "Saisi",
+      "derived": "Déduit"
+    },
+    "principalWarning": "Votre saisie implique un rendement réel non positif ({{rate}}), donc aucun taux positif ne peut préserver le capital indéfiniment. Le taux perpétuel est affiché à 0%.",
+    "ltwrHorizonNote": "Le LTWR utilise un horizon à long terme fixe de {{years}} ans."
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2552,5 +2552,35 @@
     "backendUnreachable": "Backend non raggiungibile. L'app è in modalità solo client.",
     "backendDepTag": "backend",
     "refresh": "Aggiorna"
+  },
+  "withdrawalRate": {
+    "inputType": {
+      "label": "Sto inserendo questo tasso come",
+      "help": "Scegli quale concetto di tasso di prelievo rappresenta il tuo input. Gli altri due vengono derivati da esso."
+    },
+    "types": {
+      "swr": "Tasso di Prelievo Sicuro (SWR)",
+      "ltwr": "Tasso di Prelievo a Lungo Termine (LTWR)",
+      "pwr": "Tasso di Prelievo Perpetuo (PWR)"
+    },
+    "short": {
+      "swr": "SWR",
+      "ltwr": "LTWR",
+      "pwr": "PWR"
+    },
+    "explanations": {
+      "swr": "Tasso massimo aggiustato per l'inflazione che evita di esaurire il portafoglio nel tuo orizzonte di {{years}} anni.",
+      "ltwr": "Via di mezzo sostenibile su un lungo orizzonte di {{years}} anni, dove SWR e PWR convergono.",
+      "pwr": "Tasso che preserva il capitale indefinitamente — in genere il più conservativo."
+    },
+    "results": {
+      "heading": "Opzioni del tasso di prelievo",
+      "description": "Inserisci un tasso; gli altri due vengono derivati dal rendimento reale implicito usando un modello di ammortamento deterministico.",
+      "impliedRealReturn": "Rendimento reale implicito",
+      "youEntered": "Inserito",
+      "derived": "Derivato"
+    },
+    "principalWarning": "Il tuo input implica un rendimento reale non positivo ({{rate}}), quindi nessun tasso positivo può preservare il capitale per sempre. Il tasso perpetuo è mostrato come 0%.",
+    "ltwrHorizonNote": "LTWR usa un orizzonte a lungo termine fisso di {{years}} anni."
   }
 }

--- a/src/utils/withdrawalRateConversion.ts
+++ b/src/utils/withdrawalRateConversion.ts
@@ -1,0 +1,173 @@
+/**
+ * Withdrawal Rate Conversion — SWR / LTWR / PWR
+ *
+ * Issue #193: the user enters ONE withdrawal rate and selects which of the
+ * three concepts it represents; we derive the other two.
+ *
+ * MODEL — deterministic implied-real-return (amortization) model.
+ * --------------------------------------------------------------------------
+ * This is intentionally a *deterministic* model, distinct from the stochastic
+ * Monte Carlo longevity simulator in `withdrawalRateSimulator.ts` (which keeps
+ * powering the success-rate chart). All three rates are expressed as a level,
+ * inflation-adjusted (real) withdrawal as a fraction of the *initial* portfolio.
+ *
+ * Single latent variable: the implied constant real (after-inflation) return
+ * `r` that the portfolio earns each year.
+ *
+ *   - Annuity / amortization factor:
+ *         A(r, N) = r / (1 - (1 + r)^(-N))
+ *     This is the level real withdrawal that depletes the portfolio to exactly
+ *     zero over N years given constant real return r. Its limit as r -> 0 is
+ *     1/N, and (for r > 0) its limit as N -> ∞ is r.
+ *
+ *   - PWR (Perpetual Withdrawal Rate) = r. Withdrawing exactly the real return
+ *     each year preserves the real principal indefinitely. Equals lim A(r,N)
+ *     as N -> ∞ for r > 0. If the implied real return is non-positive, no
+ *     positive rate preserves principal forever, so we surface that and clamp
+ *     the *displayed* PWR to 0 (while keeping the internal r for round-trips).
+ *
+ *   - SWR (Safe Withdrawal Rate) = A(r, N_swr), with N_swr the retirement
+ *     horizon (default 30y, e.g. the Trinity-study 4%/30y rule).
+ *
+ *   - LTWR (Long-Term Withdrawal Rate) = A(r, N_ltwr), a fixed long horizon
+ *     (default 50y). It is the "middle ground" where SWR and PWR converge over
+ *     long timeframes: for r > 0 and N_swr < N_ltwr, A(r,30) >= A(r,50) >= r,
+ *     i.e. PWR <= LTWR <= SWR.
+ *
+ * Conversion: from the entered rate + its type we back out r (directly for PWR,
+ * by numerically inverting A for SWR/LTWR), then recompute the other two. Since
+ * every rate is a deterministic function of the single variable r, conversions
+ * round-trip exactly.
+ */
+
+export type WithdrawalRateType = 'swr' | 'ltwr' | 'pwr';
+
+export const WITHDRAWAL_RATE_TYPES: readonly WithdrawalRateType[] = ['swr', 'ltwr', 'pwr'] as const;
+
+/** Default retirement horizon for SWR (Trinity-study convention). */
+export const DEFAULT_SWR_HORIZON_YEARS = 30;
+/** Default long horizon for LTWR. Documented assumption (see module header). */
+export const DEFAULT_LTWR_HORIZON_YEARS = 50;
+
+export interface WithdrawalRateConversionParams {
+  /** Horizon in years used for the SWR annuity (e.g. 30). */
+  swrHorizonYears: number;
+  /** Long horizon in years used for the LTWR annuity (e.g. 50). */
+  ltwrHorizonYears: number;
+}
+
+export interface WithdrawalRateTriple {
+  /** Safe Withdrawal Rate, % (e.g. 4 for 4%). */
+  swr: number;
+  /** Long-Term Withdrawal Rate, %. */
+  ltwr: number;
+  /** Perpetual Withdrawal Rate, % (clamped to >= 0 for display). */
+  pwr: number;
+  /** Implied constant real return backed out from the input, % (may be < 0). */
+  impliedRealReturn: number;
+  /** False when the implied real return is <= 0 (principal cannot be preserved forever). */
+  principalPreserved: boolean;
+}
+
+/**
+ * Level real withdrawal (as a fraction of initial principal) that depletes the
+ * portfolio over `years` at constant real return `r`.
+ *
+ * @param r real return as a fraction (e.g. 0.04 for 4%); must be > -1.
+ * @param years horizon in years; must be > 0.
+ */
+export function annuityWithdrawalFactor(r: number, years: number): number {
+  if (years <= 0) throw new Error('years must be greater than 0');
+  if (r <= -1) throw new Error('real return r must be greater than -1');
+  // Limit as r -> 0 is 1/N; use it directly for tiny |r| to avoid 0/0.
+  if (Math.abs(r) < 1e-9) return 1 / years;
+  // denom = 1 - (1+r)^(-N); computed via expm1/log1p for numerical stability.
+  const denom = -Math.expm1(-years * Math.log1p(r));
+  return r / denom;
+}
+
+/**
+ * Invert {@link annuityWithdrawalFactor}: find the real return `r` such that
+ * A(r, years) === targetFactor. A is strictly increasing in r on (-1, ∞), so a
+ * bracketed bisection is robust.
+ *
+ * @param targetFactor target withdrawal factor as a fraction (e.g. 0.04).
+ * @param years horizon in years.
+ */
+export function solveRealReturn(targetFactor: number, years: number): number {
+  if (years <= 0) throw new Error('years must be greater than 0');
+  if (targetFactor <= 0) throw new Error('targetFactor must be greater than 0');
+
+  let lo = -0.95;
+  let hi = 1.0;
+  // Expand the upper bracket if the target rate is unusually high.
+  let guardUpper = 0;
+  while (annuityWithdrawalFactor(hi, years) < targetFactor && guardUpper < 100) {
+    hi *= 2;
+    guardUpper++;
+  }
+  // Expand the lower bracket toward -1 if the target is unusually low.
+  let guardLower = 0;
+  while (annuityWithdrawalFactor(lo, years) > targetFactor && lo > -0.999999 && guardLower < 100) {
+    lo = (lo - 1) / 2; // -0.95 -> -0.975 -> -0.9875 ... approaches -1
+    guardLower++;
+  }
+
+  for (let i = 0; i < 200; i++) {
+    const mid = (lo + hi) / 2;
+    const value = annuityWithdrawalFactor(mid, years);
+    if (Math.abs(value - targetFactor) < 1e-12) return mid;
+    if (value < targetFactor) lo = mid;
+    else hi = mid;
+  }
+  return (lo + hi) / 2;
+}
+
+/**
+ * Convert a single entered withdrawal rate into the full SWR/LTWR/PWR triple.
+ *
+ * @param rate entered rate in percent (e.g. 4 for 4%); must be > 0.
+ * @param type which rate the user entered.
+ * @param params SWR / LTWR horizons.
+ */
+export function convertWithdrawalRates(
+  rate: number,
+  type: WithdrawalRateType,
+  params: WithdrawalRateConversionParams,
+): WithdrawalRateTriple {
+  if (!(rate > 0)) throw new Error('rate must be greater than 0');
+  if (params.swrHorizonYears <= 0 || params.ltwrHorizonYears <= 0) {
+    throw new Error('horizons must be greater than 0');
+  }
+
+  const rateFraction = rate / 100;
+
+  // Back out the implied real return r (fraction) from the entered rate.
+  let r: number;
+  switch (type) {
+    case 'pwr':
+      r = rateFraction; // PWR = r directly
+      break;
+    case 'swr':
+      r = solveRealReturn(rateFraction, params.swrHorizonYears);
+      break;
+    case 'ltwr':
+      r = solveRealReturn(rateFraction, params.ltwrHorizonYears);
+      break;
+  }
+
+  const swr = annuityWithdrawalFactor(r, params.swrHorizonYears) * 100;
+  const ltwr = annuityWithdrawalFactor(r, params.ltwrHorizonYears) * 100;
+  const principalPreserved = r > 0;
+  // PWR equals r; a non-positive real return cannot sustain a perpetual
+  // positive withdrawal, so clamp the displayed value to 0.
+  const pwr = principalPreserved ? r * 100 : 0;
+
+  return {
+    swr,
+    ltwr,
+    pwr,
+    impliedRealReturn: r * 100,
+    principalPreserved,
+  };
+}

--- a/tests/pages/fire-calculator/withdrawalRateConversion.test.ts
+++ b/tests/pages/fire-calculator/withdrawalRateConversion.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  annuityWithdrawalFactor,
+  solveRealReturn,
+  convertWithdrawalRates,
+  DEFAULT_SWR_HORIZON_YEARS,
+  DEFAULT_LTWR_HORIZON_YEARS,
+} from '../../../src/utils/withdrawalRateConversion';
+
+describe('annuityWithdrawalFactor', () => {
+  it('returns 1/N at r = 0 (limit)', () => {
+    expect(annuityWithdrawalFactor(0, 30)).toBeCloseTo(1 / 30, 10);
+    expect(annuityWithdrawalFactor(0, 50)).toBeCloseTo(1 / 50, 10);
+  });
+
+  it('is numerically stable for very small r', () => {
+    expect(annuityWithdrawalFactor(1e-9, 30)).toBeCloseTo(1 / 30, 6);
+  });
+
+  it('is strictly increasing in r for fixed N', () => {
+    let prev = -Infinity;
+    for (let r = -0.05; r <= 0.15 + 1e-9; r += 0.005) {
+      const v = annuityWithdrawalFactor(r, 30);
+      expect(v).toBeGreaterThan(prev);
+      prev = v;
+    }
+  });
+
+  it('is strictly decreasing in N for positive r', () => {
+    const r = 0.04;
+    expect(annuityWithdrawalFactor(r, 30)).toBeGreaterThan(annuityWithdrawalFactor(r, 50));
+    expect(annuityWithdrawalFactor(r, 50)).toBeGreaterThan(r); // approaches r from above
+  });
+
+  it('throws for r <= -1', () => {
+    expect(() => annuityWithdrawalFactor(-1, 30)).toThrow();
+    expect(() => annuityWithdrawalFactor(-1.5, 30)).toThrow();
+  });
+});
+
+describe('solveRealReturn', () => {
+  it('inverts annuityWithdrawalFactor (round-trip on r)', () => {
+    for (const r of [-0.02, 0, 0.01, 0.03, 0.05, 0.1]) {
+      const factor = annuityWithdrawalFactor(r, 30);
+      const solved = solveRealReturn(factor, 30);
+      expect(solved).toBeCloseTo(r, 6);
+    }
+  });
+
+  it('recovers ~1.26% real return for the classic 4%/30y SWR', () => {
+    const r = solveRealReturn(0.04, 30);
+    // 4% over 30 years implies a low positive real return
+    expect(r).toBeGreaterThan(0);
+    expect(r).toBeLessThan(0.03);
+  });
+
+  it('returns negative r when the rate is below 1/N', () => {
+    const r = solveRealReturn(0.02, 30); // below 1/30 ≈ 3.33%
+    expect(r).toBeLessThan(0);
+  });
+});
+
+describe('convertWithdrawalRates', () => {
+  const params = {
+    swrHorizonYears: DEFAULT_SWR_HORIZON_YEARS,
+    ltwrHorizonYears: DEFAULT_LTWR_HORIZON_YEARS,
+  };
+
+  it('keeps the user-entered rate unchanged for each input type', () => {
+    expect(convertWithdrawalRates(4, 'swr', params).swr).toBeCloseTo(4, 6);
+    expect(convertWithdrawalRates(3.5, 'ltwr', params).ltwr).toBeCloseTo(3.5, 6);
+    expect(convertWithdrawalRates(3, 'pwr', params).pwr).toBeCloseTo(3, 6);
+  });
+
+  it('enforces PWR <= LTWR <= SWR for a typical SWR input', () => {
+    const t = convertWithdrawalRates(4, 'swr', params);
+    expect(t.pwr).toBeLessThanOrEqual(t.ltwr + 1e-9);
+    expect(t.ltwr).toBeLessThanOrEqual(t.swr + 1e-9);
+  });
+
+  it('enforces PWR <= LTWR <= SWR for a typical LTWR input', () => {
+    const t = convertWithdrawalRates(3.5, 'ltwr', params);
+    expect(t.pwr).toBeLessThanOrEqual(t.ltwr + 1e-9);
+    expect(t.ltwr).toBeLessThanOrEqual(t.swr + 1e-9);
+  });
+
+  it('enforces PWR <= LTWR <= SWR for a typical PWR input', () => {
+    const t = convertWithdrawalRates(3, 'pwr', params);
+    expect(t.pwr).toBeLessThanOrEqual(t.ltwr + 1e-9);
+    expect(t.ltwr).toBeLessThanOrEqual(t.swr + 1e-9);
+  });
+
+  it('round-trips SWR -> PWR -> SWR consistently', () => {
+    const fromSwr = convertWithdrawalRates(4.2, 'swr', params);
+    const backFromPwr = convertWithdrawalRates(fromSwr.pwr, 'pwr', params);
+    expect(backFromPwr.swr).toBeCloseTo(4.2, 4);
+    expect(backFromPwr.ltwr).toBeCloseTo(fromSwr.ltwr, 4);
+  });
+
+  it('round-trips LTWR -> SWR -> LTWR consistently', () => {
+    const fromLtwr = convertWithdrawalRates(3.6, 'ltwr', params);
+    const backFromSwr = convertWithdrawalRates(fromLtwr.swr, 'swr', params);
+    expect(backFromSwr.ltwr).toBeCloseTo(3.6, 4);
+    expect(backFromSwr.pwr).toBeCloseTo(fromLtwr.pwr, 4);
+  });
+
+  it('flags a non-positive real return and clamps displayed PWR to 0', () => {
+    const t = convertWithdrawalRates(2, 'swr', params); // below 1/30 -> negative r
+    expect(t.impliedRealReturn).toBeLessThan(0);
+    expect(t.pwr).toBe(0);
+    expect(t.principalPreserved).toBe(false);
+  });
+
+  it('marks principal as preserved for a positive real return', () => {
+    const t = convertWithdrawalRates(4, 'swr', params);
+    expect(t.impliedRealReturn).toBeGreaterThan(0);
+    expect(t.principalPreserved).toBe(true);
+  });
+
+  it('throws on non-positive input rate', () => {
+    expect(() => convertWithdrawalRates(0, 'swr', params)).toThrow();
+    expect(() => convertWithdrawalRates(-1, 'pwr', params)).toThrow();
+  });
+
+  it('longer SWR horizon lowers the derived SWR for a fixed PWR', () => {
+    const short = convertWithdrawalRates(3, 'pwr', { swrHorizonYears: 20, ltwrHorizonYears: 50 });
+    const long = convertWithdrawalRates(3, 'pwr', { swrHorizonYears: 40, ltwrHorizonYears: 50 });
+    expect(long.swr).toBeLessThan(short.swr);
+  });
+});


### PR DESCRIPTION
## Summary

Implements GitHub issue #193. The Withdrawal Rate tool previously used only the Safe Withdrawal Rate (SWR). Now the user enters **one** rate, selects which of the three concepts it represents, and the app derives the other two:

- enter **SWR** → derive **LTWR** + **PWR**
- enter **LTWR** → derive **PWR** + **SWR**
- enter **PWR** → derive **LTWR** + **SWR**

Closes #193

## Model (documented assumptions)

A deterministic **implied-real-return amortization model**, separate from the existing stochastic Monte Carlo success-rate chart (which is unchanged). A single latent variable — the implied real return `r` — links all three rates:

- Annuity factor `A(r, N) = r / (1 − (1+r)^(−N))`, limit `1/N` at `r→0` (computed via `expm1`/`log1p` for stability).
- **PWR = r** (perpetual: preserves real principal; equals `lim A(r,N)` as `N→∞` for `r>0`).
- **SWR = A(r, N_swr)**, `N_swr` = retirement horizon (default 30y).
- **LTWR = A(r, N_ltwr)**, `N_ltwr` = fixed 50y long-term horizon.

Given the entered rate + type, `r` is backed out (directly for PWR, by inverting `A` via bracketed bisection for SWR/LTWR), then the other two are recomputed. Conversions round-trip exactly. For typical inputs **PWR ≤ LTWR ≤ SWR**. If the entered rate implies a non-positive real return, PWR is shown as 0% with an explanatory note (internal `r` preserved for round-trips). Full rationale in the module header and `docs/user/withdrawal-rate.md`.

## Changes

- `src/utils/withdrawalRateConversion.ts` — new conversion module.
- `src/components/WithdrawalRatePage.tsx` — rate-type selector (radio group) + three-rate results panel with explanations, implied real return, and warning; uses the centralized logger.
- `src/App.css` — minimal styles for the selector + entered-card highlight.
- i18n: additive `withdrawalRate` namespace in all 5 locales (en/de/es/fr/it) with real translations.
- `docs/user/withdrawal-rate.md` + link in `docs/user/README.md`.
- `tests/pages/fire-calculator/withdrawalRateConversion.test.ts` — 18 tests (ordering, round-trips, edge cases, monotonicity, numerical stability).

## Verification

- `npm test` → **1197 passed (65 files)**
- `npm run build` → green (tsc + vite + docs)

## Conflict-awareness

Edits to shared files (i18n JSONs, App.css) are additive only; no changes to `App.tsx` or `navbarLabels.ts`.