### PR TITLE
fix(updater): stop release asset 404 from spaced artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,42 @@ jobs:
           echo "Staged release assets:"
           ls -la dist-assets
 
+      - name: Verify update manifests reference staged assets
+        run: |
+          set -euo pipefail
+          # Guard against the auto-updater 404 class of bug: every file the
+          # update manifests point at (latest*.yml `files[].url` and `path`)
+          # must actually be staged for upload under the exact same basename.
+          # If an artifact name ever reintroduces a space (or any character the
+          # manifest sanitizes but GitHub rewrites differently), this fails the
+          # release instead of shipping an updater that can't download itself.
+          python3 -c "import yaml" 2>/dev/null || pip install --quiet --break-system-packages pyyaml
+          python3 - <<'PY'
+          import glob, os, sys, yaml
+          missing = []
+          manifests = sorted(glob.glob('dist-assets/latest*.yml'))
+          if not manifests:
+              print('::error::No latest*.yml update manifests were staged.')
+              sys.exit(1)
+          for man in manifests:
+              with open(man) as fh:
+                  data = yaml.safe_load(fh) or {}
+              refs = {e.get('url') for e in data.get('files', []) if e.get('url')}
+              if data.get('path'):
+                  refs.add(data['path'])
+              for ref in sorted(refs):
+                  if not os.path.exists(os.path.join('dist-assets', ref)):
+                      missing.append((os.path.basename(man), ref))
+          if missing:
+              print('::error::Update manifest(s) reference assets that are not staged for upload:')
+              for man, ref in missing:
+                  print(f'  {man} -> {ref}')
+              print('This would make the auto-updater 404. Check electron-builder artifactName (no spaces).')
+              sys.exit(1)
+          for man in manifests:
+              print(f'OK: {os.path.basename(man)} references only staged assets')
+          PY
+
       - name: Build release notes (changelog + installation)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/engineering/auto-updater.md
+++ b/docs/engineering/auto-updater.md
@@ -186,6 +186,25 @@ publish:
 files alongside the installer so `electron-updater` can resolve the
 latest version.
 
+### Artifact naming (do not break the updater)
+
+Artifact file names **must not contain spaces**. `electron-builder.yml`
+pins a space-free `artifactName` (`Fire-Tools-...`) for exactly this
+reason. A space in `productName` ("Fire Tools") is otherwise mangled
+three different ways and the updater 404s:
+
+| Stage | Name |
+|-------|------|
+| on-disk artifact (default `${productName}` template) | `Fire Tools-...` (space) |
+| `latest*.yml` `url` (electron-builder sanitizes) | `Fire-Tools-...` (hyphen) |
+| uploaded GitHub release asset (Releases rewrites) | `Fire.Tools-...` (dot) |
+
+`electron-updater` fetches the manifest `url` (hyphen) which never
+matches the uploaded asset (dot) → `404`. The release workflow has a
+**Verify update manifests reference staged assets** step that fails the
+build if any `latest*.yml` entry has no matching staged file, so this
+can't silently ship again.
+
 ## Local testing
 
 The updater is disabled by default in `npm run electron:dev` because

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,17 @@
 appId: dev.mb-consulting.firetools
 productName: Fire Tools
 copyright: Copyright © 2026 Fire Tools Contributors
+
+# Artifact names MUST NOT contain spaces. `productName` ("Fire Tools") has one,
+# and the space is mangled inconsistently across the update pipeline:
+#   on-disk file -> "Fire Tools-..." (space)
+#   latest*.yml  -> "Fire-Tools-..." (electron-updater sanitizes space to hyphen)
+#   GitHub asset -> "Fire.Tools-..." (Releases rewrites space to a dot on upload)
+# The manifest url (hyphen) then never matches the uploaded asset (dot) and
+# electron-updater 404s. Pinning a space-free template keeps the on-disk file,
+# the manifest url, and the uploaded asset byte-for-byte identical.
+artifactName: "Fire-Tools-${version}-${arch}.${ext}"
+
 directories:
   output: release/${version}
   buildResources: electron/build
@@ -62,7 +73,8 @@ nsis:
   oneClick: false
   perMachine: false
   allowToChangeInstallationDirectory: true
-  artifactName: "${productName}-Setup-${version}-${arch}.${ext}"
+  # Space-free for the same reason as the top-level artifactName above.
+  artifactName: "Fire-Tools-Setup-${version}-${arch}.${ext}"
   shortcutName: Fire Tools
   uninstallDisplayName: Fire Tools ${version}
   createDesktopShortcut: true


### PR DESCRIPTION
## Problem

Auto-updater 404s on every download, e.g.:
```
https://github.com/fire-tools-inc/app/releases/download/v2.2.0/Fire-Tools-2.2.0-arm64-mac.zip → 404
```

## Root cause

`productName: Fire Tools` contains a **space**, which gets mangled three different ways across the release pipeline:

| Stage | Name |
|-------|------|
| on-disk artifact (default `${productName}` template) | `Fire Tools-...` (space) |
| `latest*.yml` `url` (electron-updater sanitizes) | `Fire-Tools-...` (hyphen) |
| uploaded GitHub release asset (Releases rewrites) | `Fire.Tools-...` (dot) |

electron-updater fetches the manifest `url` (**hyphen**) which never matches the uploaded asset (**dot**) → 404. Confirmed against the live `latest-mac.yml` (macOS dmg+zip) and `latest.yml` (Windows nsis) for both v2.2.0 and v2.2.1.

## Fix

- **`electron-builder.yml`** — pin a space-free `artifactName` (`Fire-Tools-...`) for all targets + the nsis override, so the on-disk file, manifest `url`, and uploaded asset are byte-for-byte identical.
- **`.github/workflows/release.yml`** — add a *Verify update manifests reference staged assets* step that fails the release if any `latest*.yml` entry has no matching staged file. Locally verified: it **fails** the old dot/hyphen layout and **passes** the fixed hyphen-only layout.
- **`docs/engineering/auto-updater.md`** — document the no-spaces naming requirement.

## Note on already-published releases

This fixes all **future** releases. Once a corrected build is published and becomes "latest", existing clients resolve updates again. The already-published v2.2.0 / v2.2.1 manifests stay broken unless their live assets are renamed (dot→hyphen) — can do that as a separate live-ops step if wanted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>