### PR TITLE
Restore GitHub Pages demo (continuous deploy on push to main)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,9 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -72,7 +73,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -103,7 +103,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v') # kinda useless since we only run on tags BUT still.
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,110 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Display coverage summary
+        if: always()
+        run: |
+          echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
+          if [ -f coverage/coverage-summary.json ]; then
+            node -e "
+              const fs = require('fs');
+              const coverage = JSON.parse(fs.readFileSync('./coverage/coverage-summary.json', 'utf8'));
+              const total = coverage.total;
+              console.log('| Category | Coverage |');
+              console.log('|----------|----------|');
+              console.log('| Lines | ' + total.lines.pct + '% |');
+              console.log('| Statements | ' + total.statements.pct + '% |');
+              console.log('| Functions | ' + total.functions.pct + '% |');
+              console.log('| Branches | ' + total.branches.pct + '% |');
+            " >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Coverage summary not available" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload test results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: test-results
+          path: test-results.json
+          retention-days: 30
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 30
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: './dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') # kinda useless since we only run on tags BUT still.
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -3,7 +3,7 @@ name: Auto bump patch version
 # Automatically bumps the PATCH version whenever a PR is merged to main
 # (e.g. 2.1.0 -> 2.1.1). It commits the bump back to main but NEVER creates a
 # git tag — release tags are minted by maintainers, which is what drives the
-# release.yml pipeline.
+# deploy.yml / release.yml pipelines.
 #
 # Recursion is prevented three ways:
 #   1. The job is skipped when the head commit is itself a version bump

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,7 +307,7 @@ Serves the production build locally for testing.
 
 ### Deployment
 - Automatic deployment to GitHub Pages via GitHub Actions
-- Triggered when a version tag matching `v*` (e.g. `v1.2.3`) is pushed
+- Triggered automatically on every push to `main` (continuous demo); also runnable manually via `workflow_dispatch`
 - Base path configured as `/app/` for GitHub Pages
 - Workflow file: `.github/workflows/deploy.yml`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,10 +306,10 @@ npm run preview
 Serves the production build locally for testing.
 
 ### Deployment
-- The app ships as a desktop build (Electron) and a self-hosted Docker stack;
-  there is no public web deployment.
-- Desktop releases are built by `.github/workflows/release.yml`, triggered when
-  a version tag matching `v*` (e.g. `v1.2.3`) is pushed.
+- Automatic deployment to GitHub Pages via GitHub Actions
+- Triggered when a version tag matching `v*` (e.g. `v1.2.3`) is pushed
+- Base path configured as `/app/` for GitHub Pages
+- Workflow file: `.github/workflows/deploy.yml`
 
 ## Common Tasks for AI Agents
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A privacy-first suite of **FIRE (Financial Independence Retire Early)** planning tools. Financial data is stored locally by default; optional integrations (Yahoo Finance prices, LLM categorization) contact external services only when explicitly enabled.
 
