### PR TITLE
feat(breakdown): make By Sector an industry-sector view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.8",
-        "electron": "^42.3.3",
+        "electron": "^41.7.1",
         "electron-builder": "^26.15.2",
         "jsdom": "^29.1.1",
         "marked": "^18.0.5",
@@ -298,6 +298,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.3.tgz",
+      "integrity": "sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -1794,15 +1804,6 @@
       "version": "0.0.6",
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
       "dev": true,
@@ -2468,14 +2469,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -3287,19 +3280,19 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.3.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.3.tgz",
-      "integrity": "sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==",
+      "version": "41.7.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.7.2.tgz",
+      "integrity": "sha512-oYbZNimoMlAy6Fp/o5x2vTggptuPsIbnPKCb6jGf1PJStXH7Gkw0MUQrBliHmDqKLW7yeE+SPsvFNILVN0ORMQ==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
         "@electron/get": "^5.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js",
-        "install-electron": "install.js"
+        "electron": "cli.js"
       },
       "engines": {
         "node": ">= 22.12.0"
@@ -3703,25 +3696,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3745,14 +3719,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5402,11 +5368,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7336,15 +7297,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.8",
-    "electron": "^42.3.3",
+    "electron": "^41.7.1",
     "electron-builder": "^26.15.2",
     "jsdom": "^29.1.1",
     "marked": "^18.0.5",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -839,7 +839,7 @@
         "title": "Nach Region"
       },
       "sector": {
-        "description": "Individual stocks use their listed sector from Yahoo Finance. ETFs use a sector label inferred from their fund name (e.g. \"Technology\", \"Government Bonds\"), as Yahoo no longer exposes per-ETF holdings without authentication.",
+        "description": "Industry-sector mix (e.g. Technology, Financial Services, Consumer goods). Individual stocks use their listed sector from Yahoo Finance. Broad-market ETFs are expanded into industry sectors using approximate weightings for well-known indices (e.g. S&P 500, MSCI World, FTSE All-World), since Yahoo no longer exposes per-ETF holdings without authentication. Bond, commodity, and single-sector funds keep their own label.",
         "title": "Nach Sektor"
       }
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -839,7 +839,7 @@
         "title": "By Region"
       },
       "sector": {
-        "description": "Individual stocks use their listed sector from Yahoo Finance. ETFs use a sector label inferred from their fund name (e.g. \"Technology\", \"Government Bonds\"), as Yahoo no longer exposes per-ETF holdings without authentication.",
+        "description": "Industry-sector mix (e.g. Technology, Financial Services, Consumer goods). Individual stocks use their listed sector from Yahoo Finance. Broad-market ETFs are expanded into industry sectors using approximate weightings for well-known indices (e.g. S&P 500, MSCI World, FTSE All-World), since Yahoo no longer exposes per-ETF holdings without authentication. Bond, commodity, and single-sector funds keep their own label.",
         "title": "By Sector"
       }
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -839,7 +839,7 @@
         "title": "Por región"
       },
       "sector": {
-        "description": "Individual stocks use their listed sector from Yahoo Finance. ETFs use a sector label inferred from their fund name (e.g. \"Technology\", \"Government Bonds\"), as Yahoo no longer exposes per-ETF holdings without authentication.",
+        "description": "Industry-sector mix (e.g. Technology, Financial Services, Consumer goods). Individual stocks use their listed sector from Yahoo Finance. Broad-market ETFs are expanded into industry sectors using approximate weightings for well-known indices (e.g. S&P 500, MSCI World, FTSE All-World), since Yahoo no longer exposes per-ETF holdings without authentication. Bond, commodity, and single-sector funds keep their own label.",
         "title": "Por sector"
       }
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -839,7 +839,7 @@
         "title": "Par région"
       },
       "sector": {
-        "description": "Individual stocks use their listed sector from Yahoo Finance. ETFs use a sector label inferred from their fund name (e.g. \"Technology\", \"Government Bonds\"), as Yahoo no longer exposes per-ETF holdings without authentication.",
+        "description": "Industry-sector mix (e.g. Technology, Financial Services, Consumer goods). Individual stocks use their listed sector from Yahoo Finance. Broad-market ETFs are expanded into industry sectors using approximate weightings for well-known indices (e.g. S&P 500, MSCI World, FTSE All-World), since Yahoo no longer exposes per-ETF holdings without authentication. Bond, commodity, and single-sector funds keep their own label.",
         "title": "Par secteur"
       }
     },

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -839,7 +839,7 @@
         "title": "Per regione"
       },
       "sector": {
-        "description": "Individual stocks use their listed sector from Yahoo Finance. ETFs use a sector label inferred from their fund name (e.g. \"Technology\", \"Government Bonds\"), as Yahoo no longer exposes per-ETF holdings without authentication.",
+        "description": "Industry-sector mix (e.g. Technology, Financial Services, Consumer goods). Individual stocks use their listed sector from Yahoo Finance. Broad-market ETFs are expanded into industry sectors using approximate weightings for well-known indices (e.g. S&P 500, MSCI World, FTSE All-World), since Yahoo no longer exposes per-ETF holdings without authentication. Bond, commodity, and single-sector funds keep their own label.",
         "title": "Per settore"
       }
     },

