### PR TITLE
Fix updater release asset naming

### DIFF
--- a/docs/engineering/auto-updater.md
+++ b/docs/engineering/auto-updater.md
@@ -189,7 +189,7 @@ latest version.
 ### Artifact naming (do not break the updater)
 
 Artifact file names **must not contain spaces**. `electron-builder.yml`
-pins a space-free `artifactName` (`Fire-Tools-...`) for exactly this
+pins a space-free `artifactName` (`Fire.Tools-...`) for exactly this
 reason. A space in `productName` ("Fire Tools") is otherwise mangled
 three different ways and the updater 404s:
 
@@ -200,10 +200,11 @@ three different ways and the updater 404s:
 | uploaded GitHub release asset (Releases rewrites) | `Fire.Tools-...` (dot) |
 
 `electron-updater` fetches the manifest `url` (hyphen) which never
-matches the uploaded asset (dot) → `404`. The release workflow has a
-**Verify update manifests reference staged assets** step that fails the
-build if any `latest*.yml` entry has no matching staged file, so this
-can't silently ship again.
+matches the uploaded asset (dot) -> `404`. Pinning dot-based artifact
+names makes the manifest URL and uploaded asset match. The release
+workflow's **Verify update manifests reference staged assets** step still
+fails the build if any `latest*.yml` entry has no matching staged file,
+so this can't silently ship again.
 
 ## Local testing
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -3,14 +3,13 @@ productName: Fire Tools
 copyright: Copyright © 2026 Fire Tools Contributors
 
 # Artifact names MUST NOT contain spaces. `productName` ("Fire Tools") has one,
-# and the space is mangled inconsistently across the update pipeline:
+# and default templates have historically been mangled inconsistently:
 #   on-disk file -> "Fire Tools-..." (space)
 #   latest*.yml  -> "Fire-Tools-..." (electron-updater sanitizes space to hyphen)
 #   GitHub asset -> "Fire.Tools-..." (Releases rewrites space to a dot on upload)
-# The manifest url (hyphen) then never matches the uploaded asset (dot) and
-# electron-updater 404s. Pinning a space-free template keeps the on-disk file,
-# the manifest url, and the uploaded asset byte-for-byte identical.
-artifactName: "Fire-Tools-${version}-${arch}.${ext}"
+# Use the GitHub-safe dot prefix explicitly so manifests and uploaded assets
+# resolve to the same URL.
+artifactName: "Fire.Tools-${version}-${arch}.${ext}"
 
 directories:
   output: release/${version}
@@ -42,6 +41,7 @@ asar: true
 afterSign: scripts/electron-after-sign.cjs
 
 mac:
+  artifactName: "Fire.Tools-${version}-${arch}-mac.${ext}"
   category: public.app-category.finance
   hardenedRuntime: true
   gatekeeperAssess: false
@@ -74,7 +74,7 @@ nsis:
   perMachine: false
   allowToChangeInstallationDirectory: true
   # Space-free for the same reason as the top-level artifactName above.
-  artifactName: "Fire-Tools-Setup-${version}-${arch}.${ext}"
+  artifactName: "Fire.Tools-Setup-${version}-${arch}.${ext}"
   shortcutName: Fire Tools
   uninstallDisplayName: Fire Tools ${version}
   createDesktopShortcut: true


### PR DESCRIPTION
## Summary
- use dot-based Electron release artifact names so updater manifests match GitHub release asset URLs
- add a macOS-specific artifact name template to avoid default `Fire Tools` names
- update auto-updater docs for the 404 failure mode

## Validation
- Parsed `electron-builder.yml` as YAML
- Simulated the reported `Fire-Tools` manifest vs `Fire.Tools` asset mismatch
- Ran `git diff --check` and `git diff --cached --check`