### PR TITLE
Fix macOS updater signature validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,58 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Require macOS signing and notarization credentials
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -eu
+          missing=0
+          if [ -z "$CSC_LINK" ]; then
+            echo "::error::Missing Actions secret CSC_LINK (base64 Developer ID Application .p12)."
+            missing=1
+          fi
+          if [ -z "$CSC_KEY_PASSWORD" ]; then
+            echo "::error::Missing Actions secret CSC_KEY_PASSWORD."
+            missing=1
+          fi
+          if [ -z "$APPLE_API_KEY_BASE64" ]; then
+            echo "::error::Missing Actions secret APPLE_API_KEY_BASE64 (base64 App Store Connect .p8)."
+            missing=1
+          fi
+          if [ -z "$APPLE_API_KEY_ID" ]; then
+            echo "::error::Missing Actions secret APPLE_API_KEY_ID."
+            missing=1
+          fi
+          if [ -z "$APPLE_API_ISSUER" ]; then
+            echo "::error::Missing Actions secret APPLE_API_ISSUER."
+            missing=1
+          fi
+          if [ -z "$APPLE_TEAM_ID" ]; then
+            echo "::error::Missing Actions secret APPLE_TEAM_ID."
+            missing=1
+          fi
+          exit "$missing"
+
+      - name: Prepare App Store Connect API key
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        run: |
+          set -eu
+          umask 077
+          APPLE_API_KEY="$RUNNER_TEMP/apple-api-key.p8"
+          printf '%s' "$APPLE_API_KEY_BASE64" | base64 --decode > "$APPLE_API_KEY"
+          if [ ! -s "$APPLE_API_KEY" ]; then
+            echo "::error::Decoded App Store Connect API key is empty."
+            exit 1
+          fi
+          chmod 600 "$APPLE_API_KEY"
+          echo "APPLE_API_KEY=$APPLE_API_KEY" >> "$GITHUB_ENV"
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -66,11 +118,16 @@ jobs:
           esac
 
       - name: Build Fire Tools and create DMG
-        run: npm run electron:dist -- --publish never --mac dmg zip --${{ matrix.arch }}
+        run: npm run electron:dist -- --publish never --mac dmg zip --${{ matrix.arch }} --config.mac.forceCodeSigning=true
         env:
           APP_VERSION: ${{ github.ref_name }}
           NODE_NO_WARNINGS: '1'
           DEBUG: electron-builder
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Verify build output exists
         run: |
@@ -81,6 +138,65 @@ jobs:
           fi
           echo "release/ contents:"
           find release -maxdepth 4 -type f \( -name '*.dmg' -o -name '*.zip' -o -name '*.blockmap' \) -print
+
+      - name: Verify updater payload signing and notarization
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -eu
+          ZIP_LIST="$RUNNER_TEMP/fire-tools-update-zips.txt"
+          find release -type f -name 'Fire.Tools-*-${{ matrix.arch }}-mac.zip' -print > "$ZIP_LIST"
+          ZIP_COUNT=$(wc -l < "$ZIP_LIST" | tr -d '[:space:]')
+          if [ "$ZIP_COUNT" -ne 1 ]; then
+            echo "::error::Expected exactly one ${{ matrix.arch }} macOS updater ZIP, found $ZIP_COUNT."
+            cat "$ZIP_LIST"
+            exit 1
+          fi
+
+          IFS= read -r ZIP_PATH < "$ZIP_LIST"
+          VERIFY_DIR="$RUNNER_TEMP/verify-macos-${{ matrix.arch }}"
+          rm -rf "$VERIFY_DIR"
+          mkdir -p "$VERIFY_DIR"
+          ditto -x -k "$ZIP_PATH" "$VERIFY_DIR"
+          APP_PATH="$VERIFY_DIR/Fire Tools.app"
+          if [ ! -d "$APP_PATH" ]; then
+            echo "::error::Updater ZIP does not contain Fire Tools.app."
+            exit 1
+          fi
+
+          codesign --verify --deep --strict --verbose=4 "$APP_PATH"
+          SIGNING_DETAILS=$(codesign -dvvv "$APP_PATH" 2>&1)
+          printf '%s\n' "$SIGNING_DETAILS"
+
+          if printf '%s\n' "$SIGNING_DETAILS" | grep -q '^Signature=adhoc$'; then
+            echo "::error::macOS updater payload is ad-hoc signed and cannot self-update."
+            exit 1
+          fi
+
+          AUTHORITY=$(printf '%s\n' "$SIGNING_DETAILS" | sed -n 's/^Authority=//p' | head -1)
+          case "$AUTHORITY" in
+            "Developer ID Application:"*) ;;
+            *)
+              echo "::error::Expected Developer ID Application signature, found '${AUTHORITY:-none}'."
+              exit 1
+              ;;
+          esac
+
+          TEAM_ID=$(printf '%s\n' "$SIGNING_DETAILS" | sed -n 's/^TeamIdentifier=//p' | head -1)
+          if [ "$TEAM_ID" != "$APPLE_TEAM_ID" ]; then
+            echo "::error::Signing TeamIdentifier '${TEAM_ID:-none}' does not match APPLE_TEAM_ID."
+            exit 1
+          fi
+
+          REQUIREMENT=$(codesign -d -r- "$APP_PATH" 2>&1)
+          printf '%s\n' "$REQUIREMENT"
+          if printf '%s\n' "$REQUIREMENT" | grep -q 'designated => cdhash'; then
+            echo "::error::Designated requirement is pinned to a build-specific cdhash."
+            exit 1
+          fi
+
+          xcrun stapler validate "$APP_PATH"
+          spctl --assess --type execute --verbose=4 "$APP_PATH"
 
       - name: Clear quarantine attributes
         run: |
