### PR TITLE
Fix GitHub Pages demo asset paths

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -13,6 +13,7 @@ instead.
 - [Migrations & rollbacks](./migrations.md)
 - [Audit log](./audit-log.md)
 - [Logging & PII handling](./logging.md)
+- [GitHub Pages deploy](./github-pages.md)
 - [Cutting a release](./releasing.md)
 
 ## Architecture at a glance

--- a/docs/engineering/github-pages.md
+++ b/docs/engineering/github-pages.md
@@ -1,0 +1,20 @@
+# GitHub Pages deploy
+
+The public site is deployed by [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml)
+from the generated `dist/` directory:
+
+- `dist/index.html` is the landing page.
+- `dist/demo/` is the Vite web demo.
+- `dist/docs/` is the rendered documentation.
+- `dist/api/` is the OpenAPI viewer.
+
+The demo uses stable entry and chunk filenames (`assets/index.js`,
+`assets/index.css`, and stable chunk names) instead of Vite's default hashed
+filenames. GitHub Pages caches HTML for a short time; during a deploy, a browser
+can briefly hold an older `demo/index.html`. Stable asset paths keep that stale
+HTML loading the app instead of requesting deleted `index-*.js` or
+`index-*.css` files and rendering a blank page.
+
+Run `npm run build` before opening a Pages deploy PR. The generated
+`dist/demo/index.html` should reference `/app/demo/assets/index.js` and
+`/app/demo/assets/index.css` for the production repository.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -111,6 +111,7 @@ const PAGES_BASE = GITHUB_SLUG ? `/${GITHUB_SLUG.repo}/demo/` : '/demo/'
 const APP_PAGES_URL = GITHUB_SLUG
   ? `https://${GITHUB_SLUG.owner}.github.io${PAGES_BASE}`
   : ''
+const isPagesBuild = (mode: string): boolean => mode === 'production'
 
 if (!GITHUB_SLUG) {
   console.warn(
@@ -250,7 +251,27 @@ export default defineConfig(({ mode, command }) => ({
       : '/demo/',
   build: {
     outDir: mode === 'electron' ? 'dist-electron' : 'dist/demo',
+    rollupOptions: isPagesBuild(mode)
+      ? {
+          output: {
+            entryFileNames: 'assets/[name].js',
+            chunkFileNames: 'assets/[name].js',
+            assetFileNames: 'assets/[name][extname]',
+          },
+        }
+      : undefined,
   },
+  worker: isPagesBuild(mode)
+    ? {
+        rollupOptions: {
+          output: {
+            entryFileNames: 'assets/worker-[name].js',
+            chunkFileNames: 'assets/worker-[name].js',
+            assetFileNames: 'assets/worker-[name][extname]',
+          },
+        },
+      }
+    : undefined,
   define: {
     __APP_VERSION__: JSON.stringify(APP_VERSION),
     __APP_COMMIT_HASH__: JSON.stringify(APP_COMMIT_HASH),


### PR DESCRIPTION
## Summary
- Use stable asset/chunk filenames for production Pages builds
- Use stable worker filenames so stale cached demo HTML does not request deleted hashed assets
- Document the GitHub Pages deploy layout and cache rationale

## Validation
- npm run build
- Local Pages preview at /app/demo/ rendered with no console errors
- npm test