### PR TITLE
Fix references after repo move to fire-tools-inc/app

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/mbianchidev/fire-tools/security/advisories/new
+    url: https://github.com/fire-tools-inc/app/security/advisories/new
     about: Report a security vulnerability privately. Please do not create a public issue for security concerns.
   - name: Documentation
-    url: https://github.com/mbianchidev/fire-tools/blob/main/README.md
+    url: https://github.com/fire-tools-inc/app/blob/main/README.md
     about: Check the documentation for help with common questions.
   - name: Support
-    url: https://github.com/mbianchidev/fire-tools/blob/main/SUPPORT.md
+    url: https://github.com/fire-tools-inc/app/blob/main/SUPPORT.md
     about: Get help and support information.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ This document provides comprehensive instructions for AI agents working on the F
 - Node.js ^20.19.0 || ^22.12.0 || >=24.0.0
 
 ### Backend (implemented — [`server/`](server/))
-Local-deployment / Electron path (issues [#133](https://github.com/mbianchidev/fire-tools/issues/133),
-[#189](https://github.com/mbianchidev/fire-tools/issues/189),
-[#195](https://github.com/mbianchidev/fire-tools/issues/195),
-[#222](https://github.com/mbianchidev/fire-tools/issues/222)):
+Local-deployment / Electron path (issues [#133](https://github.com/fire-tools-inc/app/issues/133),
+[#189](https://github.com/fire-tools-inc/app/issues/189),
+[#195](https://github.com/fire-tools-inc/app/issues/195),
+[#222](https://github.com/fire-tools-inc/app/issues/222)):
 - **Runtime**: Node.js + Express 4 + TypeScript (strict, ESM)
 - **REST API**: OpenAPI 3.0.3 contract at [`docs/api/openapi.yaml`](docs/api/openapi.yaml). See [`docs/api/README.md`](docs/api/README.md) for conventions, type mapping, and client generation.
 - **Database**: better-sqlite3 (SQLite as the **first-class** target), **PostgreSQL-compatible** schema. DDL at [`docs/database/schema.sql`](docs/database/schema.sql); design notes and ERD at [`docs/database/README.md`](docs/database/README.md).
@@ -308,7 +308,7 @@ Serves the production build locally for testing.
 ### Deployment
 - Automatic deployment to GitHub Pages via GitHub Actions
 - Triggered when a version tag matching `v*` (e.g. `v1.2.3`) is pushed
-- Base path configured as `/fire-tools/` for GitHub Pages
+- Base path configured as `/app/` for GitHub Pages
 - Workflow file: `.github/workflows/deploy.yml`
 
 ## Common Tasks for AI Agents

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,13 @@ Before you begin, ensure you have the following installed:
 
 2. **Clone your fork** to your local machine:
    ```bash
-   git clone https://github.com/YOUR-USERNAME/fire-tools.git
-   cd fire-tools
+   git clone https://github.com/YOUR-USERNAME/app.git
+   cd app
    ```
 
 3. **Add the upstream repository**:
    ```bash
-   git remote add upstream https://github.com/mbianchidev/fire-tools.git
+   git remote add upstream https://github.com/fire-tools-inc/app.git
    ```
 
 4. **Install dependencies**:
@@ -209,10 +209,10 @@ We use GitHub Issue Templates to help you report bugs and request features. This
 
 ### Quick Links
 
-- 🐛 **[Report a Bug](https://github.com/mbianchidev/fire-tools/issues/new?template=bug_report.yml)** - Something isn't working correctly
-- ✨ **[Request a Feature](https://github.com/mbianchidev/fire-tools/issues/new?template=feature_request.yml)** - Suggest a new feature or improvement
-- 🎨 **[UX/UI Suggestion](https://github.com/mbianchidev/fire-tools/issues/new?template=ux_ui_suggestion.yml)** - Improve the user experience or interface
-- 🔒 **[Security Issue](https://github.com/mbianchidev/fire-tools/security/advisories/new)** - Report security vulnerabilities privately
+- 🐛 **[Report a Bug](https://github.com/fire-tools-inc/app/issues/new?template=bug_report.yml)** - Something isn't working correctly
+- ✨ **[Request a Feature](https://github.com/fire-tools-inc/app/issues/new?template=feature_request.yml)** - Suggest a new feature or improvement
+- 🎨 **[UX/UI Suggestion](https://github.com/fire-tools-inc/app/issues/new?template=ux_ui_suggestion.yml)** - Improve the user experience or interface
+- 🔒 **[Security Issue](https://github.com/fire-tools-inc/app/security/advisories/new)** - Report security vulnerabilities privately
 
 You can also report bugs directly from the app via **Settings → Support & Feedback → Report a Bug**.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A privacy-first suite of **FIRE (Financial Independence Retire Early)** planning tools. Financial data is stored locally by default; optional integrations (Yahoo Finance prices, LLM categorization) contact external services only when explicitly enabled.
 
-**[Try the live demo →](https://mbianchidev.github.io/fire-tools/demo/)**
+**[Try the live demo →](https://fire-tools-inc.github.io/app/demo/)**
 
 ---
 
@@ -40,7 +40,7 @@ This software is for **educational and planning purposes only** — not financia
 ## Quick Start
 
 ```bash
-git clone https://github.com/mbianchidev/fire-tools.git && cd fire-tools
+git clone https://github.com/fire-tools-inc/app.git && cd app
 npm install
 npm run dev          # → http://localhost:5173
 ```
@@ -118,7 +118,7 @@ Full policy: [SECURITY.md](SECURITY.md)
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Check [open issues](https://github.com/mbianchidev/fire-tools/issues), fork, branch, and submit a PR.
+See [CONTRIBUTING.md](CONTRIBUTING.md). Check [open issues](https://github.com/fire-tools-inc/app/issues), fork, branch, and submit a PR.
 
 ---
 
@@ -130,9 +130,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Check [open issues](https://github.com/m
 
 ## Support
 
-- 🐛 [Report a bug](https://github.com/mbianchidev/fire-tools/issues/new?template=bug_report.yml)
-- ✨ [Request a feature](https://github.com/mbianchidev/fire-tools/issues/new?template=feature_request.yml)
-- 🎨 [UX/UI suggestion](https://github.com/mbianchidev/fire-tools/issues/new?template=ux_ui_suggestion.yml)
+- 🐛 [Report a bug](https://github.com/fire-tools-inc/app/issues/new?template=bug_report.yml)
+- ✨ [Request a feature](https://github.com/fire-tools-inc/app/issues/new?template=feature_request.yml)
+- 🎨 [UX/UI suggestion](https://github.com/fire-tools-inc/app/issues/new?template=ux_ui_suggestion.yml)
 - 💬 [SUPPORT.md](SUPPORT.md)
 
 You can also report bugs from the app: **Settings → Support & Feedback**.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,10 +8,10 @@ Thank you for using Fire Tools! This document explains how to get help with the 
 
 Use our issue templates to get help quickly:
 
-- 🐛 **[Report a Bug](https://github.com/mbianchidev/fire-tools/issues/new?template=bug_report.yml)** - Something isn't working correctly
-- ✨ **[Request a Feature](https://github.com/mbianchidev/fire-tools/issues/new?template=feature_request.yml)** - Suggest a new feature or improvement
-- 🎨 **[UX/UI Suggestion](https://github.com/mbianchidev/fire-tools/issues/new?template=ux_ui_suggestion.yml)** - Improve the user experience or interface
-- 🔒 **[Security Issue](https://github.com/mbianchidev/fire-tools/security/advisories/new)** - Report security vulnerabilities privately
+- 🐛 **[Report a Bug](https://github.com/fire-tools-inc/app/issues/new?template=bug_report.yml)** - Something isn't working correctly
+- ✨ **[Request a Feature](https://github.com/fire-tools-inc/app/issues/new?template=feature_request.yml)** - Suggest a new feature or improvement
+- 🎨 **[UX/UI Suggestion](https://github.com/fire-tools-inc/app/issues/new?template=ux_ui_suggestion.yml)** - Improve the user experience or interface
+- 🔒 **[Security Issue](https://github.com/fire-tools-inc/app/security/advisories/new)** - Report security vulnerabilities privately
 
 ### Report from Within the App
 
@@ -26,7 +26,7 @@ You can also report bugs and request features directly from Fire Tools:
 
 The primary way to get support is by **opening an issue** on GitHub using our templates:
 
-👉 [View all issue options](https://github.com/mbianchidev/fire-tools/issues/new/choose)
+👉 [View all issue options](https://github.com/fire-tools-inc/app/issues/new/choose)
 
 This allows the community to:
 - See and benefit from questions and answers
@@ -52,7 +52,7 @@ Our issue templates guide you through providing the right information. In genera
 
 ### Bug Reports
 
-Found a bug? [Report it here!](https://github.com/mbianchidev/fire-tools/issues/new?template=bug_report.yml) Include:
+Found a bug? [Report it here!](https://github.com/fire-tools-inc/app/issues/new?template=bug_report.yml) Include:
 - Description of the bug
 - Bug category (UI, UX, calculation, data, performance)
 - Steps to reproduce
@@ -63,7 +63,7 @@ Found a bug? [Report it here!](https://github.com/mbianchidev/fire-tools/issues/
 
 ### Feature Requests
 
-Have an idea for a new feature? [Request it here!](https://github.com/mbianchidev/fire-tools/issues/new?template=feature_request.yml) Include:
+Have an idea for a new feature? [Request it here!](https://github.com/fire-tools-inc/app/issues/new?template=feature_request.yml) Include:
 - Description of the feature
 - Why it would be useful
 - How you envision it working
@@ -103,7 +103,7 @@ Please be patient - this is an open source project maintained by volunteers.
 
 ### Live Demo
 
-Try the live version: [https://mbianchidev.github.io/fire-tools/](https://mbianchidev.github.io/fire-tools/)
+Try the live version: [https://fire-tools-inc.github.io/app/](https://fire-tools-inc.github.io/app/)
 
 ## What We Don't Support
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8,7 +8,7 @@ info:
     Fire Tools is currently a client-side React app that stores everything in
     encrypted cookies. This OpenAPI contract describes the **planned** backend
     that will power local deployments (Docker / Electron) — see
-    [issue #133](https://github.com/mbianchidev/fire-tools/issues/133).
+    [issue #133](https://github.com/fire-tools-inc/app/issues/133).
 
     **Status — contract only.** No server implementation exists yet.
 
@@ -26,10 +26,10 @@ info:
       scheme below is reserved for multi-tenant deployments and is opt-in.
   license:
     name: MIT
-    url: https://github.com/mbianchidev/fire-tools/blob/main/LICENSE
+    url: https://github.com/fire-tools-inc/app/blob/main/LICENSE
   contact:
     name: Fire Tools
-    url: https://github.com/mbianchidev/fire-tools
+    url: https://github.com/fire-tools-inc/app
 
 servers:
   - url: http://localhost:8080/api/v1

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -4,9 +4,9 @@ Fire Tools' planned local-deployment backend stores data in a relational
 database. This document describes the schema in [`schema.sql`](./schema.sql).
 
 > **Status — contract only.** The backend itself is not yet implemented
-> (tracked in issues [#189](https://github.com/mbianchidev/fire-tools/issues/189),
-> [#195](https://github.com/mbianchidev/fire-tools/issues/195),
-> [#222](https://github.com/mbianchidev/fire-tools/issues/222)). This schema
+> (tracked in issues [#189](https://github.com/fire-tools-inc/app/issues/189),
+> [#195](https://github.com/fire-tools-inc/app/issues/195),
+> [#222](https://github.com/fire-tools-inc/app/issues/222)). This schema
 > defines the persistence contract that the future backend will honour.
 
 ---
@@ -178,5 +178,5 @@ restricted by deployment policy, not by schema. To migrate:
   (e.g. `node-pg-migrate` for Postgres, `goose` or `dbmate` for either).
   Until then, `schema.sql` is the only DDL artifact.
 - **Audit log table.** Tracked separately in
-  [#188](https://github.com/mbianchidev/fire-tools/issues/188).
+  [#188](https://github.com/fire-tools-inc/app/issues/188).
 - **Backups, encryption-at-rest, role grants.** Deployer concern.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,9 +1,9 @@
 # Local Docker Compose deployment
 
 Covers issues
-[#129](https://github.com/mbianchidev/fire-tools/issues/129) (decouple +
+[#129](https://github.com/fire-tools-inc/app/issues/129) (decouple +
 containerize) and
-[#195](https://github.com/mbianchidev/fire-tools/issues/195) (local
+[#195](https://github.com/fire-tools-inc/app/issues/195) (local
 database).
 
 The backend implements the full OpenAPI contract against SQLite. Migrations

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -30,9 +30,9 @@ instead.
   any third-party client you build on top of the OpenAPI contract.
 - **Backend** — a small Node.js + Express service in `server/`. SQLite is the
   default storage; Postgres is supported via a Docker Compose profile.
-- **Contract** — [OpenAPI 3.0.3](https://github.com/mbianchidev/fire-tools/blob/main/docs/api/openapi.yaml).
+- **Contract** — [OpenAPI 3.0.3](https://github.com/fire-tools-inc/app/blob/main/docs/api/openapi.yaml).
   Source of truth for both server routes and any generated client. Also
-  published at [`/fire-tools/api/`](https://mbianchidev.github.io/fire-tools/api/).
+  published at [`/app/api/`](https://fire-tools-inc.github.io/app/api/).
 
 ## Why a local-first backend?
 
@@ -62,7 +62,7 @@ don't need to think about auth on day one.
 
 ## Related links
 
-- [Project README](https://github.com/mbianchidev/fire-tools)
-- [Issue tracker](https://github.com/mbianchidev/fire-tools/issues)
-- [Live OpenAPI viewer](https://mbianchidev.github.io/fire-tools/api/)
-- [Mobile repo plan](https://github.com/mbianchidev/fire-tools/blob/main/docs/mobile/README.md)
+- [Project README](https://github.com/fire-tools-inc/app)
+- [Issue tracker](https://github.com/fire-tools-inc/app/issues)
+- [Live OpenAPI viewer](https://fire-tools-inc.github.io/app/api/)
+- [Mobile repo plan](https://github.com/fire-tools-inc/app/blob/main/docs/mobile/README.md)

--- a/docs/engineering/api-client.md
+++ b/docs/engineering/api-client.md
@@ -4,9 +4,9 @@ The backend is described by an [OpenAPI 3.0.3](https://spec.openapis.org/oas/v3.
 contract. The same contract drives the official client and any client you
 choose to build.
 
-- **Source**: [`docs/api/openapi.yaml`](https://github.com/mbianchidev/fire-tools/blob/main/docs/api/openapi.yaml)
-- **Live viewer**: <https://mbianchidev.github.io/fire-tools/api/>
-- **Raw spec**: <https://mbianchidev.github.io/fire-tools/api/openapi.yaml>
+- **Source**: [`docs/api/openapi.yaml`](https://github.com/fire-tools-inc/app/blob/main/docs/api/openapi.yaml)
+- **Live viewer**: <https://fire-tools-inc.github.io/app/api/>
+- **Raw spec**: <https://fire-tools-inc.github.io/app/api/openapi.yaml>
 
 ## Lint the spec
 

--- a/docs/engineering/auto-updater.md
+++ b/docs/engineering/auto-updater.md
@@ -1,6 +1,6 @@
 # Auto-updater design
 
-Tracking issue: [#236](https://github.com/mbianchidev/fire-tools/issues/236).
+Tracking issue: [#236](https://github.com/fire-tools-inc/app/issues/236).
 Applies to the **Electron desktop build only**; the web build self-refreshes
 on reload and ignores `settings.updater.*`.
 
@@ -178,8 +178,8 @@ UI can disable Restore.
 ```yaml
 publish:
   - provider: github
-    owner: mbianchidev
-    repo: fire-tools
+    owner: fire-tools-inc
+    repo: app
 ```
 
 `.github/workflows/release.yml` uploads the `*.yml` and `*.blockmap`

--- a/docs/engineering/backend-deploy.md
+++ b/docs/engineering/backend-deploy.md
@@ -11,8 +11,8 @@ stack. You get the API on `:3000` and (optionally) Postgres on `:5432`.
 ## Quick start (SQLite)
 
 ```sh
-git clone https://github.com/mbianchidev/fire-tools.git
-cd fire-tools
+git clone https://github.com/fire-tools-inc/app.git
+cd app
 docker compose build --no-cache
 docker compose up -d backend
 curl http://localhost:3000/api/v1/health

--- a/docs/engineering/database.md
+++ b/docs/engineering/database.md
@@ -3,8 +3,8 @@
 The backend treats SQLite as a **first-class** storage target and keeps the
 schema **Postgres-compatible** so the same DDL runs on both engines.
 
-- DDL: [`docs/database/schema.sql`](https://github.com/mbianchidev/fire-tools/blob/main/docs/database/schema.sql)
-- Design notes + ERD: [`docs/database/README.md`](https://github.com/mbianchidev/fire-tools/blob/main/docs/database/README.md)
+- DDL: [`docs/database/schema.sql`](https://github.com/fire-tools-inc/app/blob/main/docs/database/schema.sql)
+- Design notes + ERD: [`docs/database/README.md`](https://github.com/fire-tools-inc/app/blob/main/docs/database/README.md)
 
 ## Why SQLite first?
 
@@ -40,8 +40,8 @@ sqlite3 :memory: < docs/database/schema.sql
 
 Whenever you change `docs/database/schema.sql` you **must** update:
 
-1. The matching schema in [`docs/api/openapi.yaml`](https://github.com/mbianchidev/fire-tools/blob/main/docs/api/openapi.yaml).
-2. The matching TypeScript interface or union in [`src/types/*.ts`](https://github.com/mbianchidev/fire-tools/tree/main/src/types).
+1. The matching schema in [`docs/api/openapi.yaml`](https://github.com/fire-tools-inc/app/blob/main/docs/api/openapi.yaml).
+2. The matching TypeScript interface or union in [`src/types/*.ts`](https://github.com/fire-tools-inc/app/tree/main/src/types).
 3. A migration file with a **rollback** companion — see
    [migrations & rollbacks](./migrations.md).
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -1,6 +1,6 @@
 # Mobile app — separate repo, Flutter
 
-Tracking issue: [#134](https://github.com/mbianchidev/fire-tools/issues/134).
+Tracking issue: [#134](https://github.com/fire-tools-inc/app/issues/134).
 
 ## Why a separate repo
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -22,9 +22,9 @@ walkthrough and a screenshot so you can see exactly what to expect.
 
 ## How to install
 
-- **Web** — open <https://mbianchidev.github.io/fire-tools/demo/>. Nothing to install.
+- **Web** — open <https://fire-tools-inc.github.io/app/demo/>. Nothing to install.
 - **Desktop** — grab the `.dmg` (macOS), `.exe` (Windows) or `.AppImage` (Linux)
-  from the [releases page](https://github.com/mbianchidev/fire-tools/releases).
+  from the [releases page](https://github.com/fire-tools-inc/app/releases).
 - **Self-hosted** — see the
   [engineering docs](../engineering/README.md) for the Docker Compose stack.
 

--- a/docs/user/expense-tracker.md
+++ b/docs/user/expense-tracker.md
@@ -17,7 +17,7 @@ annual expenses (the number that drives the FIRE target) instead of guessing.
 
 Use **Import PDF** to upload a bank statement. Fire Tools includes lightweight
 extractors for a handful of common European bank PDF layouts (see
-[`docs/pdf-import.md`](https://github.com/mbianchidev/fire-tools/blob/main/docs/pdf-import.md) for the supported list and how to
+[`docs/pdf-import.md`](https://github.com/fire-tools-inc/app/blob/main/docs/pdf-import.md) for the supported list and how to
 contribute one). Imported rows land in a staging table where you can map them
 to categories before committing.
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -77,6 +77,6 @@ linux:
 
 publish:
   provider: github
-  owner: mbianchidev
-  repo: fire-tools
+  owner: fire-tools-inc
+  repo: app
   releaseType: release

--- a/electron/README.md
+++ b/electron/README.md
@@ -2,7 +2,7 @@
 
 Wraps the existing React SPA so it ships as a signed binary on macOS,
 Windows and Linux. Tracks issue
-[#132](https://github.com/mbianchidev/fire-tools/issues/132).
+[#132](https://github.com/fire-tools-inc/app/issues/132).
 
 > **Scope of this scaffold.** Wraps the React SPA **and bundles the
 > Node + Express + SQLite backend in-process**: the main process starts the

--- a/electron/dev-app-update.yml
+++ b/electron/dev-app-update.yml
@@ -1,3 +1,3 @@
 provider: github
-owner: mbianchidev
-repo: fire-tools
+owner: fire-tools-inc
+repo: app

--- a/electron/menu.cjs
+++ b/electron/menu.cjs
@@ -5,8 +5,8 @@
 
 const { app, Menu, shell, BrowserWindow, dialog } = require('electron');
 
-const REPO_URL = 'https://github.com/mbianchidev/fire-tools';
-const DOCS_URL = 'https://mbianchidev.github.io/fire-tools/';
+const REPO_URL = 'https://github.com/fire-tools-inc/app';
+const DOCS_URL = 'https://fire-tools-inc.github.io/app/';
 const ISSUES_URL = `${REPO_URL}/issues/new/choose`;
 const RELEASES_URL = `${REPO_URL}/releases`;
 

--- a/package.json
+++ b/package.json
@@ -41,15 +41,15 @@
   "author": {
     "name": "Fire Tools Contributors",
     "email": "noreply@mb-consulting.dev",
-    "url": "https://github.com/mbianchidev/fire-tools"
+    "url": "https://github.com/fire-tools-inc/app"
   },
-  "homepage": "https://github.com/mbianchidev/fire-tools",
+  "homepage": "https://github.com/fire-tools-inc/app",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mbianchidev/fire-tools.git"
+    "url": "git+https://github.com/fire-tools-inc/app.git"
   },
   "bugs": {
-    "url": "https://github.com/mbianchidev/fire-tools/issues"
+    "url": "https://github.com/fire-tools-inc/app/issues"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -88,7 +88,7 @@ function pageHtml({ section, slug, html, pages, siblingSection }) {
         <a href="../user/">User docs</a>
         <a href="../engineering/">Engineering docs</a>
         <a href="../../api/">API reference</a>
-        <a href="https://github.com/mbianchidev/fire-tools" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/fire-tools-inc/app" target="_blank" rel="noopener">GitHub</a>
         <a class="cta" href="../../demo/">Open the demo</a>
       </nav>
     </header>
@@ -201,7 +201,7 @@ export async function buildDocs() {
         <a href="./user/">User docs</a>
         <a href="./engineering/">Engineering docs</a>
         <a href="../api/">API reference</a>
-        <a href="https://github.com/mbianchidev/fire-tools" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/fire-tools-inc/app" target="_blank" rel="noopener">GitHub</a>
         <a class="cta" href="../demo/">Open the demo</a>
       </nav>
     </header>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/.."
 
 DEFAULT_BRANCH="main"
 REMOTE="origin"
-REPO_URL="https://github.com/mbianchidev/fire-tools"
+REPO_URL="https://github.com/fire-tools-inc/app"
 
 err()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; }
 info() { printf '\033[36m==>\033[0m %s\n' "$*"; }

--- a/server/README.md
+++ b/server/README.md
@@ -3,11 +3,11 @@
 Local-deployment backend for Fire Tools. Implements the OpenAPI contract at
 [`../docs/api/openapi.yaml`](../docs/api/openapi.yaml) end-to-end against
 SQLite. PostgreSQL profile is wired in compose but the driver itself isn't
-implemented yet — see issue [#195](https://github.com/mbianchidev/fire-tools/issues/195).
+implemented yet — see issue [#195](https://github.com/fire-tools-inc/app/issues/195).
 
 Covers issues
-[#129](https://github.com/mbianchidev/fire-tools/issues/129),
-[#195](https://github.com/mbianchidev/fire-tools/issues/195).
+[#129](https://github.com/fire-tools-inc/app/issues/129),
+[#195](https://github.com/fire-tools-inc/app/issues/195).
 
 ## Stack
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -482,7 +482,7 @@ function NavigateBridge() {
 
 function App() {
   // SPA lives under /demo on the web so the landing page can sit at the root.
-  // Production = GitHub Pages under /fire-tools. Electron detection covers
+  // Production = GitHub Pages under /app. Electron detection covers
   // both packaged (file://) and unpackaged dev (http://) launches via the
   // preload bridge that only exists inside Electron.
   const isElectron =
@@ -491,7 +491,7 @@ function App() {
   const basename = isElectron
     ? '/'
     : import.meta.env.MODE === 'production'
-    ? '/fire-tools/demo'
+    ? '/app/demo'
     : '/demo';
   const { t } = useTranslation();
   
@@ -599,7 +599,7 @@ function App() {
                   {t('app.cookiePolicy')}
                 </button>
                 <span className="footer-separator">•</span>
-                <a href="https://github.com/mbianchidev/fire-tools" target="_blank" rel="noopener noreferrer">{t('app.github')}</a>
+                <a href="https://github.com/fire-tools-inc/app" target="_blank" rel="noopener noreferrer">{t('app.github')}</a>
               </div>
             </footer>
           )}

--- a/src/components/DemoBanner.tsx
+++ b/src/components/DemoBanner.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { IS_DEMO_MODE } from '../utils/demoMode';
 import './DemoBanner.css';
 
-const RELEASES_URL = 'https://github.com/mbianchidev/fire-tools/releases/latest';
+const RELEASES_URL = 'https://github.com/fire-tools-inc/app/releases/latest';
 
 export function DemoBanner() {
   const { t } = useTranslation();

--- a/src/components/FIREMetrics.tsx
+++ b/src/components/FIREMetrics.tsx
@@ -61,7 +61,7 @@ export const FIREMetrics: React.FC<FIREMetricsProps> = ({
     : Math.min(currentAge + zoomYears, projections[projections.length - 1]?.age || currentAge);
 
   const handleShare = async () => {
-    const SHARE_ROOT = 'https://mbianchidev.github.io/fire-tools/demo/fire-calculator';
+    const SHARE_ROOT = 'https://fire-tools-inc.github.io/app/demo/fire-calculator';
     const url = `${SHARE_ROOT}${window.location.search}${window.location.hash}`;
     try {
       await navigator.clipboard.writeText(url);

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -47,7 +47,7 @@ export function HomePage() {
             </p>
             <div className="warning-actions">
               <a 
-                href="https://github.com/mbianchidev/fire-calculator#getting-started" 
+                href="https://github.com/fire-tools-inc/app#quick-start" 
                 target="_blank" 
                 rel="noopener noreferrer"
                 className="warning-button"

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -2850,7 +2850,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                 </div>
                 <p className="setting-help">{t('settings.reportBugHelp')}</p>
                 <a 
-                  href="https://github.com/mbianchidev/fire-tools/issues/new?template=bug_report.yml" 
+                  href="https://github.com/fire-tools-inc/app/issues/new?template=bug_report.yml" 
                   target="_blank" 
                   rel="noopener noreferrer"
                   className="secondary-btn external-link-btn"
@@ -2868,7 +2868,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                 </div>
                 <p className="setting-help">{t('settings.requestFeatureHelp')}</p>
                 <a 
-                  href="https://github.com/mbianchidev/fire-tools/issues/new?template=feature_request.yml" 
+                  href="https://github.com/fire-tools-inc/app/issues/new?template=feature_request.yml" 
                   target="_blank" 
                   rel="noopener noreferrer"
                   className="secondary-btn external-link-btn"
@@ -2886,7 +2886,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                 </div>
                 <p className="setting-help">{t('settings.uxUiSuggestionHelp')}</p>
                 <a 
-                  href="https://github.com/mbianchidev/fire-tools/issues/new?template=ux_ui_suggestion.yml" 
+                  href="https://github.com/fire-tools-inc/app/issues/new?template=ux_ui_suggestion.yml" 
                   target="_blank" 
                   rel="noopener noreferrer"
                   className="secondary-btn external-link-btn"
@@ -2904,7 +2904,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                 </div>
                 <p className="setting-help">{t('settings.reportSecurityIssueHelp')}</p>
                 <a 
-                  href="https://github.com/mbianchidev/fire-tools/security/advisories/new" 
+                  href="https://github.com/fire-tools-inc/app/security/advisories/new" 
                   target="_blank" 
                   rel="noopener noreferrer"
                   className="secondary-btn external-link-btn"
@@ -2923,7 +2923,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                 <p className="setting-help">{t('settings.documentationHelp')}</p>
                 <div className="export-buttons">
                   <a 
-                    href="https://github.com/mbianchidev/fire-tools/blob/main/README.md" 
+                    href="https://github.com/fire-tools-inc/app/blob/main/README.md" 
                     target="_blank" 
                     rel="noopener noreferrer"
                     className="secondary-btn external-link-btn"
@@ -2931,7 +2931,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                     <MaterialIcon name="open_in_new" /> README
                   </a>
                   <a 
-                    href="https://github.com/mbianchidev/fire-tools/blob/main/CONTRIBUTING.md" 
+                    href="https://github.com/fire-tools-inc/app/blob/main/CONTRIBUTING.md" 
                     target="_blank" 
                     rel="noopener noreferrer"
                     className="secondary-btn external-link-btn"
@@ -2939,7 +2939,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ onSettingsChange }) 
                     <MaterialIcon name="open_in_new" /> {t('settings.contributingGuide')}
                   </a>
                   <a 
-                    href="https://github.com/mbianchidev/fire-tools/blob/main/SUPPORT.md" 
+                    href="https://github.com/fire-tools-inc/app/blob/main/SUPPORT.md" 
                     target="_blank" 
                     rel="noopener noreferrer"
                     className="secondary-btn external-link-btn"

--- a/src/constants/navbarLabels.ts
+++ b/src/constants/navbarLabels.ts
@@ -1,7 +1,7 @@
 /**
  * Navbar labels — English ONLY. Do NOT localize.
  *
- * Per issue mbianchidev/fire-tools#233, the app navbar must always render in
+ * Per issue fire-tools-inc/app#233, the app navbar must always render in
  * English regardless of the user's selected UI language. These strings are the
  * single source of truth for the top-level navigation and any navbar-styled
  * links that appear elsewhere (e.g. on the 404 page).

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1963,7 +1963,7 @@
               "type": "ul",
               "items": [
                 "<strong>Anwendungsname:</strong> Fire Tools",
-                "<strong>Repository:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>Repository:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Kontakt:</strong> security@mb-consulting.dev"
               ]
             }
@@ -2232,7 +2232,7 @@
               "type": "ul",
               "items": [
                 "<strong>E-Mail:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>"
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>"
               ]
             }
           ]
@@ -2532,7 +2532,7 @@
               "type": "ul",
               "items": [
                 "<strong>E-Mail:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Issues:</strong> Melden Sie alle Probleme in unserem GitHub-Issue-Tracker"
               ]
             }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1963,7 +1963,7 @@
               "type": "ul",
               "items": [
                 "<strong>Application Name:</strong> Fire Tools",
-                "<strong>Repository:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>Repository:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Contact:</strong> security@mb-consulting.dev"
               ]
             }
@@ -2232,7 +2232,7 @@
               "type": "ul",
               "items": [
                 "<strong>Email:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>"
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>"
               ]
             }
           ]
@@ -2532,7 +2532,7 @@
               "type": "ul",
               "items": [
                 "<strong>Email:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Issues:</strong> Report any concerns on our GitHub issue tracker"
               ]
             }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1963,7 +1963,7 @@
               "type": "ul",
               "items": [
                 "<strong>Nombre de la aplicación:</strong> Fire Tools",
-                "<strong>Repositorio:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>Repositorio:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Contacto:</strong> security@mb-consulting.dev"
               ]
             }
@@ -2232,7 +2232,7 @@
               "type": "ul",
               "items": [
                 "<strong>Correo electrónico:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>"
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>"
               ]
             }
           ]
@@ -2532,7 +2532,7 @@
               "type": "ul",
               "items": [
                 "<strong>Correo electrónico:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Issues:</strong> Informa cualquier problema en nuestro rastreador de issues de GitHub"
               ]
             }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1963,7 +1963,7 @@
               "type": "ul",
               "items": [
                 "<strong>Nom de l'application :</strong> Fire Tools",
-                "<strong>Dépôt :</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>Dépôt :</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Contact :</strong> security@mb-consulting.dev"
               ]
             }
@@ -2232,7 +2232,7 @@
               "type": "ul",
               "items": [
                 "<strong>E-mail :</strong> security@mb-consulting.dev",
-                "<strong>GitHub :</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>"
+                "<strong>GitHub :</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>"
               ]
             }
           ]
@@ -2532,7 +2532,7 @@
               "type": "ul",
               "items": [
                 "<strong>E-mail :</strong> security@mb-consulting.dev",
-                "<strong>GitHub :</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>GitHub :</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Issues :</strong> Signalez tout problème dans notre tracker d'issues GitHub"
               ]
             }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1963,7 +1963,7 @@
               "type": "ul",
               "items": [
                 "<strong>Nome dell'applicazione:</strong> Fire Tools",
-                "<strong>Repository:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>Repository:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Contatti:</strong> security@mb-consulting.dev"
               ]
             }
@@ -2232,7 +2232,7 @@
               "type": "ul",
               "items": [
                 "<strong>Email:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>"
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>"
               ]
             }
           ]
@@ -2532,7 +2532,7 @@
               "type": "ul",
               "items": [
                 "<strong>Email:</strong> security@mb-consulting.dev",
-                "<strong>GitHub:</strong> <a href=\"https://github.com/mbianchidev/fire-tools\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/mbianchidev/fire-tools</a>",
+                "<strong>GitHub:</strong> <a href=\"https://github.com/fire-tools-inc/app\" target=\"_blank\" rel=\"noopener noreferrer\">github.com/fire-tools-inc/app</a>",
                 "<strong>Issue:</strong> Segnala qualsiasi problema nel nostro tracker delle issue su GitHub"
               ]
             }

--- a/src/types/investmentGrowth.ts
+++ b/src/types/investmentGrowth.ts
@@ -1,6 +1,6 @@
 /**
  * Investment Growth Calculator Types
- * See: https://github.com/mbianchidev/fire-tools/issues/96
+ * See: https://github.com/fire-tools-inc/app/issues/96
  */
 
 export type ContributionFrequency = 'monthly' | 'quarterly' | 'yearly';

--- a/tests/shared/navbarLabels.test.ts
+++ b/tests/shared/navbarLabels.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for issue mbianchidev/fire-tools#233.
+ * Regression tests for issue fire-tools-inc/app#233.
  *
  * The app navbar must always render in English, regardless of the user's
  * selected UI language. This is enforced by:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -216,7 +216,7 @@ export default defineConfig(({ mode, command }) => ({
         ? '/'
         : './'
       : mode === 'production'
-      ? '/fire-tools/demo/'
+      ? '/app/demo/'
       : '/demo/',
   build: {
     outDir: mode === 'electron' ? 'dist-electron' : 'dist/demo',

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 Static landing page for `fire-tools`. Hand-rolled HTML + CSS — no build
 step, no framework. Tracks issue
-[#138](https://github.com/mbianchidev/fire-tools/issues/138).
+[#138](https://github.com/fire-tools-inc/app/issues/138).
 
 ## Where it lives in production
 
@@ -10,8 +10,8 @@ step, no framework. Tracks issue
 (the site root) so it ships at the GitHub Pages root. The SPA lives
 under `dist/demo/`. The live URLs are:
 
-- `https://mbianchidev.github.io/fire-tools/` — this landing page
-- `https://mbianchidev.github.io/fire-tools/demo/` — the read-only demo app
+- `https://fire-tools-inc.github.io/app/` — this landing page
+- `https://fire-tools-inc.github.io/app/demo/` — the read-only demo app
 
 ## Local preview
 

--- a/website/index.html
+++ b/website/index.html
@@ -20,7 +20,7 @@
         <a href="./api/" rel="noopener">API</a>
         <a href="./docs/user/" rel="noopener">User docs</a>
         <a href="./docs/engineering/" rel="noopener">Engineering docs</a>
-        <a href="https://github.com/mbianchidev/fire-tools" rel="noopener">GitHub</a>
+        <a href="https://github.com/fire-tools-inc/app" rel="noopener">GitHub</a>
         <a class="cta" href="./demo/">Open the demo</a>
       </nav>
     </header>
@@ -37,7 +37,7 @@
         <div class="hero-cta">
           <a class="btn primary" href="./demo/">Open the demo</a>
           <a class="btn ghost" href="#download">Download desktop</a>
-          <a class="btn ghost" href="https://github.com/mbianchidev/fire-tools" rel="noopener">View on GitHub</a>
+          <a class="btn ghost" href="https://github.com/fire-tools-inc/app" rel="noopener">View on GitHub</a>
         </div>
       </section>
 
@@ -151,7 +151,7 @@
           <article>
             <h3>Desktop</h3>
             <p>macOS, Windows, Linux. Built with Electron — full read/write app, offline-first, your data stays local.</p>
-            <a class="btn primary" href="https://github.com/mbianchidev/fire-tools/releases">Releases</a>
+            <a class="btn primary" href="https://github.com/fire-tools-inc/app/releases">Releases</a>
           </article>
           <article>
             <h3>Self-host</h3>
@@ -160,7 +160,7 @@
           </article>
           <article>
             <h3>Mobile</h3>
-            <p>Flutter app, tracked in <a href="https://github.com/mbianchidev/fire-tools/issues/134">#134</a>. Coming as a separate repo.</p>
+            <p>Flutter app, tracked in <a href="https://github.com/fire-tools-inc/app/issues/134">#134</a>. Coming as a separate repo.</p>
             <button class="btn primary is-disabled" type="button" disabled aria-disabled="true" title="Coming soon">Planned · coming soon</button>
           </article>
         </div>


### PR DESCRIPTION
## Why
Repo moved from `mbianchidev/fire-tools` → `fire-tools-inc/app`. This updates everything that would break (or silently point at the old location) after the move.

## What broke and is now fixed
- **Auto-updater** — `electron-builder.yml` + `electron/dev-app-update.yml` `owner/repo` now `fire-tools-inc` / `app` (electron-updater resolves releases from these; previously it would 404).
- **GitHub Pages base path** — new site is `fire-tools-inc.github.io/app/`:
  - `vite.config.ts` production base `/fire-tools/demo/` → `/app/demo/`
  - `src/App.tsx` router basename `/fire-tools/demo` → `/app/demo`
- **All repo + Pages URLs** — `github.com/mbianchidev/fire-tools` → `github.com/fire-tools-inc/app` and `mbianchidev.github.io/fire-tools` → `fire-tools-inc.github.io/app` across docs, `website/`, i18n locales, source, scripts, issue templates, OpenAPI.
- **Clone instructions** — `cd fire-tools` → `cd app` (README, backend-deploy, CONTRIBUTING) + CONTRIBUTING fork URL.
- **package.json** — `repository` / `homepage` / `bugs` / `author.url`.
- **Stale link** — `mbianchidev/fire-calculator#getting-started` setup link repointed to the new repo.

## Intentionally kept (NOT tied to repo location — changing them would break things)
- Internal identifiers: cookie/storage keys (`fire-tools-*`), IPC channels (`fire-tools:*`), log prefixes (`[fire-tools]`), env vars (`FIRETOOLS_*`), `appId`, productName, Electron `userData` paths, and package `name: fire-tools` (drives the NSIS install dir + update continuity).
- Personal attribution/funding: footer `@mbianchidev`, `FUNDING.yml`, `CODEOWNERS`.

## Validation
- `npm run build` ✅ (built demo verified to emit `/app/demo/` asset paths; landing emits `github.com/fire-tools-inc/app` links)
- `npm test` ✅ 1235 passed / 0 failed
- Diff is 116 insertions / 116 deletions (pure string swaps, no structural changes)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>