@@ -97,6 +213,13 @@ jobs:
             release/**/*.blockmap
           if-no-files-found: error
           retention-days: 1
+
+      - name: Remove notarization API key
+        if: always()
+        run: |
+          if [ -n "${APPLE_API_KEY:-}" ]; then
+            rm -f "$APPLE_API_KEY"
+          fi
 
   build-windows:
     name: Build Windows Installer
@@ -278,10 +401,10 @@ jobs:
           ### macOS
           1. Download the arm64 DMG for Apple Silicon Macs, or the x64 DMG for Intel Macs.
           2. Open the DMG and drag **Fire Tools** to Applications.
-          3. If macOS blocks the app because it isn't notarized yet, run:
-             ```sh
-             xattr -cr "/Applications/Fire Tools.app"
-             ```
+          3. Releases are Developer ID signed and notarized. If upgrading from v2.3.2 or earlier,
+             replace the app manually this once; those older unsigned/ad-hoc builds cannot
+             authenticate the first signed auto-update. Future updates install normally from
+             inside the app.
 
           ### Windows
           1. Download the `Fire Tools Setup` `.exe`.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Use `npm run electron:dev` if you only want Vite + Electron without the backend.
 |------|---------|------------|---------|
 | **Web demo** | None — read-only preview | [Live demo](https://fire-tools-inc.github.io/app/demo/) | Seeded sample data; nothing you enter is saved |
 | **Docker** | SQLite (volume-backed) | `docker compose up -d` → `localhost:8080` | [docs/deployment/](docs/deployment/) |
-| **Electron** | SQLite at OS userData path | `npm run electron:dist` | [electron/README.md](electron/README.md) |
+| **Electron** | SQLite at OS userData path | `npm run electron:dist` | Tagged releases require Developer ID signing and notarization; [desktop docs](electron/README.md) |
 | **Mobile** | Via backend API | Separate Flutter repo | [docs/mobile/](docs/mobile/) |
 
 ---

--- a/docs/engineering/auto-updater.md
+++ b/docs/engineering/auto-updater.md
@@ -186,6 +186,30 @@ publish:
 files alongside the installer so `electron-updater` can resolve the
 latest version.
 
+### macOS signing requirement
+
+Squirrel.Mac validates an update against the installed app's code-signing
+designated requirement. Ad-hoc signatures use a build-specific `cdhash`, so a
+new build can never satisfy the previous build's requirement even when both
+bundles use the same identifier. Production macOS auto-update therefore
+requires every release to be signed with a Developer ID Application
+certificate from the same Apple Team and notarized.
+
+The macOS release jobs:
+
+1. Require the Developer ID certificate and App Store Connect API-key secrets.
+2. Force electron-builder to fail instead of silently emitting an unsigned app.
+3. Extract the actual updater ZIP and reject unsigned/ad-hoc signatures,
+   unexpected signing authorities or Team IDs, `cdhash`-only designated
+   requirements, missing notarization tickets, and failed Gatekeeper checks.
+
+Published macOS builds through v2.3.2 were not Developer ID-signed; recent
+versions were ad-hoc signed and cannot authenticate the first properly signed
+update. Those users must manually replace the app with the first Developer
+ID-signed release once. Later updates work normally, and Developer ID
+certificate renewal within the same Team ID does not require another manual
+migration.
+
 ### Artifact naming (do not break the updater)
 
 Artifact file names **must not contain spaces**. `electron-builder.yml`

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -58,8 +58,10 @@ mac:
         - arm64
   # Code-signing & notarization driven via env:
   #   CSC_LINK, CSC_KEY_PASSWORD (signing cert)
-  #   APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID (notarization)
-  notarize: false
+  #   APPLE_API_KEY, APPLE_API_KEY_ID, APPLE_API_ISSUER (notarization)
+  # Tagged releases force code signing in release.yml; local unsigned builds
+  # retain the afterSign ad-hoc fallback for development only.
+  notarize: true
 
 win:
   legalTrademarks: ""

--- a/electron/README.md
+++ b/electron/README.md
@@ -47,6 +47,12 @@ secret is missing, then extracts the updater ZIP and verifies its signature,
 Team ID, designated requirement, stapled notarization ticket, and Gatekeeper
 assessment before upload.
 
+CI does **not** need an `APPLE_ID`, Apple Account password, or app-specific
+password. It authenticates notarization with an App Store Connect API key.
+However, this is not Apple-account-free: obtaining the certificate and API key
+requires an Apple Account enrolled in the paid Apple Developer Program
+(99 USD per membership year, or local equivalent).
+
 Configure these repository Actions secrets (never commit their values):
 
 | Secret | Purpose |
@@ -60,12 +66,53 @@ Configure these repository Actions secrets (never commit their values):
 | `WINDOWS_CERTIFICATE_LINK` | Path/URL to the Windows code-signing certificate |
 | `WINDOWS_CERTIFICATE_PASSWORD` | Password for the Windows certificate |
 
-Create single-line base64 values on macOS with:
+### Create the macOS release secrets
 
-```sh
-base64 -i DeveloperIDApplication.p12 | pbcopy
-base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
-```
+1. Enroll the Apple Account that owns the release identity in the
+   [Apple Developer Program](https://developer.apple.com/programs/enroll/).
+2. In **Keychain Access**, choose **Certificate Assistant → Request a
+   Certificate From a Certificate Authority**, enter the account email and a
+   common name, select **Saved to disk**, and save the CSR.
+3. Open
+   [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/certificates/list),
+   add a certificate, choose **Developer ID Application**, upload the CSR, and
+   download the generated `.cer`.
+4. Open the `.cer` so macOS installs it in the login keychain. Under
+   **My Certificates**, confirm the certificate expands to show its private
+   key.
+5. Select the certificate and private key, export them as a password-protected
+   `.p12`, and retain that export password.
+6. Create the signing secrets:
+
+   - `CSC_LINK`: run `base64 -i DeveloperIDApplication.p12 | pbcopy` and use
+     the clipboard contents.
+   - `CSC_KEY_PASSWORD`: use the `.p12` export password.
+   - `APPLE_TEAM_ID`: use the 10-character Team ID shown in the Apple Developer
+     membership details or in the certificate name's final parentheses.
+
+7. In [App Store Connect](https://appstoreconnect.apple.com/), the Account
+   Holder must first open **Users and Access → Integrations** and request App
+   Store Connect API access if it has not already been enabled.
+8. As an Account Holder or Admin, open **Users and Access → Integrations →
+   Team Keys**, generate a Team Key with **App Manager** access, and download
+   the `.p8` file immediately. Apple allows each private key to be downloaded
+   only once.
+9. Create the notarization secrets:
+
+   - `APPLE_API_KEY_BASE64`: run
+     `base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy` and use the clipboard contents.
+   - `APPLE_API_KEY_ID`: copy the Key ID displayed for that Team Key.
+   - `APPLE_API_ISSUER`: copy the Issuer ID displayed on the Team Keys page.
+
+10. In the GitHub repository, open **Settings → Secrets and variables →
+    Actions**, choose **New repository secret**, and add all six values exactly
+    as named above.
+
+The App Store Connect API key replaces Apple ID/password authentication only
+for automation. Without paid Apple Developer Program membership there is no
+supported way to issue a Developer ID Application certificate or notarize the
+app; macOS distribution must then remain manual and the Squirrel auto-updater
+must stay disabled.
 
 Local `npm run electron:dist` builds can still use the ad-hoc `afterSign`
 fallback when no certificate is configured. Those builds are for development

--- a/electron/README.md
+++ b/electron/README.md
@@ -41,20 +41,46 @@ Artifacts land in `release/<version>/`. Defaults: `.dmg` (macOS),
 
 ## Signing & notarization
 
-Env vars (set in CI secrets — never commit):
+Tagged macOS releases must use a **Developer ID Application** certificate and
+Apple notarization. The release workflow fails before building if any required
+secret is missing, then extracts the updater ZIP and verifies its signature,
+Team ID, designated requirement, stapled notarization ticket, and Gatekeeper
+assessment before upload.
 
-| Var                          | Purpose                                    |
-|------------------------------|--------------------------------------------|
-| `CSC_LINK`                   | Path/URL to `.p12` macOS signing cert      |
-| `CSC_KEY_PASSWORD`           | Password for the `.p12`                    |
-| `APPLE_ID`                   | Apple ID for notarization                  |
-| `APPLE_APP_SPECIFIC_PASSWORD`| App-specific password                      |
-| `APPLE_TEAM_ID`              | Apple Developer team id                    |
-| `WINDOWS_CERTIFICATE_LINK`   | Path/URL to Windows code-signing cert      |
-| `WINDOWS_CERTIFICATE_PASSWORD` | Password for the Windows cert            |
+Configure these repository Actions secrets (never commit their values):
 
-Set `notarize: true` in [`../electron-builder.yml`](../electron-builder.yml)
-once macOS notarization credentials are wired into CI.
+| Secret | Purpose |
+|--------|---------|
+| `CSC_LINK` | Base64-encoded Developer ID Application `.p12` |
+| `CSC_KEY_PASSWORD` | Password for the `.p12` |
+| `APPLE_API_KEY_BASE64` | Base64-encoded App Store Connect API key `.p8` |
+| `APPLE_API_KEY_ID` | App Store Connect API key ID |
+| `APPLE_API_ISSUER` | App Store Connect issuer UUID |
+| `APPLE_TEAM_ID` | Apple Developer Team ID; also checked against the signed app |
+| `WINDOWS_CERTIFICATE_LINK` | Path/URL to the Windows code-signing certificate |
+| `WINDOWS_CERTIFICATE_PASSWORD` | Password for the Windows certificate |
+
+Create single-line base64 values on macOS with:
+
+```sh
+base64 -i DeveloperIDApplication.p12 | pbcopy
+base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
+```
+
+Local `npm run electron:dist` builds can still use the ad-hoc `afterSign`
+fallback when no certificate is configured. Those builds are for development
+only and cannot safely self-update.
+
+### Existing unsigned installs
+
+Published macOS builds through v2.3.2 were not Developer ID-signed; recent
+versions, including v2.2.1 and v2.3.2, were ad-hoc signed. macOS assigns each
+ad-hoc build a designated requirement tied to its exact code hash, so ShipIt
+rejects the next version with
+`code failed to satisfy specified code requirement(s)`. Users must download
+and install the **first Developer ID-signed release** manually once.
+Auto-update works normally after that; future certificate renewals under the
+same Apple Team ID do not require another manual migration.
 
 ## Security posture
 
@@ -171,5 +197,3 @@ SHA-256 verification). Clicking **Restore** runs
 
 See [`docs/engineering/auto-updater.md`](../docs/engineering/auto-updater.md)
 for the full design including manifest schema and rollback flow.
-
-

--- a/scripts/electron-after-sign.cjs
+++ b/scripts/electron-after-sign.cjs
@@ -13,7 +13,8 @@
 // on the .app bundle so the signature carries the right identifier. This
 // is a no-op on non-macOS platforms or when a real signing identity was
 // already used (CSC_LINK / CSC_NAME set), which already supplies a proper
-// identifier.
+// identifier. Ad-hoc output is for local development only: its designated
+// requirement is build-specific, so Squirrel.Mac cannot use it for updates.
 
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');


### PR DESCRIPTION
## Summary
- require Developer ID signing and App Store Connect notarization credentials for tagged macOS releases
- force signing to fail closed and validate the actual updater ZIP's authority, Team ID, designated requirement, notarization ticket, and Gatekeeper status
- document the one-time manual reinstall required for installs through v2.3.2
- document how to create and configure every Apple/GitHub credential

## Account requirement
CI does not store an `APPLE_ID`, Apple Account password, or app-specific password. Notarization uses an App Store Connect Team API key, but creating that key and the Developer ID certificate still requires an Apple Account enrolled in the paid Apple Developer Program.

## Required before the next tag
Configure repository Actions secrets: `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_API_KEY_BASE64`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, and `APPLE_TEAM_ID`.

## Validation
- full test suite
- production/docs build
- local ad-hoc macOS packaging path
- release-only force-signing failure without a Developer ID identity
- workflow and electron-builder YAML validation