--- a/src/utils/etfHeuristics.ts
+++ b/src/utils/etfHeuristics.ts
@@ -167,10 +167,13 @@ export function inferEtfInfo(longName: string | undefined, shortName?: string): 
     }
   }
 
-  // If no sector theme matched but we did identify a region, default focus to Equity.
+  // If no specific asset/sector theme matched but we did identify a region, this
+  // is a broad equity basket. Mark the focus as Equity, but deliberately DON'T
+  // synthesize a "<Region> Equity" sector — that's a region label, not an
+  // industry sector. Broad baskets are expanded into real industry sectors
+  // (Technology, Financial Services, ...) via `inferIndexSectorWeights`.
   if (!result.sectorTheme && result.regionTheme) {
     result.assetFocus = 'Equity';
-    result.sectorTheme = `${result.regionTheme} Equity`;
   }
 
   return result;

--- a/src/utils/indexSectorWeights.ts
+++ b/src/utils/indexSectorWeights.ts
@@ -1,0 +1,229 @@
+/**
+ * Index → industry-sector weightings
+ *
+ * Yahoo Finance's per-ETF holdings endpoint (`quoteSummary` + `topHoldings`)
+ * requires crumb auth that a static browser app can't obtain, so a broad-market
+ * ETF would otherwise collapse into a single synthetic "<Region> Equity" bucket
+ * on the Portfolio Breakdown "By Sector" chart — which is a region label, not an
+ * industry sector.
+ *
+ * To make the sector breakdown genuinely *industry-based* (Finance, Technology,
+ * Consumer goods, Healthcare, ...) we map well-known broad indices to an
+ * approximate GICS / Morningstar industry-sector profile. A single S&P 500 ETF
+ * then contributes proportionally to Technology / Financial Services / etc.,
+ * just as it would if real holdings were available.
+ *
+ * The weightings are intentionally approximate, hand-maintained snapshots of
+ * public index fact sheets — they are meant to give a representative industry
+ * mix, not a to-the-basis-point allocation. They are normalized at lookup time
+ * so callers always receive fractions summing to 1.
+ */
+
+import { SectorWeight } from '../types/portfolioBreakdown';
+
+/**
+ * Canonical industry-sector labels.
+ *
+ * These deliberately match Yahoo Finance's Morningstar-style `sectorDisp`
+ * strings returned for individual stocks, so ETF-derived weightings merge into
+ * the same buckets as direct stock holdings on the breakdown page.
+ */
+export const INDUSTRY_SECTORS = {
+  TECHNOLOGY: 'Technology',
+  FINANCIAL_SERVICES: 'Financial Services',
+  HEALTHCARE: 'Healthcare',
+  CONSUMER_CYCLICAL: 'Consumer Cyclical',
+  CONSUMER_DEFENSIVE: 'Consumer Defensive',
+  COMMUNICATION_SERVICES: 'Communication Services',
+  INDUSTRIALS: 'Industrials',
+  ENERGY: 'Energy',
+  UTILITIES: 'Utilities',
+  BASIC_MATERIALS: 'Basic Materials',
+  REAL_ESTATE: 'Real Estate',
+} as const;
+
+type SectorProfile = Partial<Record<string, number>>;
+
+/**
+ * Approximate industry-sector profiles for major broad indices.
+ * Values are relative weights; they are normalized to sum to 1 on lookup.
+ */
+const INDEX_PROFILES = {
+  US_LARGE_CAP: {
+    [INDUSTRY_SECTORS.TECHNOLOGY]: 30,
+    [INDUSTRY_SECTORS.FINANCIAL_SERVICES]: 13,
+    [INDUSTRY_SECTORS.HEALTHCARE]: 12,
+    [INDUSTRY_SECTORS.CONSUMER_CYCLICAL]: 10,
+    [INDUSTRY_SECTORS.COMMUNICATION_SERVICES]: 9,
+    [INDUSTRY_SECTORS.INDUSTRIALS]: 8,
+    [INDUSTRY_SECTORS.CONSUMER_DEFENSIVE]: 6,
+    [INDUSTRY_SECTORS.ENERGY]: 4,
+    [INDUSTRY_SECTORS.UTILITIES]: 2.5,
+    [INDUSTRY_SECTORS.REAL_ESTATE]: 2.5,
+    [INDUSTRY_SECTORS.BASIC_MATERIALS]: 2,
+  },
+  US_TECH_GROWTH: {
+    // Nasdaq-100 style: tech / comms heavy, essentially no financials.
+    [INDUSTRY_SECTORS.TECHNOLOGY]: 50,
+    [INDUSTRY_SECTORS.COMMUNICATION_SERVICES]: 16,
+    [INDUSTRY_SECTORS.CONSUMER_CYCLICAL]: 14,
+    [INDUSTRY_SECTORS.HEALTHCARE]: 6,
+    [INDUSTRY_SECTORS.CONSUMER_DEFENSIVE]: 6,
+    [INDUSTRY_SECTORS.INDUSTRIALS]: 5,
+    [INDUSTRY_SECTORS.UTILITIES]: 1,
+    [INDUSTRY_SECTORS.BASIC_MATERIALS]: 2,
+  },
+  US_SMALL_CAP: {
+    // Russell 2000 style: more cyclical, less mega-cap tech.
+    [INDUSTRY_SECTORS.FINANCIAL_SERVICES]: 18,
+    [INDUSTRY_SECTORS.INDUSTRIALS]: 17,
+    [INDUSTRY_SECTORS.HEALTHCARE]: 16,
+    [INDUSTRY_SECTORS.TECHNOLOGY]: 13,
+    [INDUSTRY_SECTORS.CONSUMER_CYCLICAL]: 11,
+    [INDUSTRY_SECTORS.REAL_ESTATE]: 6,
+    [INDUSTRY_SECTORS.ENERGY]: 6,
+    [INDUSTRY_SECTORS.BASIC_MATERIALS]: 5,
+    [INDUSTRY_SECTORS.CONSUMER_DEFENSIVE]: 4,
+    [INDUSTRY_SECTORS.UTILITIES]: 3,
+    [INDUSTRY_SECTORS.COMMUNICATION_SERVICES]: 1,
+  },
+  DEVELOPED_WORLD: {
+    [INDUSTRY_SECTORS.TECHNOLOGY]: 25,
+    [INDUSTRY_SECTORS.FINANCIAL_SERVICES]: 15,
+    [INDUSTRY_SECTORS.HEALTHCARE]: 12,
+    [INDUSTRY_SECTORS.INDUSTRIALS]: 11,
+    [INDUSTRY_SECTORS.CONSUMER_CYCLICAL]: 10,
+    [INDUSTRY_SECTORS.COMMUNICATION_SERVICES]: 7,
+    [INDUSTRY_SECTORS.CONSUMER_DEFENSIVE]: 7,
+    [INDUSTRY_SECTORS.ENERGY]: 4,
+    [INDUSTRY_SECTORS.BASIC_MATERIALS]: 4,
+    [INDUSTRY_SECTORS.UTILITIES]: 3,
+    [INDUSTRY_SECTORS.REAL_ESTATE]: 2,
+  },
+  ALL_WORLD: {
+    [INDUSTRY_SECTORS.TECHNOLOGY]: 24,
+    [INDUSTRY_SECTORS.FINANCIAL_SERVICES]: 16,
+    [INDUSTRY_SECTORS.HEALTHCARE]: 11,
+    [INDUSTRY_SECTORS.INDUSTRIALS]: 11,
+    [INDUSTRY_SECTORS.CONSUMER_CYCLICAL]: 11,
+    [INDUSTRY_SECTORS.COMMUNICATION_SERVICES]: 7,
+    [INDUSTRY_SECTORS.CONSUMER_DEFENSIVE]: 6,
+    [INDUSTRY_SECTORS.ENERGY]: 5,
+    [INDUSTRY_SECTORS.BASIC_MATERIALS]: 4,
+    [INDUSTRY_SECTORS.UTILITIES]: 3,
+    [INDUSTRY_SECTORS.REAL_ESTATE]: 2,
+  },
+  EMERGING_MARKETS: {
+    [INDUSTRY_SECTORS.TECHNOLOGY]: 22,
+    [INDUSTRY_SECTORS.FINANCIAL_SERVICES]: 22,
+    [INDUSTRY_SECTORS.CONSUMER_CYCLICAL]: 13,
+    [INDUSTRY_SECTORS.COMMUNICATION_SERVICES]: 9,
+    [INDUSTRY_SECTORS.BASIC_MATERIALS]: 8,
+    [INDUSTRY_SECTORS.ENERGY]: 6,
+    [INDUSTRY_SECTORS.INDUSTRIALS]: 6,
+    [INDUSTRY_SECTORS.CONSUMER_DEFENSIVE]: 5,
+    [INDUSTRY_SECTORS.HEALTHCARE]: 4,
+    [INDUSTRY_SECTORS.UTILITIES]: 3,
+    [INDUSTRY_SECTORS.REAL_ESTATE]: 2,
+  },
+  EUROPE: {
+    [INDUSTRY_SECTORS.FINANCIAL_SERVICES]: 18,
+    [INDUSTRY_SECTORS.INDUSTRIALS]: 16,
+    [INDUSTRY_SECTORS.HEALTHCARE]: 15,
+    [INDUSTRY_SECTORS.CONSUMER_DEFENSIVE]: 10,
+    [INDUSTRY_SECTORS.CONSUMER_CYCLICAL]: 10,
+    [INDUSTRY_SECTORS.TECHNOLOGY]: 9,
+    [INDUSTRY_SECTORS.BASIC_MATERIALS]: 7,
+    [INDUSTRY_SECTORS.ENERGY]: 5,
+    [INDUSTRY_SECTORS.COMMUNICATION_SERVICES]: 4,
+    [INDUSTRY_SECTORS.UTILITIES]: 4,
+    [INDUSTRY_SECTORS.REAL_ESTATE]: 2,
+  },
+} satisfies Record<string, SectorProfile>;
+
+type IndexKey = keyof typeof INDEX_PROFILES;
+
+/**
+ * Ordered name patterns → index profile. Most specific first; the first match
+ * wins. Broad "all-world / all-country" patterns are checked before the generic
+ * "world" pattern so a developed-world fund isn't mistaken for all-world.
+ */
+const INDEX_PATTERNS: Array<{ regex: RegExp; index: IndexKey }> = [
+  // US tech / growth (Nasdaq-100)
+  { regex: /\b(nasdaq[- ]?100|qqq)\b/i, index: 'US_TECH_GROWTH' },
+
+  // US small cap (check before generic US large cap)
+  { regex: /\b(russell ?2000|s&p ?600|small[- ]?cap)\b/i, index: 'US_SMALL_CAP' },
+
+  // US large cap / total US market
+  {
+    regex:
+      /\b(s&p ?500|s&p500|sp500|russell ?(1000|3000)|dow jones (industrial|us)|us ?500|total (us|u\.s\.) ?(stock|market)|crsp us total|us total market|msci usa|us large)\b/i,
+    index: 'US_LARGE_CAP',
+  },
+
+  // Global incl. emerging (all-world / all-country / ACWI)
+  {
+    regex:
+      /\b(all[- ]?world|all[- ]?country|acwi|all cap|ftse global|total world|global all|whole world)\b/i,
+    index: 'ALL_WORLD',
+  },
+
+  // Emerging markets
+  { regex: /\b(emerging markets?|emerging market|\bem\b|emim|developing markets?)\b/i, index: 'EMERGING_MARKETS' },
+
+  // Developed world (MSCI World, FTSE Developed, EAFE, World index)
+  {
+    regex: /\b(msci world|ftse developed|developed world|developed markets?|world index|world equity|eafe|world ex|\bworld\b)\b/i,
+    index: 'DEVELOPED_WORLD',
+  },
+
+  // Europe
+  {
+    regex:
+      /\b(euro ?stoxx ?(50|600)?|stoxx ?(europe ?)?600|msci europe|ftse develop(ed)? europe|ftse europe|europe(an)? equity|stoxx europe)\b/i,
+    index: 'EUROPE',
+  },
+];
+
+function normalizeProfile(profile: SectorProfile): SectorWeight[] {
+  const entries = Object.entries(profile).filter(
+    (e): e is [string, number] => typeof e[1] === 'number' && e[1] > 0,
+  );
+  const total = entries.reduce((sum, [, w]) => sum + w, 0);
+  if (total <= 0) return [];
+  return entries
+    .map(([sector, w]) => ({ sector, weight: w / total }))
+    .sort((a, b) => b.weight - a.weight);
+}
+
+/**
+ * Infer industry-sector weightings for a broad-market fund from its name.
+ *
+ * Returns normalized `SectorWeight[]` (fractions summing to 1) when the fund
+ * name matches a known broad index, or `undefined` when no confident match is
+ * found (e.g. single-country, bond, commodity, or sector-themed funds, which the
+ * caller classifies through other heuristics).
+ */
+export function inferIndexSectorWeights(
+  longName: string | undefined,
+  shortName?: string,
+): SectorWeight[] | undefined {
+  const text = [longName, shortName].filter(Boolean).join(' ');
+  if (!text) return undefined;
+
+  // Funds that are explicitly bond / commodity / real-estate / single-sector are
+  // not broad equity baskets — don't force an equity industry profile on them.
+  if (/\b(bond|treasur(y|ies)|gilt|bund|fixed income|govt|sovereign|aggregate|gold|silver|commodit(y|ies)|crude|oil|reit|money market)\b/i.test(text)) {
+    return undefined;
+  }
+
+  for (const { regex, index } of INDEX_PATTERNS) {
+    if (regex.test(text)) {
+      return normalizeProfile(INDEX_PROFILES[index]);
+    }
+  }
+  return undefined;
+}
+
+export const _internal = { INDEX_PROFILES, INDEX_PATTERNS, normalizeProfile };