-**[Download the desktop app →](https://github.com/fire-tools-inc/app/releases)**
+**[Try the live demo →](https://fire-tools-inc.github.io/app/demo/)**
 
 ---
 
@@ -67,7 +67,7 @@ Use `npm run electron:dev` if you only want Vite + Electron without the backend.
 
 | Mode | Storage | How to run | Details |
 |------|---------|------------|---------|
-| **Browser** | AES-256-encrypted cookies + localStorage | `npm run dev` | Client-side only |
+| **Browser** | AES-256-encrypted cookies + localStorage | `npm run dev` or hosted demo | Client-side only |
 | **Docker** | SQLite (volume-backed) | `docker compose up -d` → `localhost:8080` | [docs/deployment/](docs/deployment/) |
 | **Electron** | SQLite at OS userData path | `npm run electron:dist` | [electron/README.md](electron/README.md) |
 | **Mobile** | Via backend API | Separate Flutter repo | [docs/mobile/](docs/mobile/) |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -101,6 +101,10 @@ Please be patient - this is an open source project maintained by volunteers.
 - **[AGENTS.md](AGENTS.md)** - Technical documentation for developers
 - **[SECURITY.md](SECURITY.md)** - Security policy and vulnerability reporting
 
+### Live Demo
+
+Try the live version: [https://fire-tools-inc.github.io/app/](https://fire-tools-inc.github.io/app/)
+
 ## What We Don't Support
 
 Fire Tools is a free, open source tool for educational purposes. Please note:

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -31,7 +31,8 @@ instead.
 - **Backend** — a small Node.js + Express service in `server/`. SQLite is the
   default storage; Postgres is supported via a Docker Compose profile.
 - **Contract** — [OpenAPI 3.0.3](https://github.com/fire-tools-inc/app/blob/main/docs/api/openapi.yaml).
-  Source of truth for both server routes and any generated client.
+  Source of truth for both server routes and any generated client. Also
+  published at [`/app/api/`](https://fire-tools-inc.github.io/app/api/).
 
 ## Why a local-first backend?
 
@@ -63,5 +64,5 @@ don't need to think about auth on day one.
 
 - [Project README](https://github.com/fire-tools-inc/app)
 - [Issue tracker](https://github.com/fire-tools-inc/app/issues)
-- [OpenAPI contract](https://github.com/fire-tools-inc/app/blob/main/docs/api/openapi.yaml)
+- [Live OpenAPI viewer](https://fire-tools-inc.github.io/app/api/)
 - [Mobile repo plan](https://github.com/fire-tools-inc/app/blob/main/docs/mobile/README.md)

--- a/docs/engineering/api-client.md
+++ b/docs/engineering/api-client.md
@@ -5,7 +5,8 @@ contract. The same contract drives the official client and any client you
 choose to build.
 
 - **Source**: [`docs/api/openapi.yaml`](https://github.com/fire-tools-inc/app/blob/main/docs/api/openapi.yaml)
-- **Raw spec**: <https://raw.githubusercontent.com/fire-tools-inc/app/main/docs/api/openapi.yaml>
+- **Live viewer**: <https://fire-tools-inc.github.io/app/api/>
+- **Raw spec**: <https://fire-tools-inc.github.io/app/api/openapi.yaml>
 
 ## Lint the spec
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -22,6 +22,7 @@ walkthrough and a screenshot so you can see exactly what to expect.
 
 ## How to install
 
+- **Web** — open <https://fire-tools-inc.github.io/app/demo/>. Nothing to install.
 - **Desktop** — grab the `.dmg` (macOS), `.exe` (Windows) or `.AppImage` (Linux)
   from the [releases page](https://github.com/fire-tools-inc/app/releases).
 - **Self-hosted** — see the
@@ -32,7 +33,7 @@ walkthrough and a screenshot so you can see exactly what to expect.
 - **Desktop app (Electron)** — your inputs are stored in a local SQLite database
   inside the OS-managed `userData` directory (e.g. `~/Library/Application
   Support/Fire Tools/firetools.db` on macOS). Nothing leaves the machine.
-- **Browser (running locally)** — your inputs are encrypted with AES-256 and stored
+- **Browser / hosted demo** — your inputs are encrypted with AES-256 and stored
   in cookies + localStorage on your device. Cookies are flagged `Secure` and
   `SameSite=Strict` and the encryption key never leaves the browser.
 

--- a/electron/menu.cjs
+++ b/electron/menu.cjs
@@ -6,7 +6,7 @@
 const { app, Menu, shell, BrowserWindow, dialog } = require('electron');
 
 const REPO_URL = 'https://github.com/fire-tools-inc/app';
-const DOCS_URL = `${REPO_URL}/tree/main/docs/user`;
+const DOCS_URL = 'https://fire-tools-inc.github.io/app/';
 const ISSUES_URL = `${REPO_URL}/issues/new/choose`;
 const RELEASES_URL = `${REPO_URL}/releases`;
 

--- a/website/README.md
+++ b/website/README.md
@@ -4,14 +4,14 @@ Static landing page for `fire-tools`. Hand-rolled HTML + CSS — no build
 step, no framework. Tracks issue
 [#138](https://github.com/fire-tools-inc/app/issues/138).
 
-## Status
+## Where it lives in production
 
-The hosted GitHub Pages deployment has been retired — the browser demo
-persisted nothing server-side and was never a usable product surface, so the
-app now ships only as the desktop build and the self-hosted Docker stack.
+`npm run build:landing` copies the contents of `website/` to `dist/`
+(the site root) so it ships at the GitHub Pages root. The SPA lives
+under `dist/demo/`. The live URLs are:
 
-`npm run build:landing` still copies `website/` into `dist/` if you want to
-host the landing page yourself.
+- `https://fire-tools-inc.github.io/app/` — this landing page
+- `https://fire-tools-inc.github.io/app/demo/` — the read-only demo app
 
 ## Local preview
 


### PR DESCRIPTION
## Why
Bring back the GitHub Pages demo. Frontend changes pushed to `main` should be reflected in the live demo automatically, and the OpenAPI viewer + docs should stay available on Pages.

## Changes
- Revert the Pages-deployment removal: restores `.github/workflows/deploy.yml` and the demo/docs/OpenAPI links across README, docs, SUPPORT.md, website/README, AGENTS.md, `electron/menu.cjs`.
- **Trigger changed** from `v*` tags → **push to `main`** (+ `workflow_dispatch`), so every merge to main redeploys the demo. Dropped the tag-only job gates.
- Build publishes `dist/api` (OpenAPI viewer + `openapi.yaml`) and `dist/docs` (user + engineering), so both ride the same deploy.
- Live URL: https://fire-tools-inc.github.io/app/ (demo at `/app/demo/`).

## Not included
- The `isGitHubPages` security banner stays **removed** (your earlier explicit call). Say the word if you want a 'demo only / data not saved' notice back.

## Verification
- `npm run build` ✅ — `dist/api/openapi.yaml` + viewer and `dist/docs` present
- `npm test` ✅ 1235/1235 pass