### PR TITLE
perf: make route navigation responsive

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -26,9 +26,11 @@ instead.
 +----------------+        +----------------+        +----------------+
 ```
 
-- **Client** — the React app under `src/`. Built with Vite. Identical bundle
-  ships to the web (`dist/`), the desktop apps (Electron loads `dist/`), and
-  any third-party client you build on top of the OpenAPI contract.
+- **Client** — the React app under `src/`. Built with Vite. Tool pages are
+  emitted as route-level chunks, preloaded when navigation intent is detected,
+  chart-heavy views render progressively after the page shell, and language
+  packs load on demand with English kept as the fallback. The same client ships
+  to the web (`dist/`) and Electron.
 - **Backend** — a small Node.js + Express service in `server/`. SQLite is the
   default storage; Postgres is supported via a Docker Compose profile.
 - **Contract** — [OpenAPI 3.0.3](https://github.com/fire-tools-inc/app/blob/main/docs/api/openapi.yaml).
@@ -52,6 +54,8 @@ don't need to think about auth on day one.
 | Path | Purpose |
 | ---- | ------- |
 | `src/` | React + TypeScript frontend (Vite) |
+| `src/i18n/` | On-demand translation resources and language setup |
+| `src/routes/` | Lazy route registry and navigation preloading |
 | `server/` | Node.js + Express + better-sqlite3 backend |
 | `electron/` | Electron main + preload (desktop wrapper) |
 | `website/` | Marketing landing page |

--- a/src/App.css
+++ b/src/App.css
@@ -132,6 +132,63 @@ body {
   flex-direction: column;
 }
 
+.route-loading,
+.route-load-error {
+  flex: 1;
+  min-height: 18rem;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.route-loading .material-symbols-outlined {
+  color: var(--accent-primary);
+  animation: route-loading-spin 900ms linear infinite;
+}
+
+.route-load-error {
+  max-width: 42rem;
+  margin: 0 auto;
+}
+
+.route-load-error > .material-symbols-outlined {
+  color: var(--error);
+}
+
+.route-load-error p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.chart-loading-placeholder,
+.chart-load-error {
+  grid-column: 1 / -1;
+  min-height: 22rem;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.chart-loading-placeholder .material-symbols-outlined {
+  color: var(--accent-primary);
+  animation: route-loading-spin 900ms linear infinite;
+}
+
+.chart-load-error {
+  color: var(--error);
+}
+
+@keyframes route-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .app-header {
   background: linear-gradient(135deg, var(--accent-primary), var(--accent-gold));
   backdrop-filter: blur(20px);
@@ -433,6 +490,116 @@ body {
   border-bottom: none;
 }
 
+.action-btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.add-btn {
+  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-gold) 100%);
+  color: white;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, var(--success) 0%, #16a34a 100%);
+  color: white;
+  font-weight: 700;
+  border: none;
+}
+
+.primary-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 150, 136, 0.4);
+}
+
+.reset-btn {
+  background: linear-gradient(135deg, #6b7280 0%, #4b5563 100%);
+  color: white;
+  border: 1px solid #9ca3af;
+}
+
+.reset-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.5);
+  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
+}
+
+.back-btn {
+  background: linear-gradient(135deg, var(--info) 0%, var(--info) 100%);
+  color: white;
+}
+
+.back-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(33, 150, 243, 0.4);
+}
+
+.start-over-btn {
+  background: linear-gradient(135deg, var(--warning) 0%, var(--warning) 100%);
+  color: white;
+}
+
+.start-over-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(255, 152, 0, 0.4);
+}
+
+.export-btn {
+  background: linear-gradient(135deg, var(--success) 0%, var(--success) 100%);
+  color: white;
+}
+
+.import-btn {
+  background: linear-gradient(135deg, var(--info) 0%, var(--info) 100%);
+  color: white;
+}
+
+.action-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.allocation-info {
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-top: 2rem;
+}
+
+.allocation-info h4 {
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+}
+
+.allocation-info ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.allocation-info li {
+  padding: 0.5rem 0;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.collapsible-section {
+  background: var(--bg-elevated);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
 .collapsible-header {
   width: 100%;
   background: none;
@@ -441,13 +608,18 @@ body {
   text-align: left;
   cursor: pointer;
   transition: opacity var(--transition-fast);
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .collapsible-header h4 {
   color: var(--text-primary);
   font-family: var(--font-heading);
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .collapsible-header:hover {
@@ -457,6 +629,44 @@ body {
 .collapsible-header:focus {
   outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
+}
+
+.collapse-icon-small {
+  font-size: 0.8rem;
+  margin-left: 0.5rem;
+}
+
+.how-to-use-content {
+  margin-top: 1rem;
+  padding-left: 1.5rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 767px) {
+  .collapsible-section {
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .how-to-use-content {
+    font-size: 0.9rem;
+    padding-left: 1rem;
+  }
+
+  .how-to-use-content li {
+    margin-bottom: 0.5rem;
+  }
 }
 
 .form-section h3 {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,56 +1,67 @@
-import { BrowserRouter, HashRouter, Routes, Route, Link, useLocation, useSearchParams, useNavigate } from 'react-router-dom';
+import { BrowserRouter, HashRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 // Use HashRouter under file:// (Electron) so deep links work without a server.
 const Router = typeof window !== 'undefined' && window.location.protocol === 'file:' ? HashRouter : BrowserRouter;
-import { useState, useEffect, useMemo, useRef, createContext, useContext } from 'react';
+import { createContext, lazy, startTransition, Suspense, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CalculatorInputs, CalculationResult } from './types/calculator';
-import { DEFAULT_INPUTS } from './utils/defaults';
-import { calculateFIRE } from './utils/fireCalculator';
-import { calculateFIREPortfolioData } from './utils/allocationCalculator';
-import { CalculatorInputsForm } from './components/CalculatorInputsForm';
-import { IncomeExpensesChart } from './components/IncomeExpensesChart';
-import { NetWorthChart } from './components/NetWorthChart';
-import { FIREMetrics } from './components/FIREMetrics';
-import { MonteCarloPage } from './components/MonteCarloPage';
-import { ReverseFIRECalculatorPage } from './components/ReverseFIRECalculatorPage';
-import { InvestmentGrowthPage } from './components/InvestmentGrowthPage';
-import { WithdrawalRatePage } from './components/WithdrawalRatePage';
-import { AssetAllocationPage } from './components/AssetAllocationPage';
-import { PortfolioBacktestPage } from './components/PortfolioBacktestPage';
-import { PortfolioBreakdownPage } from './components/PortfolioBreakdownPage';
-import { ExpenseTrackerPage } from './components/ExpenseTrackerPage';
-import { NetWorthTrackerPage } from './components/NetWorthTrackerPage';
-import { DebtPayoffPage } from './components/DebtPayoffPage';
 import { HomePage } from './components/HomePage';
-import { DataManagement } from './components/DataManagement';
 import { ProfileMenu } from './components/ProfileMenu';
 import { ToolsMenu } from './components/ToolsMenu';
 import { NotificationBell } from './components/NotificationBell';
-import { SettingsPage } from './components/SettingsPage';
 import { CookieConsent } from './components/CookieConsent';
 import { DemoBanner } from './components/DemoBanner';
-import UpdateNotification from './components/UpdateNotification';
-import { GuidedTour } from './components/GuidedTour';
 import { NotFoundPage } from './components/NotFoundPage';
-import { QuestionnairePage } from './components/QuestionnairePage';
 import { QuestionnairePrompt } from './components/QuestionnairePrompt';
-import { PolicyModal, PolicyType } from './components/PolicyModal';
+import { PolicyModal } from './components/PolicyModal';
+import type { PolicyType } from './components/PolicyModal';
+import { PreloadLink } from './components/PreloadLink';
 import { AuditLogProvider } from './contexts/AuditLogContext';
-import { useAuditLog } from './contexts/AuditLogContext';
-import { serializeInputsToURL, deserializeInputsFromURL, hasURLParams } from './utils/urlParams';
-import { saveFireCalculatorInputs, loadFireCalculatorInputs, clearAllData, loadAssetAllocation } from './utils/cookieStorage';
-import { exportFireCalculatorToCSV, importFireCalculatorFromCSV } from './utils/csvExport';
-import { loadSettings, saveSettings, type UserSettings } from './utils/cookieSettings';
+import { loadSettings, type UserSettings } from './utils/cookieSettings';
+import { loadTourCompleted } from './utils/tourPreferences';
 import { syncPreferencesFromBackend } from './utils/uiPreferencesSync';
+import { logger } from './utils/logger';
+import {
+  LazyAssetAllocationPage,
+  LazyDebtPayoffPage,
+  LazyExpenseTrackerPage,
+  LazyFIRECalculatorPage,
+  LazyInvestmentGrowthPage,
+  LazyMonteCarloPage,
+  LazyNetWorthTrackerPage,
+  LazyPortfolioBacktestPage,
+  LazyPortfolioBreakdownPage,
+  LazyQuestionnairePage,
+  LazyReverseFIRECalculatorPage,
+  LazySettingsPage,
+  LazyWithdrawalRatePage,
+  preloadRoute,
+} from './routes/lazyPages';
 import './App.css';
-import './components/AssetAllocationManager.css';
-import './components/ExpenseTrackerPage.css';
-import './components/NetWorthTrackerPage.css';
-import './components/GuidedTour.css';
-import './components/NotificationBell.css';
 import { MaterialIcon } from './components/MaterialIcon';
 import { FireIcon } from './components/FireIcon';
 import { NAVBAR_LABELS } from './constants/navbarLabels';
+
+const GuidedTour = lazy(async () => {
+  try {
+    const module = await import('./components/GuidedTour');
+    return { default: module.GuidedTour };
+  } catch (error) {
+    logger.error('guided-tour', 'chunk-load-failed', 'failed to load guided tour', {
+      pii: { error: error instanceof Error ? error.message : String(error) },
+    });
+    return { default: () => null };
+  }
+});
+
+const UpdateNotification = lazy(async () => {
+  try {
+    return await import('./components/UpdateNotification');
+  } catch (error) {
+    logger.error('updater', 'chunk-load-failed', 'failed to load update notification', {
+      pii: { error: error instanceof Error ? error.message : String(error) },
+    });
+    return { default: () => null };
+  }
+});
 
 // Context for policy modal
 interface PolicyModalContextType {
@@ -85,46 +96,46 @@ function Navigation({ accountName, showPortfolioBreakdown }: { accountName: stri
         {isOpen ? <MaterialIcon name="close" /> : <MaterialIcon name="menu" />}
       </button>
       <div className={`nav-links ${isOpen ? 'open' : ''}`}>
-        <Link
+        <PreloadLink
           to="/"
           className={`nav-link ${location.pathname === '/' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/' ? 'page' : undefined}
         >
           <MaterialIcon name="home" className="nav-icon" /> {NAVBAR_LABELS.home}
-        </Link>
-        <Link
+        </PreloadLink>
+        <PreloadLink
           to="/asset-allocation"
           className={`nav-link ${location.pathname === '/asset-allocation' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/asset-allocation' ? 'page' : undefined}
         >
           <MaterialIcon name="pie_chart" className="nav-icon" /> {NAVBAR_LABELS.assetAllocation}
-        </Link>
-        <Link
+        </PreloadLink>
+        <PreloadLink
           to="/expense-tracker"
           className={`nav-link ${location.pathname === '/expense-tracker' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/expense-tracker' ? 'page' : undefined}
         >
           <MaterialIcon name="account_balance_wallet" className="nav-icon" /> {NAVBAR_LABELS.cashflow}
-        </Link>
-        <Link
+        </PreloadLink>
+        <PreloadLink
           to="/net-worth-tracker"
           className={`nav-link ${location.pathname === '/net-worth-tracker' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/net-worth-tracker' ? 'page' : undefined}
         >
           <MaterialIcon name="paid" className="nav-icon" /> {NAVBAR_LABELS.netWorth}
-        </Link>
-        <Link
+        </PreloadLink>
+        <PreloadLink
           to="/fire-calculator"
           className={`nav-link ${location.pathname === '/fire-calculator' ? 'active' : ''}`}
           onClick={closeMenu}
           aria-current={location.pathname === '/fire-calculator' ? 'page' : undefined}
         >
           <MaterialIcon name="local_fire_department" className="nav-icon" /> {NAVBAR_LABELS.fireCalculator}
-        </Link>
+        </PreloadLink>
         <ToolsMenu onNavigate={closeMenu} showPortfolioBreakdown={showPortfolioBreakdown} />
       </div>
       <div className="nav-actions">
@@ -150,319 +161,6 @@ function PolicyRouteRedirect({ policyType }: { policyType: PolicyType }) {
   return null;
 }
 
-function FIRECalculatorPage() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const { logAuditEvent } = useAuditLog();
-  
-  // Initialize state from URL if parameters exist, otherwise from localStorage, then defaults
-  const [inputs, setInputs] = useState<CalculatorInputs>(() => {
-    // Priority 1: URL parameters (for sharing)
-    if (hasURLParams(searchParams)) {
-      return deserializeInputsFromURL(searchParams);
-    }
-    // Priority 2: localStorage (for persistence)
-    const saved = loadFireCalculatorInputs();
-    if (saved) {
-      return saved;
-    }
-    // Priority 3: defaults
-    return DEFAULT_INPUTS;
-  });
-  
-  const [result, setResult] = useState<CalculationResult | null>(null);
-  
-  // Shared zoom state for both charts (default to 30 years)
-  const [zoomYears, setZoomYears] = useState<number | 'all'>(30);
-  const [customZoomInput, setCustomZoomInput] = useState<string>('');
-  
-  // Privacy mode state (loaded from settings, toggleable on page)
-  const [isPrivacyMode, setIsPrivacyMode] = useState<boolean>(() => {
-    const settings = loadSettings();
-    return settings.privacyMode;
-  });
-  
-  // Toggle privacy mode and save to settings
-  const togglePrivacyMode = () => {
-    const newMode = !isPrivacyMode;
-    setIsPrivacyMode(newMode);
-    const settings = loadSettings();
-    saveSettings({ ...settings, privacyMode: newMode });
-  };
-
-  // Load asset allocation data for use in calculator (filtered by FIRE settings)
-  const assetAllocationData = useMemo(() => {
-    const saved = loadAssetAllocation();
-    if (!saved.assets || saved.assets.length === 0) {
-      return undefined;
-    }
-    return calculateFIREPortfolioData(saved.assets);
-  }, []);
-
-  // Update URL when inputs change
-  useEffect(() => {
-    const params = serializeInputsToURL(inputs);
-    setSearchParams(params, { replace: true });
-  }, [inputs, setSearchParams]);
-
-  // Auto-save to localStorage when inputs change
-  useEffect(() => {
-    saveFireCalculatorInputs(inputs);
-  }, [inputs]);
-
-  // Calculate FIRE results, using asset allocation data if enabled
-  useEffect(() => {
-    // If using asset allocation value, override the inputs with asset allocation data
-    let effectiveInputs = inputs;
-    if (inputs.useAssetAllocationValue && assetAllocationData) {
-      effectiveInputs = {
-        ...inputs,
-        initialSavings: assetAllocationData.totalValue,
-        stocksPercent: assetAllocationData.stocksPercent,
-        bondsPercent: assetAllocationData.bondsPercent,
-        cashPercent: assetAllocationData.cashPercent,
-      };
-    }
-    const calculationResult = calculateFIRE(effectiveInputs);
-    setResult(calculationResult);
-  }, [inputs, assetAllocationData]);
-
-  // Audit the FIRE calculation. The calc runs automatically on every input
-  // change, so we debounce and skip the initial (page-load) computation to
-  // avoid logging restores/keystrokes as discrete user actions.
-  const calcAuditInitialised = useRef(false);
-  useEffect(() => {
-    if (!result) return;
-    if (!calcAuditInitialised.current) {
-      calcAuditInitialised.current = true;
-      return;
-    }
-    const handle = setTimeout(() => {
-      logAuditEvent('RUN_CALCULATION', {
-        yearsToFIRE: result.yearsToFIRE,
-        fireTarget: result.fireTarget,
-        fireType: result.fireType,
-      });
-    }, 1500);
-    return () => clearTimeout(handle);
-  }, [result, logAuditEvent]);
-
-  const currentYear = new Date().getFullYear();
-  const currentAge = currentYear - inputs.yearOfBirth;
-  
-  const hasValidationErrors = result?.validationErrors && result.validationErrors.length > 0;
-
-  const handleExportCSV = () => {
-    const csv = exportFireCalculatorToCSV(inputs);
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `fire-calculator-data-${new Date().toISOString().split('T')[0]}.csv`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-    logAuditEvent('EXPORT_DATA', { dataset: 'fire-calculator', format: 'csv' });
-  };
-
-  const handleImportCSV = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      try {
-        const csv = e.target?.result as string;
-        const importedInputs = importFireCalculatorFromCSV(csv);
-        setInputs(importedInputs);
-        logAuditEvent('IMPORT_DATA', { dataset: 'fire-calculator', format: 'csv' });
-      } catch (error) {
-        alert(`Error importing CSV: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      }
-    };
-    reader.readAsText(file);
-    // Reset the input value so the same file can be selected again
-    event.target.value = '';
-  };
-
-  const handleResetData = () => {
-    if (confirm('Are you sure you want to reset all data? This will clear all saved data from cookies and reset to defaults.')) {
-      clearAllData();
-      setInputs(DEFAULT_INPUTS);
-    }
-  };
-
-  // Expand sidebar and scroll to a specific section
-  const expandAndScrollTo = (sectionId: string) => {
-    setSidebarCollapsed(false);
-    // Wait for the sidebar to expand and content to render
-    setTimeout(() => {
-      const element = document.getElementById(sectionId);
-      if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
-    }, 100);
-  };
-
-  return (
-    <div className="app-container">
-      <aside className={`sidebar ${sidebarCollapsed ? 'collapsed' : ''}`} aria-label="Calculator inputs">
-        <button 
-          className="sidebar-toggle-btn" 
-          onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-          title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          aria-expanded={!sidebarCollapsed}
-        >
-          <MaterialIcon name={sidebarCollapsed ? 'chevron_right' : 'chevron_left'} />
-        </button>
-        
-        {/* Collapsed state icons */}
-        <div className="sidebar-collapsed-icons">
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-data-management')}
-            title="Data Management"
-            aria-label="Expand to manage data"
-          >
-            <MaterialIcon name="save" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-initial-values')}
-            title="Initial Values"
-            aria-label="Expand to edit Initial Values"
-          >
-            <MaterialIcon name="savings" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-asset-allocation')}
-            title="Asset Allocation"
-            aria-label="Expand to edit Asset Allocation"
-          >
-            <MaterialIcon name="pie_chart" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-income')}
-            title="Income"
-            aria-label="Expand to edit Income"
-          >
-            <MaterialIcon name="payments" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-pension')}
-            title="Pension"
-            aria-label="Expand to edit Pension"
-          >
-            <MaterialIcon name="account_balance" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-expenses')}
-            title="Expenses & Savings"
-            aria-label="Expand to edit Expenses & Savings"
-          >
-            <MaterialIcon name="shopping_cart" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-fire-params')}
-            title="FIRE Parameters"
-            aria-label="Expand to edit FIRE Parameters"
-          >
-            <MaterialIcon name="gps_fixed" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-expected-returns')}
-            title="Expected Returns"
-            aria-label="Expand to edit Expected Returns"
-          >
-            <MaterialIcon name="trending_up" />
-          </button>
-          <button 
-            className="sidebar-icon-btn" 
-            onClick={() => expandAndScrollTo('section-options')}
-            title="Options"
-            aria-label="Expand to edit Options"
-          >
-            <MaterialIcon name="settings" />
-          </button>
-        </div>
-        
-        {!sidebarCollapsed && (
-          <>
-            <DataManagement
-              onExport={handleExportCSV}
-              onImport={handleImportCSV}
-              onReset={handleResetData}
-              defaultOpen={false}
-            />
-            
-            <CalculatorInputsForm 
-              inputs={inputs} 
-              onChange={setInputs} 
-              assetAllocationData={assetAllocationData}
-              isPrivacyMode={isPrivacyMode}
-            />
-          </>
-        )}
-      </aside>
-
-      <main className="main-content">
-        {hasValidationErrors && (
-          <div className="validation-error-banner" role="alert" aria-live="polite">
-            <strong><MaterialIcon name="warning" /> Validation Error</strong>
-            {result.validationErrors?.map((error, index) => (
-              <div key={index} className="validation-error-message">{error}</div>
-            ))}
-          </div>
-        )}
-        
-        {result && !hasValidationErrors && (
-          <>
-            <FIREMetrics 
-              result={result} 
-              currentAge={currentAge} 
-              zoomYears={zoomYears} 
-              inputs={inputs}
-              onLoadScenario={setInputs}
-              isPrivacyMode={isPrivacyMode}
-              onTogglePrivacyMode={togglePrivacyMode}
-            />
-            
-            <div className="charts-section" data-tour="charts-section">
-              <NetWorthChart 
-                projections={result.projections} 
-                fireTarget={result.fireTarget} 
-                currentAge={currentAge}
-                zoomYears={zoomYears}
-                onZoomChange={setZoomYears}
-                customZoomInput={customZoomInput}
-                onCustomZoomInputChange={setCustomZoomInput}
-                isPrivacyMode={isPrivacyMode}
-              />
-              <IncomeExpensesChart 
-                projections={result.projections} 
-                currentAge={currentAge}
-                zoomYears={zoomYears}
-                onZoomChange={setZoomYears}
-                customZoomInput={customZoomInput}
-                onCustomZoomInputChange={setCustomZoomInput}
-                isPrivacyMode={isPrivacyMode}
-              />
-            </div>
-          </>
-        )}
-      </main>
-    </div>
-  );
-}
-
 // Bridges Electron menu IPC events into React Router navigation.
 // Lives inside <Router> so it can use useNavigate().
 function NavigateBridge() {
@@ -472,7 +170,10 @@ function NavigateBridge() {
     if (!bridge?.onNavigate) return;
     const unsubscribe = bridge.onNavigate((path: string) => {
       if (typeof path === 'string' && path.startsWith('/')) {
-        navigate(path);
+        void preloadRoute(path);
+        startTransition(async () => {
+          await navigate(path);
+        });
       }
     });
     return () => {
@@ -498,6 +199,7 @@ function App() {
   
   // Load settings from localStorage
   const [settings, setSettings] = useState<UserSettings>(() => loadSettings());
+  const [shouldLoadTour] = useState(() => !loadTourCompleted());
   
   // Policy modal state
   const [policyModalType, setPolicyModalType] = useState<PolicyType | null>(null);
@@ -547,7 +249,11 @@ function App() {
         <div className={isElectron ? 'app app--electron' : 'app'}>
           <NavigateBridge />
           <DemoBanner />
-          {isElectron && <UpdateNotification />}
+          {isElectron && (
+            <Suspense fallback={null}>
+              <UpdateNotification />
+            </Suspense>
+          )}
           <a href="#main-content" className="skip-link">{t('app.skipToContent')}</a>
           
           <header className="app-header">
@@ -558,25 +264,34 @@ function App() {
 
           <Navigation accountName={settings.accountName} showPortfolioBreakdown={settings.experimentalFeatures?.portfolioBreakdown ?? false} />
 
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/fire-calculator" element={<FIRECalculatorPage />} />
-            <Route path="/reverse-fire-calculator" element={<ReverseFIRECalculatorPage />} />
-            <Route path="/monte-carlo" element={<MonteCarloPage />} />
-            <Route path="/investment-growth" element={<InvestmentGrowthPage />} />
-            <Route path="/withdrawal-rate" element={<WithdrawalRatePage />} />
-            <Route path="/asset-allocation" element={<AssetAllocationPage />} />
-            <Route path="/portfolio-backtest" element={<PortfolioBacktestPage />} />
-            <Route path="/portfolio-breakdown" element={settings.experimentalFeatures?.portfolioBreakdown ? <PortfolioBreakdownPage /> : <NotFoundPage />} />
-            <Route path="/expense-tracker" element={<ExpenseTrackerPage />} />
-            <Route path="/net-worth-tracker" element={<NetWorthTrackerPage />} />
-            <Route path="/debt-payoff" element={<DebtPayoffPage />} />
-            <Route path="/questionnaire" element={<QuestionnairePage />} />
-            <Route path="/settings" element={<SettingsPage onSettingsChange={handleSettingsChange} />} />
-            <Route path="/privacy-policy" element={<PolicyRouteRedirect policyType="privacy" />} />
-            <Route path="/cookie-policy" element={<PolicyRouteRedirect policyType="cookie" />} />
-            <Route path="*" element={<NotFoundPage />} />
-          </Routes>
+          <Suspense
+            fallback={(
+              <main className="route-loading" id="main-content" role="status" aria-live="polite">
+                <MaterialIcon name="progress_activity" size="large" />
+                <span>{t('common.loading')}</span>
+              </main>
+            )}
+          >
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/fire-calculator" element={<LazyFIRECalculatorPage />} />
+              <Route path="/reverse-fire-calculator" element={<LazyReverseFIRECalculatorPage />} />
+              <Route path="/monte-carlo" element={<LazyMonteCarloPage />} />
+              <Route path="/investment-growth" element={<LazyInvestmentGrowthPage />} />
+              <Route path="/withdrawal-rate" element={<LazyWithdrawalRatePage />} />
+              <Route path="/asset-allocation" element={<LazyAssetAllocationPage />} />
+              <Route path="/portfolio-backtest" element={<LazyPortfolioBacktestPage />} />
+              <Route path="/portfolio-breakdown" element={settings.experimentalFeatures?.portfolioBreakdown ? <LazyPortfolioBreakdownPage /> : <NotFoundPage />} />
+              <Route path="/expense-tracker" element={<LazyExpenseTrackerPage />} />
+              <Route path="/net-worth-tracker" element={<LazyNetWorthTrackerPage />} />
+              <Route path="/debt-payoff" element={<LazyDebtPayoffPage />} />
+              <Route path="/questionnaire" element={<LazyQuestionnairePage />} />
+              <Route path="/settings" element={<LazySettingsPage onSettingsChange={handleSettingsChange} />} />
+              <Route path="/privacy-policy" element={<PolicyRouteRedirect policyType="privacy" />} />
+              <Route path="/cookie-policy" element={<PolicyRouteRedirect policyType="cookie" />} />
+              <Route path="*" element={<NotFoundPage />} />
+            </Routes>
+          </Suspense>
 
           {!isElectron && (
             <footer className="app-footer">
@@ -612,7 +327,11 @@ function App() {
             onSwitchPolicy={openPolicy}
           />
           {!isElectron && <CookieConsent />}
-          <GuidedTour />
+          {shouldLoadTour && (
+            <Suspense fallback={null}>
+              <GuidedTour />
+            </Suspense>
+          )}
           <QuestionnairePrompt />
         </div>
       </PolicyModalContext.Provider>

--- a/src/components/AssetAllocationManager.css
+++ b/src/components/AssetAllocationManager.css
@@ -24,87 +24,6 @@
   flex-wrap: wrap;
 }
 
-.action-btn {
-  padding: 0.75rem 1.5rem;
-  border: none;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.add-btn {
-  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-gold) 100%);
-  color: white;
-}
-
-/* Primary action button (Add Asset) - more prominent with teal color */
-.primary-btn {
-  background: linear-gradient(135deg, var(--success) 0%, #16a34a 100%);
-  color: white;
-  font-weight: 700;
-  border: none;
-}
-
-.primary-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 150, 136, 0.4);
-}
-
-/* Reset button styling - lighter grey for visibility */
-.reset-btn {
-  background: linear-gradient(135deg, #6B7280 0%, #4B5563 100%);
-  color: white;
-  border: 1px solid #9CA3AF;
-}
-
-.reset-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.5);
-  background: linear-gradient(135deg, #9CA3AF 0%, #6B7280 100%);
-}
-
-/* Back button styling - blue */
-.back-btn {
-  background: linear-gradient(135deg, var(--info) 0%, var(--info) 100%);
-  color: white;
-}
-
-.back-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(33, 150, 243, 0.4);
-}
-
-/* Start Over button styling - orange-ish */
-.start-over-btn {
-  background: linear-gradient(135deg, var(--warning) 0%, var(--warning) 100%);
-  color: white;
-}
-
-.start-over-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(255, 152, 0, 0.4);
-}
-
-.export-btn {
-  background: linear-gradient(135deg, var(--success) 0%, var(--success) 100%);
-  color: white;
-}
-
-.import-btn {
-  background: linear-gradient(135deg, var(--info) 0%, var(--info) 100%);
-  color: white;
-}
-
-.action-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-
 .validation-errors {
   background: rgba(239, 68, 68, 0.2);
   border: 2px solid var(--error);
@@ -374,32 +293,6 @@
 .class-select:focus {
   outline: none;
   border-color: var(--accent-primary);
-}
-
-/* Info Section */
-.allocation-info {
-  background: var(--bg-tertiary);
-  border-radius: 8px;
-  padding: 1.5rem;
-  margin-top: 2rem;
-}
-
-.allocation-info h4 {
-  color: var(--text-primary);
-  margin-bottom: 1rem;
-  font-size: 1.2rem;
-}
-
-.allocation-info ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.allocation-info li {
-  padding: 0.5rem 0;
-  line-height: 1.6;
-  color: var(--text-secondary);
 }
 
 .info-badge {
@@ -1080,40 +973,6 @@
   padding: 1.5rem;
   border-radius: 8px;
   box-shadow: var(--shadow-sm);
-}
-
-/* Collapsible How to Use section */
-.collapsible-section {
-  background: var(--bg-elevated);
-  border-radius: 8px;
-  padding: 1rem;
-  margin-bottom: 2rem;
-  box-shadow: var(--shadow-sm);
-}
-
-.collapsible-header {
-  cursor: pointer;
-  user-select: none;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.collapsible-header h4 {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.collapse-icon-small {
-  font-size: 0.8rem;
-  margin-left: 0.5rem;
-}
-
-.how-to-use-content {
-  margin-top: 1rem;
-  padding-left: 1.5rem;
 }
 
 /* Section header with actions */
@@ -2330,21 +2189,6 @@ select:disabled {
   .asset-class-table th:first-child {
     background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-gold) 100%);
     z-index: 3;
-  }
-
-  /* Collapsible sections */
-  .collapsible-section {
-    padding: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .how-to-use-content {
-    font-size: 0.9rem;
-    padding-left: 1rem;
-  }
-
-  .how-to-use-content li {
-    margin-bottom: 0.5rem;
   }
 
   /* Class selector */

--- a/src/components/AssetAllocationPage.tsx
+++ b/src/components/AssetAllocationPage.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Suspense, useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Asset, PortfolioAllocation, AssetClass, AllocationMode } from '../types/assetAllocation';
 import { calculatePortfolioAllocation, prepareAssetClassChartData, prepareAssetChartData, formatAssetName, formatCurrency } from '../utils/allocationCalculator';
@@ -15,12 +14,13 @@ import { exportAssetAllocationToCSV, importAssetAllocationFromCSV } from '../uti
 import { loadSettings, saveSettings } from '../utils/cookieSettings';
 import { getDemoAssetAllocationData } from '../utils/defaults';
 import { syncAssetAllocationToNetWorth } from '../utils/dataSync';
+import { createLazyComponent } from '../utils/lazyComponent';
 import { useAssetPrices } from '../hooks/useAssetPrices';
+import { useDeferredRender } from '../hooks/useDeferredRender';
 import { useExchangeRates } from '../hooks/useExchangeRates';
 import { useAuditLog } from '../contexts/AuditLogContext';
 import { MaterialIcon } from './MaterialIcon';
 import { EditableAssetClassTable } from './EditableAssetClassTable';
-import { AllocationChart } from './AllocationChart';
 import { SharedAssetDialog } from './SharedAssetDialog';
 import { CollapsibleAllocationTable } from './CollapsibleAllocationTable';
 import { MassEditDialog } from './MassEditDialog';
@@ -28,6 +28,15 @@ import { DCAHelperDialog } from './DCAHelperDialog';
 import { DataManagement } from './DataManagement';
 import { ScrollToTopButton } from './ScrollToTopButton';
 import { PrivacyBlur } from './PrivacyBlur';
+import { ChartLoadingFallback, ChartLoadFailure } from './ChartLoadingState';
+import { PreloadLink } from './PreloadLink';
+import './AssetAllocationManager.css';
+
+const AllocationChart = createLazyComponent(
+  'allocation-chart',
+  () => import('./AllocationChart').then((module) => module.AllocationChart),
+  () => <ChartLoadFailure />,
+);
 
 /**
  * Calculate cash delta from assets and targets.
@@ -113,6 +122,7 @@ export const AssetAllocationPage: React.FC = () => {
   const [isDCADialogOpen, setIsDCADialogOpen] = useState(false);
   // Charts collapse state
   const [isChartsCollapsed, setIsChartsCollapsed] = useState(false);
+  const renderCharts = useDeferredRender(!isChartsCollapsed);
   // Privacy mode state (loaded from settings, toggleable on page)
   const [isPrivacyMode, setIsPrivacyMode] = useState<boolean>(() => {
     const settings = loadSettings();
@@ -809,32 +819,38 @@ export const AssetAllocationPage: React.FC = () => {
           </button>
           {!isChartsCollapsed && (
             <div id="charts-content" className="charts-row">
-              <AllocationChart
-                data={assetClassChartData}
-                title={t('assetAllocation.charts.byAssetClassLower')}
-                currency={currency}
-              />
+              {renderCharts ? (
+                <Suspense fallback={<ChartLoadingFallback />}>
+                  <AllocationChart
+                    data={assetClassChartData}
+                    title={t('assetAllocation.charts.byAssetClassLower')}
+                    currency={currency}
+                  />
 
-              {selectedAssetClass && (
-                <AllocationChart
-                  data={assetChartData}
-                  title={t('assetAllocation.charts.breakdown', { assetClass: formatAssetName(selectedAssetClass.assetClass) })}
-                  currency={currency}
-                />
+                  {selectedAssetClass && (
+                    <AllocationChart
+                      data={assetChartData}
+                      title={t('assetAllocation.charts.breakdown', { assetClass: formatAssetName(selectedAssetClass.assetClass) })}
+                      currency={currency}
+                    />
+                  )}
+                </Suspense>
+              ) : (
+                <ChartLoadingFallback />
               )}
             </div>
           )}
           {showPortfolioBreakdown && (
             <div className="breakdown-link-row">
-              <Link to="/portfolio-breakdown" className="action-btn breakdown-page-link">
+              <PreloadLink to="/portfolio-breakdown" className="action-btn breakdown-page-link">
                 <MaterialIcon name="donut_large" /> {t('assetAllocation.viewDetailedPortfolioBreakdown')}
-              </Link>
+              </PreloadLink>
             </div>
           )}
           <div className="breakdown-link-row">
-            <Link to="/portfolio-backtest" className="action-btn breakdown-page-link">
+            <PreloadLink to="/portfolio-backtest" className="action-btn breakdown-page-link">
               <MaterialIcon name="analytics" /> {t('assetAllocation.viewPortfolioBacktest')}
-            </Link>
+            </PreloadLink>
           </div>
         </section>
 

--- a/src/components/ChartLoadingState.tsx
+++ b/src/components/ChartLoadingState.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next';
+import { MaterialIcon } from './MaterialIcon';
+
+export function ChartLoadingFallback() {
+  const { t } = useTranslation();
+  return (
+    <div className="chart-loading-placeholder" role="status" aria-live="polite">
+      <MaterialIcon name="progress_activity" size="large" />
+      <span>{t('common.loading')}</span>
+    </div>
+  );
+}
+
+export function ChartLoadFailure() {
+  const { t } = useTranslation();
+  return (
+    <div className="chart-load-error" role="alert">
+      <MaterialIcon name="error" />
+      <span>{t('app.routeLoadErrorTitle')}</span>
+      <button type="button" className="secondary-btn" onClick={() => window.location.reload()}>
+        {t('app.reload')}
+      </button>
+    </div>
+  );
+}

--- a/src/components/ExpenseTrackerPage.css
+++ b/src/components/ExpenseTrackerPage.css
@@ -27,65 +27,6 @@
   box-shadow: var(--shadow-md);
 }
 
-/* Period Selector */
-.period-selector {
-  margin-bottom: 1.5rem;
-  padding: 1rem;
-  background: var(--bg-tertiary);
-  border-radius: 8px;
-}
-
-.selector-row {
-  display: flex;
-  gap: 1rem;
-  align-items: flex-end;
-  flex-wrap: wrap;
-}
-
-.selector-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.selector-group label {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-
-.selector-group select {
-  padding: 0.5rem 1rem;
-  border: 2px solid var(--border-subtle);
-  border-radius: 6px;
-  font-size: 1rem;
-  background: var(--bg-secondary);
-  cursor: pointer;
-  min-width: 120px;
-}
-
-.selector-group select:focus {
-  outline: 3px solid var(--accent-primary);
-  outline-offset: 2px;
-  border-color: var(--accent-primary);
-}
-
-.btn-add-month {
-  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-gold) 100%);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.btn-add-month:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
-}
-
 /* Summary Cards */
 .summary-section {
   margin-bottom: 2rem;
@@ -1109,19 +1050,6 @@
   opacity: 0.9;
 }
 
-/* Visually Hidden (Accessibility) */
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 /* Responsive Design */
 @media (max-width: 768px) {
   .expense-tracker-page {
@@ -1130,23 +1058,6 @@
 
   .expense-tracker-main {
     padding: 1rem;
-  }
-
-  .selector-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .selector-group {
-    width: 100%;
-  }
-
-  .selector-group select {
-    width: 100%;
-  }
-
-  .btn-add-month {
-    width: 100%;
   }
 
   .summary-cards {
@@ -1212,23 +1123,6 @@
   .transactions-table td {
     padding: 0.5rem;
   }
-}
-
-/* Back to Current Period Button */
-.btn-current-period {
-  background: linear-gradient(135deg, var(--warning) 0%, var(--warning) 100%);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.btn-current-period:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(255, 152, 0, 0.4);
 }
 
 /* Analytics View Selector */

--- a/src/components/ExpenseTrackerPage.tsx
+++ b/src/components/ExpenseTrackerPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Suspense, useState, useEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SearchableSelect, SelectOption } from './SearchableSelect';
 import { useSearchParams } from 'react-router-dom';
@@ -45,19 +45,37 @@ import {
 import { loadSettings, saveSettings, type DateFormat } from '../utils/cookieSettings';
 import { formatDate } from '../utils/dateFormatter';
 import { generateDemoExpenseData } from '../utils/demoExpenseData';
+import { createLazyComponent } from '../utils/lazyComponent';
 import { useTableSort } from '../utils/useTableSort';
 import { formatDisplayCurrency, formatDisplayPercent } from '../utils/numberFormatter';
 import { DataManagement } from './DataManagement';
-import { ExpenseBreakdownChart } from './ExpenseBreakdownChart';
-import { SpendingTrendChart } from './SpendingTrendChart';
-import { MonthlyComparisonChart } from './MonthlyComparisonChart';
 import { ValidatedNumberInput } from './ValidatedNumberInput';
 import { MaterialIcon } from './MaterialIcon';
 import { ScrollToTopButton } from './ScrollToTopButton';
 import { PrivacyBlur } from './PrivacyBlur';
 import { CategoryManagerDialog } from './CategoryManagerDialog';
 import { PDFImportDialog } from './PDFImportDialog';
+import { ChartLoadingFallback, ChartLoadFailure } from './ChartLoadingState';
+import './PeriodSelector.css';
 import './ExpenseTrackerPage.css';
+
+const ExpenseBreakdownChart = createLazyComponent(
+  'expense-breakdown-chart',
+  () => import('./ExpenseBreakdownChart').then((module) => module.ExpenseBreakdownChart),
+  () => <ChartLoadFailure />,
+);
+
+const SpendingTrendChart = createLazyComponent(
+  'spending-trend-chart',
+  () => import('./SpendingTrendChart').then((module) => module.SpendingTrendChart),
+  () => <ChartLoadFailure />,
+);
+
+const MonthlyComparisonChart = createLazyComponent(
+  'monthly-comparison-chart',
+  () => import('./MonthlyComparisonChart').then((module) => module.MonthlyComparisonChart),
+  () => <ChartLoadFailure />,
+);
 
 // Month names for display
 const MONTH_NAMES = [
@@ -1415,32 +1433,38 @@ export function ExpenseTrackerPage() {
               <h4>
                 {t('expenseTracker.expenseBreakdown', { period: periodLabel })}
               </h4>
-              <ExpenseBreakdownChart 
-                data={categoryBreakdown}
-                currency={data.currency}
-                customCategories={data.customCategories}
-              />
+              <Suspense fallback={<ChartLoadingFallback />}>
+                <ExpenseBreakdownChart
+                  data={categoryBreakdown}
+                  currency={data.currency}
+                  customCategories={data.customCategories}
+                />
+              </Suspense>
             </div>
 
             {/* Monthly Comparison Chart */}
             <div className="chart-container">
               <h4>{t('expenseTracker.monthlySpendingComparison')}</h4>
               <PrivacyBlur isPrivacyMode={isPrivacyMode}>
-                <MonthlyComparisonChart 
-                  data={monthlyComparisonData}
-                  currency={data.currency}
-                />
+                <Suspense fallback={<ChartLoadingFallback />}>
+                  <MonthlyComparisonChart
+                    data={monthlyComparisonData}
+                    currency={data.currency}
+                  />
+                </Suspense>
               </PrivacyBlur>
             </div>
 
             {/* Category Trends Chart */}
             <div className="chart-container">
               <h4>{t('expenseTracker.categorySpendingTrends')}</h4>
-              <SpendingTrendChart 
-                data={categoryTrendsData}
-                currency={data.currency}
-                customCategories={data.customCategories}
-              />
+              <Suspense fallback={<ChartLoadingFallback />}>
+                <SpendingTrendChart
+                  data={categoryTrendsData}
+                  currency={data.currency}
+                  customCategories={data.customCategories}
+                />
+              </Suspense>
             </div>
 
             {/* Category Breakdown Table */}

--- a/src/components/FIRECalculatorPage.tsx
+++ b/src/components/FIRECalculatorPage.tsx
@@ -1,0 +1,329 @@
+import { Suspense, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { CalculatorInputs, CalculationResult } from '../types/calculator';
+import { DEFAULT_INPUTS } from '../utils/defaults';
+import { calculateFIRE } from '../utils/fireCalculator';
+import { calculateFIREPortfolioData } from '../utils/allocationCalculator';
+import { serializeInputsToURL, deserializeInputsFromURL, hasURLParams } from '../utils/urlParams';
+import {
+  saveFireCalculatorInputs,
+  loadFireCalculatorInputs,
+  clearAllData,
+  loadAssetAllocation,
+} from '../utils/cookieStorage';
+import { exportFireCalculatorToCSV, importFireCalculatorFromCSV } from '../utils/csvExport';
+import { loadSettings, saveSettings } from '../utils/cookieSettings';
+import { createLazyComponent } from '../utils/lazyComponent';
+import { useAuditLog } from '../contexts/AuditLogContext';
+import { useDeferredRender } from '../hooks/useDeferredRender';
+import { CalculatorInputsForm } from './CalculatorInputsForm';
+import { FIREMetrics } from './FIREMetrics';
+import { DataManagement } from './DataManagement';
+import { MaterialIcon } from './MaterialIcon';
+import { ChartLoadingFallback, ChartLoadFailure } from './ChartLoadingState';
+
+const NetWorthChart = createLazyComponent(
+  'net-worth-chart',
+  () => import('./NetWorthChart').then((module) => module.NetWorthChart),
+  () => <ChartLoadFailure />,
+);
+
+const IncomeExpensesChart = createLazyComponent(
+  'income-expenses-chart',
+  () => import('./IncomeExpensesChart').then((module) => module.IncomeExpensesChart),
+  () => <ChartLoadFailure />,
+);
+
+export function FIRECalculatorPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { logAuditEvent } = useAuditLog();
+
+  const [inputs, setInputs] = useState<CalculatorInputs>(() => {
+    if (hasURLParams(searchParams)) {
+      return deserializeInputsFromURL(searchParams);
+    }
+    const saved = loadFireCalculatorInputs();
+    if (saved) {
+      return saved;
+    }
+    return DEFAULT_INPUTS;
+  });
+
+  const [result, setResult] = useState<CalculationResult | null>(null);
+  const [zoomYears, setZoomYears] = useState<number | 'all'>(30);
+  const [customZoomInput, setCustomZoomInput] = useState('');
+  const [isPrivacyMode, setIsPrivacyMode] = useState(() => loadSettings().privacyMode);
+
+  const togglePrivacyMode = () => {
+    const newMode = !isPrivacyMode;
+    setIsPrivacyMode(newMode);
+    const settings = loadSettings();
+    saveSettings({ ...settings, privacyMode: newMode });
+  };
+
+  const assetAllocationData = useMemo(() => {
+    const saved = loadAssetAllocation();
+    if (!saved.assets || saved.assets.length === 0) {
+      return undefined;
+    }
+    return calculateFIREPortfolioData(saved.assets);
+  }, []);
+
+  useEffect(() => {
+    const params = serializeInputsToURL(inputs);
+    setSearchParams(params, { replace: true });
+  }, [inputs, setSearchParams]);
+
+  useEffect(() => {
+    saveFireCalculatorInputs(inputs);
+  }, [inputs]);
+
+  useEffect(() => {
+    let effectiveInputs = inputs;
+    if (inputs.useAssetAllocationValue && assetAllocationData) {
+      effectiveInputs = {
+        ...inputs,
+        initialSavings: assetAllocationData.totalValue,
+        stocksPercent: assetAllocationData.stocksPercent,
+        bondsPercent: assetAllocationData.bondsPercent,
+        cashPercent: assetAllocationData.cashPercent,
+      };
+    }
+    setResult(calculateFIRE(effectiveInputs));
+  }, [inputs, assetAllocationData]);
+
+  const calcAuditInitialised = useRef(false);
+  useEffect(() => {
+    if (!result) return;
+    if (!calcAuditInitialised.current) {
+      calcAuditInitialised.current = true;
+      return;
+    }
+    const handle = setTimeout(() => {
+      logAuditEvent('RUN_CALCULATION', {
+        yearsToFIRE: result.yearsToFIRE,
+        fireTarget: result.fireTarget,
+        fireType: result.fireType,
+      });
+    }, 1500);
+    return () => clearTimeout(handle);
+  }, [result, logAuditEvent]);
+
+  const currentYear = new Date().getFullYear();
+  const currentAge = currentYear - inputs.yearOfBirth;
+  const hasValidationErrors = result?.validationErrors && result.validationErrors.length > 0;
+  const renderCharts = useDeferredRender(Boolean(result && !hasValidationErrors));
+
+  const handleExportCSV = () => {
+    const csv = exportFireCalculatorToCSV(inputs);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `fire-calculator-data-${new Date().toISOString().split('T')[0]}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    logAuditEvent('EXPORT_DATA', { dataset: 'fire-calculator', format: 'csv' });
+  };
+
+  const handleImportCSV = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (loadEvent) => {
+      try {
+        const csv = loadEvent.target?.result as string;
+        const importedInputs = importFireCalculatorFromCSV(csv);
+        setInputs(importedInputs);
+        logAuditEvent('IMPORT_DATA', { dataset: 'fire-calculator', format: 'csv' });
+      } catch (error) {
+        alert(`Error importing CSV: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = '';
+  };
+
+  const handleResetData = () => {
+    if (confirm('Are you sure you want to reset all data? This will clear all saved data from cookies and reset to defaults.')) {
+      clearAllData();
+      setInputs(DEFAULT_INPUTS);
+    }
+  };
+
+  const expandAndScrollTo = (sectionId: string) => {
+    setSidebarCollapsed(false);
+    setTimeout(() => {
+      const element = document.getElementById(sectionId);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }, 100);
+  };
+
+  return (
+    <div className="app-container">
+      <aside className={`sidebar ${sidebarCollapsed ? 'collapsed' : ''}`} aria-label="Calculator inputs">
+        <button
+          className="sidebar-toggle-btn"
+          onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+          title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!sidebarCollapsed}
+        >
+          <MaterialIcon name={sidebarCollapsed ? 'chevron_right' : 'chevron_left'} />
+        </button>
+
+        <div className="sidebar-collapsed-icons">
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-data-management')}
+            title="Data Management"
+            aria-label="Expand to manage data"
+          >
+            <MaterialIcon name="save" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-initial-values')}
+            title="Initial Values"
+            aria-label="Expand to edit Initial Values"
+          >
+            <MaterialIcon name="savings" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-asset-allocation')}
+            title="Asset Allocation"
+            aria-label="Expand to edit Asset Allocation"
+          >
+            <MaterialIcon name="pie_chart" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-income')}
+            title="Income"
+            aria-label="Expand to edit Income"
+          >
+            <MaterialIcon name="payments" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-pension')}
+            title="Pension"
+            aria-label="Expand to edit Pension"
+          >
+            <MaterialIcon name="account_balance" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-expenses')}
+            title="Expenses & Savings"
+            aria-label="Expand to edit Expenses & Savings"
+          >
+            <MaterialIcon name="shopping_cart" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-fire-params')}
+            title="FIRE Parameters"
+            aria-label="Expand to edit FIRE Parameters"
+          >
+            <MaterialIcon name="gps_fixed" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-expected-returns')}
+            title="Expected Returns"
+            aria-label="Expand to edit Expected Returns"
+          >
+            <MaterialIcon name="trending_up" />
+          </button>
+          <button
+            className="sidebar-icon-btn"
+            onClick={() => expandAndScrollTo('section-options')}
+            title="Options"
+            aria-label="Expand to edit Options"
+          >
+            <MaterialIcon name="settings" />
+          </button>
+        </div>
+
+        {!sidebarCollapsed && (
+          <>
+            <DataManagement
+              onExport={handleExportCSV}
+              onImport={handleImportCSV}
+              onReset={handleResetData}
+              defaultOpen={false}
+            />
+
+            <CalculatorInputsForm
+              inputs={inputs}
+              onChange={setInputs}
+              assetAllocationData={assetAllocationData}
+              isPrivacyMode={isPrivacyMode}
+            />
+          </>
+        )}
+      </aside>
+
+      <main className="main-content">
+        {hasValidationErrors && (
+          <div className="validation-error-banner" role="alert" aria-live="polite">
+            <strong><MaterialIcon name="warning" /> Validation Error</strong>
+            {result.validationErrors?.map((error, index) => (
+              <div key={index} className="validation-error-message">{error}</div>
+            ))}
+          </div>
+        )}
+
+        {result && !hasValidationErrors && (
+          <>
+            <FIREMetrics
+              result={result}
+              currentAge={currentAge}
+              zoomYears={zoomYears}
+              inputs={inputs}
+              onLoadScenario={setInputs}
+              isPrivacyMode={isPrivacyMode}
+              onTogglePrivacyMode={togglePrivacyMode}
+            />
+
+            <div className="charts-section" data-tour="charts-section">
+              {renderCharts ? (
+                <Suspense fallback={<ChartLoadingFallback />}>
+                  <NetWorthChart
+                    projections={result.projections}
+                    fireTarget={result.fireTarget}
+                    currentAge={currentAge}
+                    zoomYears={zoomYears}
+                    onZoomChange={setZoomYears}
+                    customZoomInput={customZoomInput}
+                    onCustomZoomInputChange={setCustomZoomInput}
+                    isPrivacyMode={isPrivacyMode}
+                  />
+                  <IncomeExpensesChart
+                    projections={result.projections}
+                    currentAge={currentAge}
+                    zoomYears={zoomYears}
+                    onZoomChange={setZoomYears}
+                    customZoomInput={customZoomInput}
+                    onCustomZoomInputChange={setCustomZoomInput}
+                    isPrivacyMode={isPrivacyMode}
+                  />
+                </Suspense>
+              ) : (
+                <ChartLoadingFallback />
+              )}
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/GuidedTour.tsx
+++ b/src/components/GuidedTour.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { loadTourCompleted, saveTourCompleted } from '../utils/tourPreferences';
@@ -385,7 +385,7 @@ export function GuidedTour({ onTourComplete }: GuidedTourProps) {
     }
   }, [isDragging, handleDragMove, handleDragEnd]);
 
-  const tourSteps: TourStep[] = [
+  const tourSteps = useMemo<TourStep[]>(() => [
     {
       title: t('guidedTour.overview.welcome.title'),
       icon: 'waving_hand',
@@ -515,10 +515,10 @@ export function GuidedTour({ onTourComplete }: GuidedTourProps) {
         </div>
       ),
     },
-  ];
+  ], [t]);
 
   // Interactive tour steps for each page
-  const fireCalculatorSteps: InteractiveStep[] = [
+  const fireCalculatorSteps = useMemo<InteractiveStep[]>(() => [
     {
       page: '/fire-calculator',
       title: t('guidedTour.interactive.fireCalculator.initialSavings.title'),
@@ -577,9 +577,9 @@ export function GuidedTour({ onTourComplete }: GuidedTourProps) {
       position: 'center',
       elementSelector: '[data-tour="charts-section"]',
     },
-  ];
+  ], [t]);
 
-  const assetAllocationSteps: InteractiveStep[] = [
+  const assetAllocationSteps = useMemo<InteractiveStep[]>(() => [
     {
       page: '/asset-allocation',
       title: t('guidedTour.interactive.assetAllocation.yourAssets.title'),
@@ -664,9 +664,9 @@ export function GuidedTour({ onTourComplete }: GuidedTourProps) {
       isDialogStep: true,
       closeDialogAfter: true,
     },
-  ];
+  ], [t]);
 
-  const expenseTrackerSteps: InteractiveStep[] = [
+  const expenseTrackerSteps = useMemo<InteractiveStep[]>(() => [
     {
       page: '/expense-tracker',
       title: t('guidedTour.interactive.expenseTracker.addIncome.title'),
@@ -758,9 +758,9 @@ export function GuidedTour({ onTourComplete }: GuidedTourProps) {
       position: 'center',
       elementSelector: '[data-tour="expense-tabs"], [data-tour="analytics-content"]',
     },
-  ];
+  ], [t]);
 
-  const netWorthSteps: InteractiveStep[] = [
+  const netWorthSteps = useMemo<InteractiveStep[]>(() => [
     {
       page: '/net-worth-tracker',
       title: t('guidedTour.interactive.netWorth.logAssets.title'),
@@ -809,10 +809,10 @@ export function GuidedTour({ onTourComplete }: GuidedTourProps) {
       position: 'center',
       elementSelector: '[data-tour="sync-options"]',
     },
-  ];
+  ], [t]);
 
   // Monte Carlo Simulation steps
-  const monteCarloSteps: InteractiveStep[] = [
+  const monteCarloSteps = useMemo<InteractiveStep[]>(() => [
     {
       page: '/monte-carlo',
       title: t('guidedTour.interactive.monteCarlo.baseData.title'),
@@ -850,15 +850,15 @@ export function GuidedTour({ onTourComplete }: GuidedTourProps) {
       position: 'center',
       elementSelector: '[data-tour="monte-carlo-logs"]',
     },
-  ];
+  ], [t]);
 
-  const pageTours: Record<string, { steps: InteractiveStep[]; nextPage: string | null; previousPage: string | null; pageName: string }> = {
+  const pageTours = useMemo<Record<string, { steps: InteractiveStep[]; nextPage: string | null; previousPage: string | null; pageName: string }>>(() => ({
     '/fire-calculator': { steps: fireCalculatorSteps, nextPage: '/asset-allocation', previousPage: null, pageName: t('guidedTour.pageNames.assetAllocation') },
     '/asset-allocation': { steps: assetAllocationSteps, nextPage: '/expense-tracker', previousPage: '/fire-calculator', pageName: t('guidedTour.pageNames.cashflowTracker') },
     '/expense-tracker': { steps: expenseTrackerSteps, nextPage: '/net-worth-tracker', previousPage: '/asset-allocation', pageName: t('guidedTour.pageNames.netWorthTracker') },
     '/net-worth-tracker': { steps: netWorthSteps, nextPage: '/monte-carlo', previousPage: '/expense-tracker', pageName: t('guidedTour.pageNames.monteCarlo') },
     '/monte-carlo': { steps: monteCarloSteps, nextPage: null, previousPage: '/net-worth-tracker', pageName: '' },
-  };
+  }), [assetAllocationSteps, expenseTrackerSteps, fireCalculatorSteps, monteCarloSteps, netWorthSteps, t]);
 
   const handleNext = () => {
     if (currentStep < tourSteps.length - 1) {

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,6 +1,6 @@
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { MaterialIcon } from './MaterialIcon';
+import { PreloadLink } from './PreloadLink';
 import './HomePage.css';
 
 export function HomePage() {
@@ -19,7 +19,7 @@ export function HomePage() {
       </section>
 
       <section className="features-grid" aria-label={t('home.toolsLabel')}>
-        <Link to="/asset-allocation" className="feature-card" aria-labelledby="asset-allocation-title">
+        <PreloadLink to="/asset-allocation" className="feature-card" aria-labelledby="asset-allocation-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="pie_chart" size="large" /></div>
           <h3 id="asset-allocation-title" className="feature-card-title">{t('home.cards.assetAllocation.title')}</h3>
           <p>
@@ -31,9 +31,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="show_chart" size="small" /> {t('home.cards.assetAllocation.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.assetAllocation.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/expense-tracker" className="feature-card" aria-labelledby="expense-tracker-title">
+        <PreloadLink to="/expense-tracker" className="feature-card" aria-labelledby="expense-tracker-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="account_balance_wallet" size="large" /></div>
           <h3 id="expense-tracker-title" className="feature-card-title">{t('home.cards.cashflow.title')}</h3>
           <p>
@@ -45,9 +45,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="analytics" size="small" /> {t('home.cards.cashflow.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.cashflow.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/net-worth-tracker" className="feature-card" aria-labelledby="net-worth-title">
+        <PreloadLink to="/net-worth-tracker" className="feature-card" aria-labelledby="net-worth-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="paid" size="large" /></div>
           <h3 id="net-worth-title" className="feature-card-title">{t('home.cards.netWorth.title')}</h3>
           <p>
@@ -59,9 +59,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="elderly" size="small" /> {t('home.cards.netWorth.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.netWorth.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/fire-calculator" className="feature-card" aria-labelledby="fire-calc-title">
+        <PreloadLink to="/fire-calculator" className="feature-card" aria-labelledby="fire-calc-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="local_fire_department" size="large" /></div>
           <h3 id="fire-calc-title" className="feature-card-title">{t('home.cards.fireCalculator.title')}</h3>
           <p>
@@ -73,9 +73,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="account_balance_wallet" size="small" /> {t('home.cards.fireCalculator.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.fireCalculator.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/monte-carlo" className="feature-card" aria-labelledby="monte-carlo-title">
+        <PreloadLink to="/monte-carlo" className="feature-card" aria-labelledby="monte-carlo-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="casino" size="large" /></div>
           <h3 id="monte-carlo-title" className="feature-card-title">{t('home.cards.monteCarlo.title')}</h3>
           <p>
@@ -87,9 +87,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="bolt" size="small" /> {t('home.cards.monteCarlo.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.monteCarlo.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/investment-growth" className="feature-card" aria-labelledby="investment-growth-title">
+        <PreloadLink to="/investment-growth" className="feature-card" aria-labelledby="investment-growth-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="trending_up" size="large" /></div>
           <h3 id="investment-growth-title" className="feature-card-title">{t('home.cards.investmentGrowth.title')}</h3>
           <p>
@@ -101,9 +101,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="savings" size="small" /> {t('home.cards.investmentGrowth.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.investmentGrowth.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/portfolio-backtest" className="feature-card" aria-labelledby="portfolio-backtest-title">
+        <PreloadLink to="/portfolio-backtest" className="feature-card" aria-labelledby="portfolio-backtest-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="analytics" size="large" /></div>
           <h3 id="portfolio-backtest-title" className="feature-card-title">{t('home.cards.portfolioBacktest.title')}</h3>
           <p>
@@ -115,9 +115,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="table_chart" size="small" /> {t('home.cards.portfolioBacktest.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.portfolioBacktest.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/withdrawal-rate" className="feature-card" aria-labelledby="withdrawal-rate-title">
+        <PreloadLink to="/withdrawal-rate" className="feature-card" aria-labelledby="withdrawal-rate-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="trending_down" size="large" /></div>
           <h3 id="withdrawal-rate-title" className="feature-card-title">{t('home.cards.withdrawalRate.title')}</h3>
           <p>
@@ -129,9 +129,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="verified" size="small" /> {t('home.cards.withdrawalRate.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.withdrawalRate.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/questionnaire" className="feature-card" aria-labelledby="fire-quiz-title">
+        <PreloadLink to="/questionnaire" className="feature-card" aria-labelledby="fire-quiz-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="quiz" size="large" /></div>
           <h3 id="fire-quiz-title" className="feature-card-title">{t('home.cards.quiz.title')}</h3>
           <p>
@@ -143,9 +143,9 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="trending_up" size="small" /> {t('home.cards.quiz.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.quiz.cta')}</span>
-        </Link>
+        </PreloadLink>
 
-        <Link to="/debt-payoff" className="feature-card" aria-labelledby="debt-payoff-title">
+        <PreloadLink to="/debt-payoff" className="feature-card" aria-labelledby="debt-payoff-title">
           <div className="feature-icon" aria-hidden="true"><MaterialIcon name="credit_score" size="large" /></div>
           <h3 id="debt-payoff-title" className="feature-card-title">{t('home.cards.debtPayoff.title')}</h3>
           <p>
@@ -157,7 +157,7 @@ export function HomePage() {
             <span className="highlight-item"><MaterialIcon name="show_chart" size="small" /> {t('home.cards.debtPayoff.h3')}</span>
           </div>
           <span className="cta-link" aria-hidden="true">{t('home.cards.debtPayoff.cta')}</span>
-        </Link>
+        </PreloadLink>
       </section>
     </main>
   );

--- a/src/components/NetWorthTrackerPage.tsx
+++ b/src/components/NetWorthTrackerPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import {
@@ -37,16 +37,31 @@ import { generateDemoNetWorthDataForYear } from '../utils/defaults';
 import { syncAssetAllocationToNetWorth, syncNetWorthToAssetAllocation, DEFAULT_ASSET_CLASS_TARGETS } from '../utils/dataSync';
 import { fetchMultipleClosingPricesForMonth } from '../utils/priceApi';
 import { fetchAssetPrices } from '../utils/dcaCalculator';
+import { createLazyComponent } from '../utils/lazyComponent';
 import { formatDisplayCurrency, formatDisplayPercent, formatDisplayNumber } from '../utils/numberFormatter';
+import { useDeferredRender } from '../hooks/useDeferredRender';
 import { DataManagement } from './DataManagement';
-import { HistoricalNetWorthChart, ChartViewMode } from './HistoricalNetWorthChart';
-import { NetWorthSankeyChart } from './NetWorthSankeyChart';
+import type { ChartViewMode } from './HistoricalNetWorthChart';
 import { SharedAssetDialog } from './SharedAssetDialog';
 import { MaterialIcon } from './MaterialIcon';
 import { SearchableSelect } from './SearchableSelect';
 import { ScrollToTopButton } from './ScrollToTopButton';
 import { PrivacyBlur } from './PrivacyBlur';
+import { ChartLoadingFallback, ChartLoadFailure } from './ChartLoadingState';
+import './PeriodSelector.css';
 import './NetWorthTrackerPage.css';
+
+const HistoricalNetWorthChart = createLazyComponent(
+  'historical-net-worth-chart',
+  () => import('./HistoricalNetWorthChart').then((module) => module.HistoricalNetWorthChart),
+  () => <ChartLoadFailure />,
+);
+
+const NetWorthSankeyChart = createLazyComponent(
+  'net-worth-sankey-chart',
+  () => import('./NetWorthSankeyChart').then((module) => module.NetWorthSankeyChart),
+  () => <ChartLoadFailure />,
+);
 
 // Month names for display
 const MONTH_NAMES = [
@@ -160,6 +175,7 @@ export function NetWorthTrackerPage() {
   
   // Chart view mode (YTD or All historical data)
   const [chartViewMode, setChartViewMode] = useState<ChartViewMode>('ytd');
+  const renderCharts = useDeferredRender(true);
   
   // Privacy mode state (loaded from settings, toggleable on page)
   const [isPrivacyMode, setIsPrivacyMode] = useState<boolean>(() => {
@@ -1288,15 +1304,21 @@ export function NetWorthTrackerPage() {
         {/* Historical Net Worth Chart */}
         <section className="chart-section" data-tour="historical-chart">
           <h3><MaterialIcon name="trending_up" /> {t('netWorth.historicalNetWorth')}</h3>
-          <HistoricalNetWorthChart
-            variations={monthlyVariations}
-            forecast={forecast}
-            currency={data.defaultCurrency}
-            previousYearEnd={previousYearEndValue}
-            viewMode={chartViewMode}
-            onViewModeChange={setChartViewMode}
-            isPrivacyMode={isPrivacyMode}
-          />
+          {renderCharts ? (
+            <Suspense fallback={<ChartLoadingFallback />}>
+              <HistoricalNetWorthChart
+                variations={monthlyVariations}
+                forecast={forecast}
+                currency={data.defaultCurrency}
+                previousYearEnd={previousYearEndValue}
+                viewMode={chartViewMode}
+                onViewModeChange={setChartViewMode}
+                isPrivacyMode={isPrivacyMode}
+              />
+            </Suspense>
+          ) : (
+            <ChartLoadingFallback />
+          )}
         </section>
 
         {/* Wealth Flow Sankey Chart */}
@@ -1306,12 +1328,18 @@ export function NetWorthTrackerPage() {
               <MaterialIcon name="account_tree" /> {t('netWorth.sankey.title')}
             </h3>
             <p className="chart-subtitle">{t('netWorth.sankey.subtitle')}</p>
-            <NetWorthSankeyChart
-              snapshot={currentMonthData}
-              currency={data.defaultCurrency}
-              showPension={data.settings.showPensionInNetWorth}
-              isPrivacyMode={isPrivacyMode}
-            />
+            {renderCharts ? (
+              <Suspense fallback={<ChartLoadingFallback />}>
+                <NetWorthSankeyChart
+                  snapshot={currentMonthData}
+                  currency={data.defaultCurrency}
+                  showPension={data.settings.showPensionInNetWorth}
+                  isPrivacyMode={isPrivacyMode}
+                />
+              </Suspense>
+            ) : (
+              <ChartLoadingFallback />
+            )}
           </section>
         )}
 

--- a/src/components/PeriodSelector.css
+++ b/src/components/PeriodSelector.css
@@ -1,0 +1,83 @@
+.period-selector {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+}
+
+.selector-row {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.selector-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.selector-group label {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.selector-group select {
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--border-subtle);
+  border-radius: 6px;
+  font-size: 1rem;
+  background: var(--bg-secondary);
+  cursor: pointer;
+  min-width: 120px;
+}
+
+.selector-group select:focus {
+  outline: 3px solid var(--accent-primary);
+  outline-offset: 2px;
+  border-color: var(--accent-primary);
+}
+
+.btn-add-month,
+.btn-current-period {
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.btn-add-month {
+  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-gold) 100%);
+}
+
+.btn-add-month:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+}
+
+.btn-current-period {
+  background: linear-gradient(135deg, var(--warning) 0%, var(--warning) 100%);
+}
+
+.btn-current-period:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(255, 152, 0, 0.4);
+}
+
+@media (max-width: 768px) {
+  .selector-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .selector-group,
+  .selector-group select,
+  .btn-add-month {
+    width: 100%;
+  }
+}

--- a/src/components/PortfolioBacktestPage.tsx
+++ b/src/components/PortfolioBacktestPage.tsx
@@ -9,6 +9,7 @@ import { formatDisplayCurrency } from '../utils/numberFormatter';
 import { MaterialIcon } from './MaterialIcon';
 import { BacktestSection } from './BacktestSection';
 import { PrivacyBlur } from './PrivacyBlur';
+import './AssetAllocationManager.css';
 
 const calculateActivePortfolioValue = (assets: Asset[]): number =>
   assets

--- a/src/components/PortfolioBreakdownPage.tsx
+++ b/src/components/PortfolioBreakdownPage.tsx
@@ -25,6 +25,7 @@ import { MaterialIcon } from './MaterialIcon';
 import { BreakdownChart } from './BreakdownChart';
 import { PrivacyBlur } from './PrivacyBlur';
 import { ScrollToTopButton } from './ScrollToTopButton';
+import './AssetAllocationManager.css';
 import './PortfolioBreakdownPage.css';
 
 interface DimensionConfig {

--- a/src/components/PreloadLink.tsx
+++ b/src/components/PreloadLink.tsx
@@ -1,0 +1,41 @@
+import { Link, type LinkProps } from 'react-router-dom';
+import { preloadRoute } from '../routes/lazyPages';
+
+function getPathname(to: LinkProps['to']): string | undefined {
+  if (typeof to === 'string') {
+    return to;
+  }
+  return to.pathname;
+}
+
+export function PreloadLink({
+  to,
+  onFocus,
+  onPointerDown,
+  onPointerEnter,
+  ...props
+}: LinkProps) {
+  const warmRoute = () => {
+    const pathname = getPathname(to);
+    if (pathname) void preloadRoute(pathname);
+  };
+
+  return (
+    <Link
+      {...props}
+      to={to}
+      onFocus={(event) => {
+        warmRoute();
+        onFocus?.(event);
+      }}
+      onPointerDown={(event) => {
+        warmRoute();
+        onPointerDown?.(event);
+      }}
+      onPointerEnter={(event) => {
+        warmRoute();
+        onPointerEnter?.(event);
+      }}
+    />
+  );
+}

--- a/src/components/ToolsMenu.tsx
+++ b/src/components/ToolsMenu.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { MaterialIcon } from './MaterialIcon';
+import { PreloadLink } from './PreloadLink';
 import { NAVBAR_LABELS } from '../constants/navbarLabels';
 import './ToolsMenu.css';
 
@@ -80,7 +81,7 @@ export const ToolsMenu: React.FC<ToolsMenuProps> = ({ onNavigate, showPortfolioB
       {isOpen && (
         <div className="tools-menu-dropdown" role="menu">
           {tools.map((tool) => (
-            <Link
+            <PreloadLink
               key={tool.to}
               to={tool.to}
               className={`tools-menu-item ${location.pathname === tool.to ? 'active' : ''}`}
@@ -92,7 +93,7 @@ export const ToolsMenu: React.FC<ToolsMenuProps> = ({ onNavigate, showPortfolioB
                 <MaterialIcon name={tool.icon} size="small" />
               </span>
               {tool.label}
-            </Link>
+            </PreloadLink>
           ))}
         </div>
       )}

--- a/src/hooks/useDeferredRender.ts
+++ b/src/hooks/useDeferredRender.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+type CancelSchedule = () => void;
+const DEFERRED_RENDER_DELAY_MS = 150;
+
+function scheduleFrame(callback: () => void): CancelSchedule {
+  if (typeof window.requestAnimationFrame === 'function') {
+    const frameId = window.requestAnimationFrame(callback);
+    return () => window.cancelAnimationFrame(frameId);
+  }
+
+  const timeoutId = window.setTimeout(callback, 16);
+  return () => window.clearTimeout(timeoutId);
+}
+
+export function useDeferredRender(enabled = true): boolean {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setReady(false);
+      return;
+    }
+
+    let cancelSecondFrame: CancelSchedule = () => {};
+    let idleCallbackId: number | undefined;
+    let delayTimeoutId: number | undefined;
+    let fallbackTimeoutId: number | undefined;
+
+    const reveal = () => setReady(true);
+    const cancelFirstFrame = scheduleFrame(() => {
+      cancelSecondFrame = scheduleFrame(() => {
+        delayTimeoutId = window.setTimeout(() => {
+          if (typeof window.requestIdleCallback === 'function') {
+            idleCallbackId = window.requestIdleCallback(reveal, { timeout: 500 });
+          } else {
+            fallbackTimeoutId = window.setTimeout(reveal, 0);
+          }
+        }, DEFERRED_RENDER_DELAY_MS);
+      });
+    });
+
+    return () => {
+      cancelFirstFrame();
+      cancelSecondFrame();
+      if (idleCallbackId !== undefined && typeof window.cancelIdleCallback === 'function') {
+        window.cancelIdleCallback(idleCallbackId);
+      }
+      if (delayTimeoutId !== undefined) window.clearTimeout(delayTimeoutId);
+      if (fallbackTimeoutId !== undefined) window.clearTimeout(fallbackTimeoutId);
+    };
+  }, [enabled]);
+
+  return ready;
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,16 +1,20 @@
 import i18n from 'i18next';
+import type { Resource, ResourceLanguage } from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import en from './locales/en.json';
-import it from './locales/it.json';
-import fr from './locales/fr.json';
-import de from './locales/de.json';
-import es from './locales/es.json';
 import { loadSettings, saveSettings } from '../utils/cookieSettings';
 import { logger } from '../utils/logger';
 
 export const SUPPORTED_LANGUAGES = ['en', 'it', 'fr', 'de', 'es'] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 export const DEFAULT_LANGUAGE: SupportedLanguage = 'en';
+
+const LANGUAGE_LOADERS: Record<SupportedLanguage, () => Promise<ResourceLanguage>> = {
+  en: () => import('./locales/en.json').then((module) => module.default),
+  it: () => import('./locales/it.json').then((module) => module.default),
+  fr: () => import('./locales/fr.json').then((module) => module.default),
+  de: () => import('./locales/de.json').then((module) => module.default),
+  es: () => import('./locales/es.json').then((module) => module.default),
+};
 
 export function isSupportedLanguage(value: unknown): value is SupportedLanguage {
   return (
@@ -29,21 +33,52 @@ function resolveInitialLanguage(): SupportedLanguage {
   return DEFAULT_LANGUAGE;
 }
 
-void i18n.use(initReactI18next).init({
-  resources: {
-    en: { translation: en },
-    it: { translation: it },
-    fr: { translation: fr },
-    de: { translation: de },
-    es: { translation: es },
-  },
-  lng: resolveInitialLanguage(),
-  fallbackLng: DEFAULT_LANGUAGE,
-  supportedLngs: [...SUPPORTED_LANGUAGES],
-  load: 'languageOnly',
-  interpolation: { escapeValue: false },
-  returnNull: false,
-});
+async function initializeI18n(): Promise<void> {
+  let initialLanguage = resolveInitialLanguage();
+  let initialResource: ResourceLanguage;
+
+  try {
+    initialResource = await LANGUAGE_LOADERS[initialLanguage]();
+  } catch (error) {
+    logger.error('i18n', 'initial-language-load-failed', 'failed to load initial language bundle', {
+      pii: {
+        language: initialLanguage,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    if (initialLanguage === DEFAULT_LANGUAGE) throw error;
+    initialLanguage = DEFAULT_LANGUAGE;
+    initialResource = await LANGUAGE_LOADERS[DEFAULT_LANGUAGE]();
+  }
+
+  const resources: Resource = {
+    [initialLanguage]: { translation: initialResource },
+  };
+
+  if (initialLanguage !== DEFAULT_LANGUAGE) {
+    try {
+      resources[DEFAULT_LANGUAGE] = {
+        translation: await LANGUAGE_LOADERS[DEFAULT_LANGUAGE](),
+      };
+    } catch (error) {
+      logger.warn('i18n', 'fallback-language-load-failed', 'failed to preload English fallback bundle', {
+        pii: { error: error instanceof Error ? error.message : String(error) },
+      });
+    }
+  }
+
+  await i18n.use(initReactI18next).init({
+    resources,
+    lng: initialLanguage,
+    fallbackLng: DEFAULT_LANGUAGE,
+    supportedLngs: [...SUPPORTED_LANGUAGES],
+    load: 'languageOnly',
+    interpolation: { escapeValue: false },
+    returnNull: false,
+  });
+}
+
+export const i18nReady = initializeI18n();
 
 /**
  * Change the active UI language and persist it to the encrypted cookie.
@@ -53,6 +88,21 @@ export async function setLanguage(lang: SupportedLanguage): Promise<void> {
   if (!isSupportedLanguage(lang)) {
     logger.error('i18n', 'unsupported-language', 'unsupported language requested', { pii: { language: lang as string } });
     return;
+  }
+  await i18nReady;
+  if (!i18n.hasResourceBundle(lang, 'translation')) {
+    try {
+      const resource = await LANGUAGE_LOADERS[lang]();
+      i18n.addResourceBundle(lang, 'translation', resource, true, true);
+    } catch (error) {
+      logger.error('i18n', 'language-load-failed', 'failed to load requested language bundle', {
+        pii: {
+          language: lang,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw error;
+    }
   }
   try {
     const current = loadSettings();

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -6,7 +6,10 @@
     "disclaimer": "Fire Tools – Hinweis: Diese Tools dienen ausschließlich Bildungszwecken. Marktdaten sind nur indikativ und können verzögert oder ungenau sein. Wenden Sie sich für professionelle Beratung an eine Finanzberatung.",
     "privacyPolicy": "Datenschutzerklärung",
     "cookiePolicy": "Cookie-Richtlinie",
-    "github": "GitHub"
+    "github": "GitHub",
+    "routeLoadErrorTitle": "Dieses Tool konnte nicht geladen werden",
+    "routeLoadErrorBody": "Die App wurde möglicherweise aktualisiert, während sie geöffnet war. Lade sie neu, um die neuesten Dateien zu verwenden.",
+    "reload": "App neu laden"
   },
   "common": {
     "save": "Speichern",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -6,7 +6,10 @@
     "disclaimer": "Fire Tools - Disclaimer: This is for educational purposes only. Market data is provided as an indication only and may be delayed or inaccurate. Consult with a financial advisor for professional advice.",
     "privacyPolicy": "Privacy Policy",
     "cookiePolicy": "Cookie Policy",
-    "github": "GitHub"
+    "github": "GitHub",
+    "routeLoadErrorTitle": "This tool couldn't be loaded",
+    "routeLoadErrorBody": "The app may have been updated while it was open. Reload to use the latest files.",
+    "reload": "Reload app"
   },
   "common": {
     "save": "Save",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -6,7 +6,10 @@
     "disclaimer": "Fire Tools - Aviso: esta herramienta tiene fines educativos. Los datos de mercado se proporcionan de forma orientativa y pueden estar retrasados o ser inexactos. Consulta con un asesor financiero para obtener consejo profesional.",
     "privacyPolicy": "Política de privacidad",
     "cookiePolicy": "Política de cookies",
-    "github": "GitHub"
+    "github": "GitHub",
+    "routeLoadErrorTitle": "No se pudo cargar esta herramienta",
+    "routeLoadErrorBody": "Es posible que la aplicación se haya actualizado mientras estaba abierta. Recárgala para usar los archivos más recientes.",
+    "reload": "Recargar la aplicación"
   },
   "common": {
     "save": "Guardar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -6,7 +6,10 @@
     "disclaimer": "Fire Tools - Avertissement : ces outils sont fournis à titre éducatif uniquement. Les données de marché sont indicatives et peuvent être retardées ou inexactes. Consultez un conseiller financier pour des conseils professionnels.",
     "privacyPolicy": "Politique de confidentialité",
     "cookiePolicy": "Politique relative aux cookies",
-    "github": "GitHub"
+    "github": "GitHub",
+    "routeLoadErrorTitle": "Impossible de charger cet outil",
+    "routeLoadErrorBody": "L'application a peut-être été mise à jour pendant son utilisation. Rechargez-la pour utiliser les fichiers les plus récents.",
+    "reload": "Recharger l'application"
   },
   "common": {
     "save": "Enregistrer",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -6,7 +6,10 @@
     "disclaimer": "Fire Tools - Avvertenza: questo strumento ha scopo puramente educativo. I dati di mercato sono forniti a titolo indicativo e potrebbero essere ritardati o inesatti. Per consigli professionali rivolgiti a un consulente finanziario.",
     "privacyPolicy": "Informativa sulla privacy",
     "cookiePolicy": "Informativa sui cookie",
-    "github": "GitHub"
+    "github": "GitHub",
+    "routeLoadErrorTitle": "Impossibile caricare questo strumento",
+    "routeLoadErrorBody": "L'app potrebbe essere stata aggiornata mentre era aperta. Ricaricala per usare i file più recenti.",
+    "reload": "Ricarica l'app"
   },
   "common": {
     "save": "Salva",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,30 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
-import './i18n'
+import { i18nReady } from './i18n'
+import { logger } from './utils/logger'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+const root = ReactDOM.createRoot(document.getElementById('root')!)
+
+void i18nReady
+  .then(() => {
+    root.render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>,
+    )
+  })
+  .catch((error) => {
+    logger.error('app', 'translation-init-failed', 'failed to initialize translations', {
+      pii: { error: error instanceof Error ? error.message : String(error) },
+    })
+    root.render(
+      <main className="route-load-error" role="alert">
+        <h1>Fire Tools could not start</h1>
+        <p>Reload the app to try downloading the required language files again.</p>
+        <button type="button" className="primary-btn" onClick={() => window.location.reload()}>
+          Reload app
+        </button>
+      </main>,
+    )
+  })

--- a/src/routes/lazyPages.tsx
+++ b/src/routes/lazyPages.tsx
@@ -1,0 +1,154 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MaterialIcon } from '../components/MaterialIcon';
+import { logger } from '../utils/logger';
+
+interface LazyPage<Props extends object> {
+  Component: LazyExoticComponent<ComponentType<Props>>;
+  preload: () => Promise<void>;
+}
+
+function RouteLoadError() {
+  const { t } = useTranslation();
+
+  return (
+    <main className="route-load-error" id="main-content" role="alert">
+      <MaterialIcon name="error" size="large" />
+      <h2>{t('app.routeLoadErrorTitle')}</h2>
+      <p>{t('app.routeLoadErrorBody')}</p>
+      <button type="button" className="primary-btn" onClick={() => window.location.reload()}>
+        <MaterialIcon name="refresh" size="small" />
+        {t('app.reload')}
+      </button>
+    </main>
+  );
+}
+
+function createLazyPage<Props extends object>(
+  routePath: string,
+  loadComponent: () => Promise<ComponentType<Props>>,
+): LazyPage<Props> {
+  let componentPromise: Promise<ComponentType<Props>> | undefined;
+  let errorReported = false;
+
+  const load = () => {
+    componentPromise ??= loadComponent();
+    return componentPromise;
+  };
+
+  const reportError = (error: unknown) => {
+    if (errorReported) return;
+    errorReported = true;
+    logger.error('routing', 'chunk-load-failed', `failed to load route module: ${routePath}`, {
+      pii: { error: error instanceof Error ? error.message : String(error) },
+    });
+  };
+
+  const Component = lazy(async () => {
+    try {
+      return { default: await load() };
+    } catch (error) {
+      reportError(error);
+      const FailedRoute = (_props: Props) => <RouteLoadError />;
+      return { default: FailedRoute };
+    }
+  });
+
+  const preload = async () => {
+    try {
+      await load();
+    } catch (error) {
+      reportError(error);
+    }
+  };
+
+  return { Component, preload };
+}
+
+const fireCalculatorRoute = createLazyPage(
+  '/fire-calculator',
+  () => import('../components/FIRECalculatorPage').then((module) => module.FIRECalculatorPage),
+);
+const reverseFireCalculatorRoute = createLazyPage(
+  '/reverse-fire-calculator',
+  () => import('../components/ReverseFIRECalculatorPage').then((module) => module.ReverseFIRECalculatorPage),
+);
+const monteCarloRoute = createLazyPage(
+  '/monte-carlo',
+  () => import('../components/MonteCarloPage').then((module) => module.MonteCarloPage),
+);
+const investmentGrowthRoute = createLazyPage(
+  '/investment-growth',
+  () => import('../components/InvestmentGrowthPage').then((module) => module.InvestmentGrowthPage),
+);
+const withdrawalRateRoute = createLazyPage(
+  '/withdrawal-rate',
+  () => import('../components/WithdrawalRatePage').then((module) => module.WithdrawalRatePage),
+);
+const assetAllocationRoute = createLazyPage(
+  '/asset-allocation',
+  () => import('../components/AssetAllocationPage').then((module) => module.AssetAllocationPage),
+);
+const portfolioBacktestRoute = createLazyPage(
+  '/portfolio-backtest',
+  () => import('../components/PortfolioBacktestPage').then((module) => module.PortfolioBacktestPage),
+);
+const portfolioBreakdownRoute = createLazyPage(
+  '/portfolio-breakdown',
+  () => import('../components/PortfolioBreakdownPage').then((module) => module.PortfolioBreakdownPage),
+);
+const expenseTrackerRoute = createLazyPage(
+  '/expense-tracker',
+  () => import('../components/ExpenseTrackerPage').then((module) => module.ExpenseTrackerPage),
+);
+const netWorthTrackerRoute = createLazyPage(
+  '/net-worth-tracker',
+  () => import('../components/NetWorthTrackerPage').then((module) => module.NetWorthTrackerPage),
+);
+const debtPayoffRoute = createLazyPage(
+  '/debt-payoff',
+  () => import('../components/DebtPayoffPage').then((module) => module.DebtPayoffPage),
+);
+const questionnaireRoute = createLazyPage(
+  '/questionnaire',
+  () => import('../components/QuestionnairePage').then((module) => module.QuestionnairePage),
+);
+const settingsRoute = createLazyPage(
+  '/settings',
+  () => import('../components/SettingsPage').then((module) => module.SettingsPage),
+);
+
+export const LazyFIRECalculatorPage = fireCalculatorRoute.Component;
+export const LazyReverseFIRECalculatorPage = reverseFireCalculatorRoute.Component;
+export const LazyMonteCarloPage = monteCarloRoute.Component;
+export const LazyInvestmentGrowthPage = investmentGrowthRoute.Component;
+export const LazyWithdrawalRatePage = withdrawalRateRoute.Component;
+export const LazyAssetAllocationPage = assetAllocationRoute.Component;
+export const LazyPortfolioBacktestPage = portfolioBacktestRoute.Component;
+export const LazyPortfolioBreakdownPage = portfolioBreakdownRoute.Component;
+export const LazyExpenseTrackerPage = expenseTrackerRoute.Component;
+export const LazyNetWorthTrackerPage = netWorthTrackerRoute.Component;
+export const LazyDebtPayoffPage = debtPayoffRoute.Component;
+export const LazyQuestionnairePage = questionnaireRoute.Component;
+export const LazySettingsPage = settingsRoute.Component;
+
+const routePreloaders: Record<string, () => Promise<void>> = {
+  '/fire-calculator': fireCalculatorRoute.preload,
+  '/reverse-fire-calculator': reverseFireCalculatorRoute.preload,
+  '/monte-carlo': monteCarloRoute.preload,
+  '/investment-growth': investmentGrowthRoute.preload,
+  '/withdrawal-rate': withdrawalRateRoute.preload,
+  '/asset-allocation': assetAllocationRoute.preload,
+  '/portfolio-backtest': portfolioBacktestRoute.preload,
+  '/portfolio-breakdown': portfolioBreakdownRoute.preload,
+  '/expense-tracker': expenseTrackerRoute.preload,
+  '/net-worth-tracker': netWorthTrackerRoute.preload,
+  '/debt-payoff': debtPayoffRoute.preload,
+  '/questionnaire': questionnaireRoute.preload,
+  '/settings': settingsRoute.preload,
+};
+
+export function preloadRoute(path: string): Promise<void> | undefined {
+  const [pathname] = path.split(/[?#]/);
+  return routePreloaders[pathname]?.();
+}

--- a/src/utils/lazyComponent.ts
+++ b/src/utils/lazyComponent.ts
@@ -1,0 +1,20 @@
+import { lazy, type ComponentType, type LazyExoticComponent, type ReactNode } from 'react';
+import { logger } from './logger';
+
+export function createLazyComponent<Props extends object>(
+  componentName: string,
+  loadComponent: () => Promise<ComponentType<Props>>,
+  renderFailure: () => ReactNode,
+): LazyExoticComponent<ComponentType<Props>> {
+  return lazy(async () => {
+    try {
+      return { default: await loadComponent() };
+    } catch (error) {
+      logger.error('ui', 'chunk-load-failed', `failed to load component: ${componentName}`, {
+        pii: { error: error instanceof Error ? error.message : String(error) },
+      });
+      const FailedComponent = (_props: Props) => renderFailure();
+      return { default: FailedComponent };
+    }
+  });
+}

--- a/tests/pages/settings/LanguageSelector.test.tsx
+++ b/tests/pages/settings/LanguageSelector.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import i18n, { DEFAULT_LANGUAGE, setLanguage } from '../../../src/i18n';
 import { LanguageSelector } from '../../../src/components/LanguageSelector';
 import { loadSettings } from '../../../src/utils/cookieSettings';
@@ -58,11 +58,10 @@ describe('LanguageSelector', () => {
 
     fireEvent.change(select, { target: { value: 'de' } });
 
-    // Let the async setLanguage promise resolve.
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(i18n.language).toBe('de');
-    expect(loadSettings().language).toBe('de');
+    await waitFor(() => {
+      expect(i18n.language).toBe('de');
+      expect(loadSettings().language).toBe('de');
+    });
   });
 
   it('falls back to English when i18n is in an unsupported language', async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,9 @@
 // Global vitest setup. Ensures i18next is initialised with English resources
 // before any component that calls `useTranslation()` is rendered.
 import { vi } from 'vitest';
-import '../src/i18n';
+import { i18nReady } from '../src/i18n';
+
+await i18nReady;
 
 vi.stubGlobal('__APP_VERSION__', '2.2.20');
 vi.stubGlobal('__APP_COMMIT_HASH__', 'testcommit');

--- a/tests/shared/PreloadLink.test.tsx
+++ b/tests/shared/PreloadLink.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PreloadLink } from '../../src/components/PreloadLink';
+import { preloadRoute } from '../../src/routes/lazyPages';
+
+vi.mock('../../src/routes/lazyPages', () => ({
+  preloadRoute: vi.fn(),
+}));
+
+describe('PreloadLink', () => {
+  beforeEach(() => {
+    vi.mocked(preloadRoute).mockClear();
+  });
+
+  it('preloads the destination when the user signals navigation intent', () => {
+    render(
+      <MemoryRouter>
+        <PreloadLink to="/fire-calculator">FIRE Calculator</PreloadLink>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: 'FIRE Calculator' });
+    fireEvent.pointerEnter(link);
+    fireEvent.pointerDown(link);
+    fireEvent.focus(link);
+
+    expect(preloadRoute).toHaveBeenCalledTimes(3);
+    expect(preloadRoute).toHaveBeenCalledWith('/fire-calculator');
+  });
+
+  it('preserves caller event handlers', () => {
+    const onFocus = vi.fn();
+    render(
+      <MemoryRouter>
+        <PreloadLink to="/settings" onFocus={onFocus}>Settings</PreloadLink>
+      </MemoryRouter>,
+    );
+
+    fireEvent.focus(screen.getByRole('link', { name: 'Settings' }));
+
+    expect(onFocus).toHaveBeenCalledOnce();
+    expect(preloadRoute).toHaveBeenCalledWith('/settings');
+  });
+});

--- a/tests/shared/useDeferredRender.test.ts
+++ b/tests/shared/useDeferredRender.test.ts
@@ -1,0 +1,57 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDeferredRender } from '../../src/hooks/useDeferredRender';
+
+describe('useDeferredRender', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) => window.setTimeout(() => callback(0), 16),
+    );
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
+    vi.stubGlobal(
+      'requestIdleCallback',
+      (callback: IdleRequestCallback) => window.setTimeout(
+        () => callback({ didTimeout: false, timeRemaining: () => 10 }),
+        0,
+      ),
+    );
+    vi.stubGlobal('cancelIdleCallback', (id: number) => window.clearTimeout(id));
+  });
+
+  afterEach(() => {
+    act(() => cleanup());
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('waits for initial paint and a grace period before rendering deferred content', () => {
+    const { result } = renderHook(() => useDeferredRender());
+
+    act(() => {
+      vi.advanceTimersByTime(181);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+      vi.runOnlyPendingTimers();
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('cancels deferred work when the content is disabled', () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useDeferredRender(enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    rerender({ enabled: false });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- split every tool route into a recoverable lazy chunk and preload destinations on pointer/focus intent
- defer chart-heavy rendering and load Recharts, analytics charts, the guided tour, and updater UI only when needed
- load only the selected locale plus the English fallback instead of bundling all five languages at startup
- keep shared controls and direct cold-route styling intact while moving page-specific CSS into route chunks

## Performance
- entry JS: **2.02 MB / 576.94 KB gzip → 341.58 KB / 102.64 KB gzip**
- initial CSS: **206.23 KB / 31.71 KB gzip → 69.89 KB / 11.70 KB gzip**
- profiled route medians: **165–318 ms → 81–98 ms**, with no recorded long tasks in the final run

## Validation
- 1,253 tests pass
- web and Electron production builds pass
- Playwright production smoke covers deferred charts, lazy locale loading/persistence, and cold direct-route styling