--- a/src/utils/yahooMetadata.ts
+++ b/src/utils/yahooMetadata.ts
@@ -24,11 +24,12 @@
 import { AssetMetadata, RegionWeight } from '../types/portfolioBreakdown';
 import { yahooFetch, hasRateLimitCapacity, YahooRateLimitError } from './yahooProxy';
 import { inferEtfInfo, isinToCountryCode } from './etfHeuristics';
+import { inferIndexSectorWeights } from './indexSectorWeights';
 import { logger } from './logger';
 
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const CACHE_PREFIX = 'fire-tools:asset-metadata:';
-const CACHE_VERSION = 2; // bumped when fields/strategy change
+const CACHE_VERSION = 3; // bumped when fields/strategy change
 
 interface CachedEntry {
   v: number;
@@ -193,12 +194,28 @@ export async function fetchAssetMetadata(
       fetchedAt: new Date().toISOString(),
     };
 
-    // ETFs: fill in provider / region theme / sector theme from the long name.
+    // ETFs: fill in provider / region theme / sector exposure from the long name.
     if (quoteType === 'ETF' || quoteType === 'MUTUALFUND') {
       const etf = inferEtfInfo(match.longname, match.shortname);
       if (etf.provider) meta.fundFamily = etf.provider;
       if (etf.regionTheme) meta.country = etf.regionTheme; // used by continent/region
-      if (!meta.sector && etf.sectorTheme) meta.sector = etf.sectorTheme;
+
+      // Industry-sector exposure, in priority order:
+      //   1. A specific single-sector / bond / commodity / real-estate theme from
+      //      the fund name wins (e.g. "Technology", "Government Bonds", "Gold").
+      //   2. Otherwise a broad index (S&P 500, MSCI World, All-World, ...) is
+      //      expanded into real GICS industry sectors so the "By Sector" breakdown
+      //      is industry-based (Technology, Financial Services, ...) instead of a
+      //      single region bucket.
+      if (etf.sectorTheme) {
+        if (!meta.sector) meta.sector = etf.sectorTheme;
+      } else if (!meta.sector) {
+        const indexWeights = inferIndexSectorWeights(match.longname, match.shortname);
+        if (indexWeights && indexWeights.length > 0) {
+          meta.sectorWeightings = indexWeights;
+        }
+      }
+
       if (etf.regionTheme) {
         const regionWeightings: RegionWeight[] = [{ region: etf.regionTheme, weight: 1 }];
         meta.regionWeightings = regionWeightings;

--- a/tests/pages/asset-allocation/etfHeuristics.test.ts
+++ b/tests/pages/asset-allocation/etfHeuristics.test.ts
@@ -79,9 +79,11 @@ describe('etfHeuristics', () => {
       expect(inferEtfInfo('Financial Select Sector SPDR Fund').sectorTheme).toBe('Financial Services');
     });
 
-    it('falls back to "<Region> Equity" sectorTheme when only a region is matched', () => {
+    it('marks broad region-only equity baskets as Equity without a fake sector label', () => {
       const info = inferEtfInfo('Vanguard FTSE All-World UCITS ETF');
-      expect(info.sectorTheme).toBe('Global Equity');
+      // A region is a region, not an industry sector — broad baskets are expanded
+      // into real industry sectors via inferIndexSectorWeights instead.
+      expect(info.sectorTheme).toBeUndefined();
       expect(info.assetFocus).toBe('Equity');
     });
 

--- a/tests/pages/asset-allocation/indexSectorWeights.test.ts
+++ b/tests/pages/asset-allocation/indexSectorWeights.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { inferIndexSectorWeights, INDUSTRY_SECTORS } from '../../../src/utils/indexSectorWeights';
+
+function total(weights: { weight: number }[] | undefined): number {
+  return (weights ?? []).reduce((s, w) => s + w.weight, 0);
+}
+
+function labels(weights: { sector: string }[] | undefined): string[] {
+  return (weights ?? []).map(w => w.sector);
+}
+
+describe('indexSectorWeights', () => {
+  describe('inferIndexSectorWeights', () => {
+    it('expands US large-cap indices into tech-led industry sectors', () => {
+      const w = inferIndexSectorWeights('SPDR S&P 500 ETF Trust');
+      expect(total(w)).toBeCloseTo(1, 6);
+      expect(labels(w)).toContain(INDUSTRY_SECTORS.TECHNOLOGY);
+      expect(labels(w)).toContain(INDUSTRY_SECTORS.FINANCIAL_SERVICES);
+      // Sorted descending, Technology dominates US large cap.
+      expect(w?.[0].sector).toBe(INDUSTRY_SECTORS.TECHNOLOGY);
+    });
+
+    it('maps Nasdaq-100 / QQQ to a tech & communication heavy profile', () => {
+      const w = inferIndexSectorWeights('Invesco QQQ Trust NASDAQ-100');
+      expect(w?.[0].sector).toBe(INDUSTRY_SECTORS.TECHNOLOGY);
+      expect(labels(w)).toContain(INDUSTRY_SECTORS.COMMUNICATION_SERVICES);
+      expect(total(w)).toBeCloseTo(1, 6);
+    });
+
+    it('maps all-world / ACWI before developed world', () => {
+      const w = inferIndexSectorWeights('Vanguard FTSE All-World UCITS ETF');
+      expect(labels(w)).toContain(INDUSTRY_SECTORS.TECHNOLOGY);
+      expect(labels(w)).toContain(INDUSTRY_SECTORS.FINANCIAL_SERVICES);
+      expect(total(w)).toBeCloseTo(1, 6);
+    });
+
+    it('maps MSCI World to a developed-world profile', () => {
+      const w = inferIndexSectorWeights('iShares Core MSCI World UCITS ETF');
+      expect(total(w)).toBeCloseTo(1, 6);
+      expect(labels(w).length).toBeGreaterThan(8);
+    });
+
+    it('maps emerging markets funds with high financials weight', () => {
+      const w = inferIndexSectorWeights('iShares Core MSCI Emerging Markets IMI');
+      expect(labels(w)).toContain(INDUSTRY_SECTORS.FINANCIAL_SERVICES);
+      expect(total(w)).toBeCloseTo(1, 6);
+    });
+
+    it('maps European indices', () => {
+      const w = inferIndexSectorWeights('Lyxor Core STOXX Europe 600 UCITS ETF');
+      expect(w?.[0].sector).toBe(INDUSTRY_SECTORS.FINANCIAL_SERVICES);
+      expect(total(w)).toBeCloseTo(1, 6);
+    });
+
+    it('maps small-cap indices distinctly from large cap', () => {
+      const w = inferIndexSectorWeights('iShares Russell 2000 ETF');
+      expect(labels(w)).toContain(INDUSTRY_SECTORS.INDUSTRIALS);
+      expect(total(w)).toBeCloseTo(1, 6);
+    });
+
+    it('returns undefined for bond, commodity and real-estate funds', () => {
+      expect(inferIndexSectorWeights('iShares Euro Govt Bond 7-10yr')).toBeUndefined();
+      expect(inferIndexSectorWeights('iShares Physical Gold ETC')).toBeUndefined();
+      expect(inferIndexSectorWeights('Vanguard Global REIT UCITS ETF')).toBeUndefined();
+      expect(inferIndexSectorWeights('SPDR Bloomberg Aggregate Bond')).toBeUndefined();
+    });
+
+    it('returns undefined for single-country and unknown funds', () => {
+      expect(inferIndexSectorWeights('iShares MSCI China A')).toBeUndefined();
+      expect(inferIndexSectorWeights('Some Random Holding Inc.')).toBeUndefined();
+      expect(inferIndexSectorWeights(undefined)).toBeUndefined();
+      expect(inferIndexSectorWeights('')).toBeUndefined();
+    });
+
+    it('normalizes every profile to sum to 1', () => {
+      const names = [
+        'SPDR S&P 500 ETF',
+        'Invesco QQQ NASDAQ-100',
+        'iShares Russell 2000',
+        'iShares MSCI World',
+        'Vanguard FTSE All-World',
+        'iShares MSCI Emerging Markets',
+        'STOXX Europe 600',
+      ];
+      for (const name of names) {
+        expect(total(inferIndexSectorWeights(name))).toBeCloseTo(1, 6);
+      }
+    });
+  });
+});

--- a/tests/pages/asset-allocation/yahooMetadata.test.ts
+++ b/tests/pages/asset-allocation/yahooMetadata.test.ts
@@ -76,7 +76,7 @@ describe('yahooMetadata', () => {
       expect(meta.country).toBe('US');
     });
 
-    it('applies ETF heuristics for an ETF', async () => {
+    it('applies ETF heuristics and expands broad indices into industry sectors', async () => {
       mockedFetch.mockResolvedValueOnce({
         quotes: [
           {
@@ -95,8 +95,34 @@ describe('yahooMetadata', () => {
       expect(meta.fundFamily).toBe('Vanguard');
       expect(meta.exchange).toBe('XETRA');
       expect(meta.country).toBe('Global');
-      expect(meta.sector).toBe('Global Equity');
+      // No fake "Global Equity" single-sector label anymore.
+      expect(meta.sector).toBeUndefined();
+      // Expanded into real industry sectors that sum to ~1.
+      expect(meta.sectorWeightings?.length).toBeGreaterThan(5);
+      const labels = meta.sectorWeightings?.map(w => w.sector) ?? [];
+      expect(labels).toContain('Technology');
+      expect(labels).toContain('Financial Services');
+      const total = (meta.sectorWeightings ?? []).reduce((s, w) => s + w.weight, 0);
+      expect(total).toBeCloseTo(1, 5);
       expect(meta.regionWeightings?.[0]).toEqual({ region: 'Global', weight: 1 });
+    });
+
+    it('keeps a specific single-sector label for sector-themed ETFs', async () => {
+      mockedFetch.mockResolvedValueOnce({
+        quotes: [
+          {
+            symbol: 'XGOV',
+            shortname: 'iShares Govt Bond',
+            longname: 'iShares Euro Government Bond 7-10yr UCITS ETF',
+            quoteType: 'ETF',
+            exchDisp: 'XETRA',
+          },
+        ],
+      });
+
+      const meta = await fetchAssetMetadata('XGOV');
+      expect(meta.sectorWeightings).toBeUndefined();
+      expect(meta.sector).toBe('Government Bonds');
     });
 
     it('caches successful results and reuses on second call', async () => {


### PR DESCRIPTION
## What

The Portfolio Breakdown **By Sector** chart now reflects real **industry sectors** (Finance, Technology, Consumer goods, Healthcare, …) instead of region-flavoured pseudo-sectors.

## Why

Broad equity ETFs (the bulk of most FIRE portfolios — S&P 500, FTSE All-World, MSCI World) had no per-holding data (Yahoo's holdings endpoint needs crumb auth a static app can't get), so each collapsed into a single synthetic `"<Region> Equity"` bucket (e.g. *Global Equity*, *United States Equity*). That's a region label, not an industry sector, and it defeated the purpose of a sector breakdown.

## How

- **New `src/utils/indexSectorWeights.ts`** — approximate GICS / Morningstar industry-sector profiles for well-known broad indices (S&P 500, Nasdaq-100, MSCI/FTSE Developed World, All-World/ACWI, Emerging Markets, Europe, US small cap). `inferIndexSectorWeights()` matches a fund name → normalized `SectorWeight[]`. Labels match Yahoo's stock `sectorDisp` so ETF- and stock-derived sectors merge into the same buckets.
- **`yahooMetadata.ts`** — broad ETFs now populate `sectorWeightings`, so a single S&P 500 ETF contributes proportionally to Technology / Financial Services / etc. A *specific* single-sector, bond, or commodity theme still wins (a Technology sector fund stays Technology; a government-bond fund stays Government Bonds). Cache version bumped (2 → 3) to invalidate stale entries.
- **`etfHeuristics.ts`** — stop synthesizing the misleading `"<Region> Equity"` sector label.
- **i18n** — updated the *By Sector* description in all 5 locales.

## Tests

- New `indexSectorWeights.test.ts` (profiles normalize to 1; bond/commodity/single-country funds return `undefined`).
- Updated `etfHeuristics` and `yahooMetadata` tests for the new behaviour.
- Full suite green: **1190 passed**, `tsc --noEmit` clean, `vite build` clean.

> Index weightings are intentionally approximate, hand-maintained snapshots of public fact sheets — representative industry mix, not to-the-basis-point allocation.