### PR TITLE
chore: auto patch-version bump on merge + bump to 2.2.0

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,75 @@
+name: Auto bump patch version
+
+# Automatically bumps the PATCH version whenever a PR is merged to main
+# (e.g. 2.1.0 -> 2.1.1). It commits the bump back to main but NEVER creates a
+# git tag — release tags are minted by maintainers, which is what drives the
+# deploy.yml / release.yml pipelines.
+#
+# Recursion is prevented three ways:
+#   1. The job is skipped when the head commit is itself a version bump
+#      (message contains "bump version to") or explicitly opts out ("[skip ci]").
+#   2. The bump commit it creates carries "[skip ci]", so GitHub skips all
+#      workflows for that push.
+#   3. Pushes made with the default GITHUB_TOKEN do not trigger new runs.
+#
+# A deliberate release bump merged as "chore: bump version to X.Y.Z" is also
+# skipped by guard (1), so the chosen version survives untouched for tagging.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: version-bump-main
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump patch version
+    runs-on: ubuntu-latest
+    if: >-
+      !contains(github.event.head_commit.message, 'bump version to') &&
+      !contains(github.event.head_commit.message, '[skip ci]')
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Compute next patch version
+        id: ver
+        run: |
+          set -euo pipefail
+          NEXT=$(node -e "const [a,b,c]=require('./package.json').version.split('.').map(Number); if([a,b,c].some(Number.isNaN)){process.exit(1)}; process.stdout.write(\`\${a}.\${b}.\${c+1}\`)")
+          CURRENT=$(node -p "require('./package.json').version")
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Bumping $CURRENT -> $NEXT"
+
+      - name: Apply version bump across files
+        run: node scripts/bump-version.mjs "${{ steps.ver.outputs.next }}"
+
+      - name: Commit and push bump (no tag)
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "No version changes to commit; nothing to do."
+            exit 0
+          fi
+          git add -u
+          git commit -m "chore: bump version to ${{ steps.ver.outputs.next }} [skip ci]"
+          # Rebase onto any concurrent main movement, then push. No tag is created.
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fire-tools",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fire-tools",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire-tools",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "FIRE tools including calculator with Monte Carlo simulations and asset allocation manager",
   "type": "module",
   "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fire-tools-server",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fire-tools-server",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "better-sqlite3": "npm:better-sqlite3-multiple-ciphers@^12.10.0",
         "cors": "^2.8.5",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire-tools-server",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Local-deployment backend for Fire Tools (SQLite-first, Postgres-compatible). Implements docs/api/openapi.yaml.",
   "private": true,
   "type": "module",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,7 +3,7 @@
 import { vi } from 'vitest';
 import '../src/i18n';
 
-vi.stubGlobal('__APP_VERSION__', '2.1.1');
+vi.stubGlobal('__APP_VERSION__', '2.2.0');
 vi.stubGlobal('__APP_COMMIT_HASH__', 'testcommit');
 vi.stubGlobal('__APP_BUILD_TIME__', '2024-01-01T00:00:00.000Z');
 vi.stubGlobal('__APP_DEPENDENCIES__', { react: '19.0.0' });


### PR DESCRIPTION
## What

1. **Auto patch-version bump** — new workflow `.github/workflows/version-bump.yml` bumps the PATCH version on every push to `main` (e.g. `2.1.0` → `2.1.1`). It commits the bump back to `main` but **never creates a tag** — release tags stay maintainer-minted (they drive `deploy.yml` / `release.yml`).
2. **Bump to 2.2.0** — root + `server/package.json`, both lockfiles, and the `__APP_VERSION__` stub in `tests/setup.ts`, via the existing `scripts/bump-version.mjs`.

## Recursion safety

The auto-bump job is skipped when the head commit message contains `bump version to` or `[skip ci]`, the bump commit it creates carries `[skip ci]`, and default-`GITHUB_TOKEN` pushes don't re-trigger workflows — triple guard.

Because this PR is merged with the subject `chore: bump version to 2.2.0`, the auto-bump guard skips it, so `main` stays at **2.2.0** for the maintainer `v2.2.0` tag.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>